### PR TITLE
Update and reconfigure golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,21 +4,59 @@ run:
 
 linters:
   fast: false
-  enable-all: true
-  disable:
-    - gomnd
+  enable:
+    - asciicheck
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
     - errcheck
-    - gochecknoglobals
-    - gochecknoinits
-    - lll
-    - unparam
-    - funlen
-    - wsl
-    - testpackage
-    - nestif
+    - exhaustive
+    - exportloopref
+    - gci
+    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+    - godot
+    - godox
+    - gofmt
+    - gofumpt
+    - goheader
+    - goimports
+    - golint
+    - gomodguard
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - interfacer
+    - maligned
+    - misspell
+    - nakedret
+    - noctx
+    - nolintlint
+    - prealloc
+    - rowserrcheck
+    - scopelint
+    - sqlclosecheck
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unused
+    - varcheck
+    - whitespace
 
 issues:
   exclude-rules:
     - linters:
         - staticcheck
       text: "SA1019:"
+
+    - linters:
+        - errcheck
+      text: "Error return value of `d.Set` is not checked"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   - GOFLAGS=-mod=vendor GO111MODULE=on
 
 install:
-  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.25.1
+  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.30.0
 
 script:
   - make test

--- a/selectel/provider_test.go
+++ b/selectel/provider_test.go
@@ -11,8 +11,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-var testAccProviders map[string]terraform.ResourceProvider
-var testAccProvider *schema.Provider
+var (
+	testAccProviders map[string]terraform.ResourceProvider
+	testAccProvider  *schema.Provider
+)
 
 func init() {
 	testAccProvider = Provider().(*schema.Provider)


### PR DESCRIPTION
Use Golangci-lint v1.30.0 in Travis CI.

Remove deprecated enable-all configuration from .golangci.yml.

Fix issues with gofumpt linter in selectel/provider_test.go.