### PR TITLE
Do not run acc tests for PRs

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
   schedule:
     - cron: '0 0 * * *'
 


### PR DESCRIPTION
Pull requests from forks don't have secrets access.

Reference:

github.community/t/make-secrets-available-to-builds-of-forks/16166/32.