### PR TITLE
Update go-selvpcclient and fix token resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.6.6
 	github.com/hashicorp/terraform-plugin-sdk v1.13.0
 	github.com/selectel/domains-go v0.2.0
-	github.com/selectel/go-selvpcclient v1.11.1
+	github.com/selectel/go-selvpcclient v1.12.0
 	github.com/selectel/mks-go v0.4.0
 	github.com/stretchr/testify v1.5.1
 )

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,8 @@ github.com/posener/complete v1.2.1/go.mod h1:6gapUrK/U1TAN7ciCoNRIdVC5sbdBTUh1DK
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/selectel/domains-go v0.2.0 h1:UBm6tc45sXsziqG7MirfHxaoMf3yYpFb2vx3GygU4kI=
 github.com/selectel/domains-go v0.2.0/go.mod h1:aDinK5D/zztY4VhoqQgYaaOnU6hqjBcszUOgAe0kPYs=
-github.com/selectel/go-selvpcclient v1.11.1 h1:SdYEmM0sCR/m/CijwgTJvNgapSnWZ7PGlGaEJm5zyQQ=
-github.com/selectel/go-selvpcclient v1.11.1/go.mod h1:GBDQZFsZNNn/Uv/Y+WT/dDCGqTPzkQakVgD48QzxVZI=
+github.com/selectel/go-selvpcclient v1.12.0 h1:LsT074HOVF1dWYapsAWjaaJDQhmDPpcsVjSwQ1r1fj0=
+github.com/selectel/go-selvpcclient v1.12.0/go.mod h1:HNteVXevZMjUCRR6lImTsGZZSTeKu89S/qbEDWDqmgc=
 github.com/selectel/mks-go v0.4.0 h1:zHY+eG+k8S8Jrfv8/nLUFDQSLR93usnhTcorsS54FTU=
 github.com/selectel/mks-go v0.4.0/go.mod h1:OrlLnGes+HK7HNxUab/8Rll5iT0XQQnx4+dW1Ysph2o=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=

--- a/selectel/resource_selectel_vpc_token_v2.go
+++ b/selectel/resource_selectel_vpc_token_v2.go
@@ -37,8 +37,8 @@ func resourceVPCTokenV2Create(d *schema.ResourceData, meta interface{}) error {
 	ctx := context.Background()
 
 	opts := tokens.TokenOpts{
-		ProjectID:  d.Get("project_id").(string),
-		DomainName: d.Get("account_name").(string),
+		ProjectID:   d.Get("project_id").(string),
+		AccountName: d.Get("account_name").(string),
 	}
 
 	log.Print(msgCreate(objectToken, opts))

--- a/vendor/github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/keypairs/requests.go
+++ b/vendor/github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/keypairs/requests.go
@@ -41,7 +41,7 @@ func Create(ctx context.Context, client *selvpcclient.ServiceClient, createOpts 
 	type nestedCreateOpts struct {
 		Keypair KeypairOpts `json:"keypair"`
 	}
-	var createKeypairOpts = nestedCreateOpts{
+	createKeypairOpts := nestedCreateOpts{
 		Keypair: createOpts,
 	}
 	requestBody, err := json.Marshal(&createKeypairOpts)

--- a/vendor/github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/quotas/requests_opts.go
+++ b/vendor/github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/quotas/requests_opts.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 )
 
+var errGetEmptyQuotasOpts = errors.New("got empty QuotasOpts")
+
 // QuotaOpts represents quota options for a single resource that can be used in the update request.
 type QuotaOpts struct {
 	// Name is a human-readable name of the resource.
@@ -54,7 +56,7 @@ We need it to marshal structure to a a JSON that the Resell v2 API wants:
 func (opts *UpdateProjectQuotasOpts) MarshalJSON() ([]byte, error) {
 	// Check the opts.
 	if len(opts.QuotasOpts) == 0 {
-		return nil, errors.New("got empty QuotasOpts")
+		return nil, errGetEmptyQuotasOpts
 	}
 
 	// Convert opts's quotas update options slice to a map that has resource names

--- a/vendor/github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/roles/requests.go
+++ b/vendor/github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/roles/requests.go
@@ -23,7 +23,7 @@ func List(ctx context.Context, client *selvpcclient.ServiceClient) ([]*Role, *se
 		return nil, responseResult, responseResult.Err
 	}
 
-	//Extract roles from the response body.
+	// Extract roles from the response body.
 	var result struct {
 		Roles []*Role `json:"roles"`
 	}

--- a/vendor/github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/tokens/doc.go
+++ b/vendor/github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/tokens/doc.go
@@ -15,7 +15,7 @@ Example of creating a project-scoped token
 Example of creating a domain-scoped token
 
   createOpts := tokens.TokenOpts{
-    DomainName: "1122334455",
+    AccountName: "1122334455",
   }
   token, err := tokens.Create(ctx, resellClient, createOpts)
   if err != nil {

--- a/vendor/github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/tokens/requests_opts.go
+++ b/vendor/github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/tokens/requests_opts.go
@@ -5,6 +5,6 @@ type TokenOpts struct {
 	// ProjectID can be used to create a project-scoped Identity token.
 	ProjectID string `json:"project_id,omitempty"`
 
-	// DomainName can be used to create a domain-scoped Identity token.
-	DomainName string `json:"domain_name,omitempty"`
+	// AccountName can be used to create a domain-scoped Identity token.
+	AccountName string `json:"account_name,omitempty"`
 }

--- a/vendor/github.com/selectel/go-selvpcclient/selvpcclient/selvpc.go
+++ b/vendor/github.com/selectel/go-selvpcclient/selvpcclient/selvpc.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	// AppVersion is a version of the application.
-	AppVersion = "1.11.1"
+	AppVersion = "1.12.0"
 
 	// AppName is a global application name.
 	AppName = "go-selvpcclient"
@@ -58,6 +58,11 @@ const (
 	// defaultExpectContinueTimeout represents the default amount of time to
 	// wait for a server's first response headers.
 	defaultExpectContinueTimeout = 1
+)
+
+var (
+	errOptsIsNotStruct = errors.New("provided options is not a structure")
+	errServiceResponse = errors.New("status code from the server")
 )
 
 // NewHTTPClient returns a reference to an initialized configured HTTP client.
@@ -172,9 +177,9 @@ func (client *ServiceClient) DoRequest(ctx context.Context, method, path string,
 	if response.StatusCode >= 400 && response.StatusCode <= 599 {
 		extendedError, err := responseResult.ExtractErr()
 		if err != nil {
-			responseResult.Err = fmt.Errorf("selvpcclient: got the %d status code from the server", response.StatusCode)
+			responseResult.Err = fmt.Errorf("selvpcclient: got the %d %w", response.StatusCode, errServiceResponse)
 		} else {
-			responseResult.Err = fmt.Errorf("selvpcclient: got the %d status code from the server: %s", response.StatusCode, extendedError)
+			responseResult.Err = fmt.Errorf("selvpcclient: got the %d %w: %s", response.StatusCode, errServiceResponse, extendedError)
 		}
 	}
 
@@ -222,7 +227,7 @@ type IPVersion string
 func BuildQueryParameters(opts interface{}) (string, error) {
 	optsValue := reflect.ValueOf(opts)
 	if optsValue.Kind() != reflect.Struct {
-		return "", errors.New("provided options is not a structure")
+		return "", errOptsIsNotStruct
 	}
 	optsType := reflect.TypeOf(opts)
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -222,7 +222,7 @@ github.com/posener/complete/match
 github.com/selectel/domains-go/pkg/v1
 github.com/selectel/domains-go/pkg/v1/domain
 github.com/selectel/domains-go/pkg/v1/record
-# github.com/selectel/go-selvpcclient v1.11.1
+# github.com/selectel/go-selvpcclient v1.12.0
 ## explicit
 github.com/selectel/go-selvpcclient/selvpcclient
 github.com/selectel/go-selvpcclient/selvpcclient/resell


### PR DESCRIPTION
Vendor go-selvpcclient v1.12.0.

Use AccountName instead of DomainName in domain-scoped
resource_selectel_vpc_token_v2.