### PR TITLE
MKS Nodegroup v1: taints support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,6 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.0.1
 	github.com/selectel/domains-go v0.2.0
 	github.com/selectel/go-selvpcclient v1.12.0
-	github.com/selectel/mks-go v0.5.1-0.20200901133315-e90912ba57c3
+	github.com/selectel/mks-go v0.6.0
 	github.com/stretchr/testify v1.5.1
 )

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,6 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.0.1
 	github.com/selectel/domains-go v0.2.0
 	github.com/selectel/go-selvpcclient v1.12.0
-	github.com/selectel/mks-go v0.5.0
+	github.com/selectel/mks-go v0.5.1-0.20200901133315-e90912ba57c3
 	github.com/stretchr/testify v1.5.1
 )

--- a/go.sum
+++ b/go.sum
@@ -245,6 +245,8 @@ github.com/selectel/mks-go v0.5.0 h1:BqEi/XxvmNpE14gBwmLx4ArvvuU1YSBvD0opzolh9pw
 github.com/selectel/mks-go v0.5.0/go.mod h1:OrlLnGes+HK7HNxUab/8Rll5iT0XQQnx4+dW1Ysph2o=
 github.com/selectel/mks-go v0.5.1-0.20200901133315-e90912ba57c3 h1:eMMMSHDwe/arK+Wy9ll4JXHVOBxSt1m7XzoUgy1EeL8=
 github.com/selectel/mks-go v0.5.1-0.20200901133315-e90912ba57c3/go.mod h1:OrlLnGes+HK7HNxUab/8Rll5iT0XQQnx4+dW1Ysph2o=
+github.com/selectel/mks-go v0.6.0 h1:5ZlqvwlVrjrrbNygsiFfUGZTyTPzPGGo8aYJkbtrYV0=
+github.com/selectel/mks-go v0.6.0/go.mod h1:OrlLnGes+HK7HNxUab/8Rll5iT0XQQnx4+dW1Ysph2o=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=

--- a/go.sum
+++ b/go.sum
@@ -243,6 +243,8 @@ github.com/selectel/go-selvpcclient v1.12.0 h1:LsT074HOVF1dWYapsAWjaaJDQhmDPpcsV
 github.com/selectel/go-selvpcclient v1.12.0/go.mod h1:HNteVXevZMjUCRR6lImTsGZZSTeKu89S/qbEDWDqmgc=
 github.com/selectel/mks-go v0.5.0 h1:BqEi/XxvmNpE14gBwmLx4ArvvuU1YSBvD0opzolh9pw=
 github.com/selectel/mks-go v0.5.0/go.mod h1:OrlLnGes+HK7HNxUab/8Rll5iT0XQQnx4+dW1Ysph2o=
+github.com/selectel/mks-go v0.5.1-0.20200901133315-e90912ba57c3 h1:eMMMSHDwe/arK+Wy9ll4JXHVOBxSt1m7XzoUgy1EeL8=
+github.com/selectel/mks-go v0.5.1-0.20200901133315-e90912ba57c3/go.mod h1:OrlLnGes+HK7HNxUab/8Rll5iT0XQQnx4+dW1Ysph2o=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=

--- a/selectel/mks.go
+++ b/selectel/mks.go
@@ -14,6 +14,7 @@ import (
 	"github.com/selectel/mks-go/pkg/v1/cluster"
 	"github.com/selectel/mks-go/pkg/v1/kubeversion"
 	"github.com/selectel/mks-go/pkg/v1/node"
+	"github.com/selectel/mks-go/pkg/v1/nodegroup"
 )
 
 const (
@@ -432,6 +433,42 @@ func flattenMKSNodegroupV1Nodes(views []*node.View) []map[string]interface{} {
 	}
 
 	return nodes
+}
+
+func flattenMKSNodegroupV1Taints(views []nodegroup.Taint) []interface{} {
+	taints := make([]interface{}, len(views))
+	for i, view := range views {
+		taints[i] = map[string]interface{}{
+			"key":    view.Key,
+			"value":  view.Value,
+			"effect": string(view.Effect),
+		}
+	}
+
+	return taints
+}
+
+func expandMKSNodegroupV1Taints(taints []interface{}) []nodegroup.Taint {
+	result := make([]nodegroup.Taint, len(taints))
+	for i := range taints {
+		taint := nodegroup.Taint{}
+		obj := taints[i].(map[string]interface{})
+		taint.Key = obj["key"].(string)
+		taint.Value = obj["value"].(string)
+
+		switch obj["effect"].(string) {
+		case string(nodegroup.NoScheduleEffect):
+			taint.Effect = nodegroup.NoScheduleEffect
+		case string(nodegroup.NoExecuteEffect):
+			taint.Effect = nodegroup.NoExecuteEffect
+		case string(nodegroup.PreferNoScheduleEffect):
+			taint.Effect = nodegroup.PreferNoScheduleEffect
+		}
+
+		result[i] = taint
+	}
+
+	return result
 }
 
 func expandMKSNodegroupV1Labels(labels map[string]interface{}) map[string]string {

--- a/selectel/mks_test.go
+++ b/selectel/mks_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/selectel/mks-go/pkg/v1/node"
+	"github.com/selectel/mks-go/pkg/v1/nodegroup"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -443,6 +444,47 @@ func TestFlattenMKSNodegroupV1Nodes(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func TestFlattenMKSNodegroupV1Taints(t *testing.T) {
+	views := []nodegroup.Taint{
+		{
+			Key:    "test-key-0",
+			Value:  "test-value-0",
+			Effect: nodegroup.NoScheduleEffect,
+		},
+		{
+			Key:    "test-key-1",
+			Value:  "test-value-1",
+			Effect: nodegroup.NoExecuteEffect,
+		},
+		{
+			Key:    "test-key-2",
+			Value:  "test-value-2",
+			Effect: nodegroup.PreferNoScheduleEffect,
+		},
+	}
+
+	expected := []interface{}{
+		map[string]interface{}{
+			"key":    "test-key-0",
+			"value":  "test-value-0",
+			"effect": "NoSchedule",
+		},
+		map[string]interface{}{
+			"key":    "test-key-1",
+			"value":  "test-value-1",
+			"effect": "NoExecute",
+		},
+		map[string]interface{}{
+			"key":    "test-key-2",
+			"value":  "test-value-2",
+			"effect": "PreferNoSchedule",
+		},
+	}
+	actual := flattenMKSNodegroupV1Taints(views)
+
+	assert.Equal(t, expected, actual)
+}
+
 func TestExpandMKSNodegroupV1Labels(t *testing.T) {
 	labels := map[string]interface{}{
 		"label-key0": "label-value0",
@@ -455,6 +497,47 @@ func TestExpandMKSNodegroupV1Labels(t *testing.T) {
 		"label-key2": "label-value2",
 	}
 	actual := expandMKSNodegroupV1Labels(labels)
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestExpandMKSNodegroupV1Taints(t *testing.T) {
+	taints := []interface{}{
+		map[string]interface{}{
+			"key":    "test-key-0",
+			"value":  "test-value-0",
+			"effect": "NoSchedule",
+		},
+		map[string]interface{}{
+			"key":    "test-key-1",
+			"value":  "test-value-1",
+			"effect": "NoExecute",
+		},
+		map[string]interface{}{
+			"key":    "test-key-2",
+			"value":  "test-value-2",
+			"effect": "PreferNoSchedule",
+		},
+	}
+
+	expected := []nodegroup.Taint{
+		{
+			Key:    "test-key-0",
+			Value:  "test-value-0",
+			Effect: nodegroup.NoScheduleEffect,
+		},
+		{
+			Key:    "test-key-1",
+			Value:  "test-value-1",
+			Effect: nodegroup.NoExecuteEffect,
+		},
+		{
+			Key:    "test-key-2",
+			Value:  "test-value-2",
+			Effect: nodegroup.PreferNoScheduleEffect,
+		},
+	}
+	actual := expandMKSNodegroupV1Taints(taints)
 
 	assert.Equal(t, expected, actual)
 }

--- a/selectel/resource_selectel_mks_nodegroup_v1_test.go
+++ b/selectel/resource_selectel_mks_nodegroup_v1_test.go
@@ -45,6 +45,17 @@ func TestAccMKSNodegroupV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key0", "label-value0"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key1", "label-value1"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key2", "label-value2"),
+
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.#", "3"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.0.key", "test-key-0"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.0.value", "test-value-0"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.0.effect", "NoSchedule"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.1.key", "test-key-1"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.1.value", "test-value-1"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.1.effect", "NoExecute"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.2.key", "test-key-2"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.2.value", "test-value-2"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.2.effect", "PreferNoSchedule"),
 				),
 			},
 			{
@@ -59,6 +70,16 @@ func TestAccMKSNodegroupV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "volume_type", "fast.ru-3a"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key3", "label-value3"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key4", "label-value4"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.#", "3"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.0.key", "test-key-0"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.0.value", "test-value-0"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.0.effect", "NoSchedule"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.1.key", "test-key-1"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.1.value", "test-value-1"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.1.effect", "NoExecute"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.2.key", "test-key-2"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.2.value", "test-value-2"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.2.effect", "PreferNoSchedule"),
 				),
 			},
 		},
@@ -145,6 +166,21 @@ resource "selectel_mks_nodegroup_v1" "nodegroup_tf_acc_test_1" {
     label-key1 = "label-value1"
     label-key2 = "label-value2"
   }
+  taints {
+    key = "test-key-0"
+    value = "test-value-0"
+    effect = "NoSchedule"
+  }
+  taints {
+    key = "test-key-1"
+    value = "test-value-1"
+    effect = "NoExecute"
+  }
+  taints {
+    key = "test-key-2"
+    value = "test-value-2"
+    effect = "PreferNoSchedule"
+  }
 }`, projectName, clusterName, kubeVersion)
 }
 
@@ -175,6 +211,21 @@ resource "selectel_mks_nodegroup_v1" "nodegroup_tf_acc_test_1" {
   labels = {
     label-key3 = "label-value3"
     label-key4 = "label-value4"
+  }
+  taints {
+    key = "test-key-0"
+    value = "test-value-0"
+    effect = "NoSchedule"
+  }
+  taints {
+    key = "test-key-1"
+    value = "test-value-1"
+    effect = "NoExecute"
+  }
+  taints {
+    key = "test-key-2"
+    value = "test-value-2"
+    effect = "PreferNoSchedule"
   }
 }`, projectName, clusterName, kubeVersion)
 }

--- a/vendor/github.com/selectel/mks-go/pkg/v1/cluster/doc.go
+++ b/vendor/github.com/selectel/mks-go/pkg/v1/cluster/doc.go
@@ -40,6 +40,13 @@ Example of creating a new cluster
           "label-key1": "label-value1",
           "label-key2": "label-value2",
         },
+        Taints: []nodegroup.Taint{
+          {
+            Key:    "test-key-0",
+            Value:  "test-value-0",
+            Effect: nodegroup.NoScheduleEffect,
+          },
+        },
       },
     },
   }

--- a/vendor/github.com/selectel/mks-go/pkg/v1/node/doc.go
+++ b/vendor/github.com/selectel/mks-go/pkg/v1/node/doc.go
@@ -16,5 +16,12 @@ Example of reinstalling a single node of a cluster nodegroup by its id
   if err != nil {
     log.Fatal(err)
   }
+
+Example of deleting a single node of a cluster nodegroup by its id
+
+  _, err := node.Delete(ctx, mksClient, clusterID, nodegroupID, nodeID)
+  if err != nil {
+    log.Fatal(err)
+  }
 */
 package node

--- a/vendor/github.com/selectel/mks-go/pkg/v1/node/requests.go
+++ b/vendor/github.com/selectel/mks-go/pkg/v1/node/requests.go
@@ -44,3 +44,17 @@ func Reinstall(ctx context.Context, client *v1.ServiceClient, clusterID, nodegro
 
 	return responseResult, err
 }
+
+// Delete deletes a node of a cluster nodegroup by its id.
+func Delete(ctx context.Context, client *v1.ServiceClient, clusterID, nodegroupID, nodeID string) (*v1.ResponseResult, error) {
+	url := strings.Join([]string{client.Endpoint, v1.ResourceURLCluster, clusterID, v1.ResourceURLNodegroup, nodegroupID, nodeID}, "/")
+	responseResult, err := client.DoRequest(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if responseResult.Err != nil {
+		err = responseResult.Err
+	}
+
+	return responseResult, err
+}

--- a/vendor/github.com/selectel/mks-go/pkg/v1/node/schemas.go
+++ b/vendor/github.com/selectel/mks-go/pkg/v1/node/schemas.go
@@ -21,4 +21,7 @@ type View struct {
 
 	// NodegroupID contains nodegroup identifier.
 	NodegroupID string `json:"nodegroup_id"`
+
+	// OSServerID contains OpenStack server identifier.
+	OSServerID string `json:"os_server_id"`
 }

--- a/vendor/github.com/selectel/mks-go/pkg/v1/nodegroup/doc.go
+++ b/vendor/github.com/selectel/mks-go/pkg/v1/nodegroup/doc.go
@@ -35,6 +35,13 @@ Example of creating a new cluster nodegroup
       "label-key1": "label-value1",
       "label-key2": "label-value2",
     },
+    Taints: []nodegroup.Taint{
+      {
+        Key:    "test-key-0",
+        Value:  "test-value-0",
+        Effect: nodegroup.NoScheduleEffect,
+      },
+    },
   }
   _, err := nodegroup.Create(ctx, mksClient, clusterID, createOpts)
   if err != nil {

--- a/vendor/github.com/selectel/mks-go/pkg/v1/nodegroup/requests_opts.go
+++ b/vendor/github.com/selectel/mks-go/pkg/v1/nodegroup/requests_opts.go
@@ -43,6 +43,16 @@ type CreateOpts struct {
 
 	// Taints represents a list of nodegroup taints.
 	Taints []Taint `json:"taints"`
+
+	// EnableAutoscale reflects if the nodegroup is allowed to be scaled automatically.
+	// Disabled by default.
+	EnableAutoscale *bool `json:"enable_autoscale,omitempty"`
+
+	// AutoscaleMinNodes represents minimum possible number of worker nodes in the nodegroup.
+	AutoscaleMinNodes *int `json:"autoscale_min_nodes,omitempty"`
+
+	// AutoscaleMaxNodes represents maximum possible number of worker nodes in the nodegroup.
+	AutoscaleMaxNodes *int `json:"autoscale_max_nodes,omitempty"`
 }
 
 // ResizeOpts represents options for the nodegroup Resize request.
@@ -56,4 +66,13 @@ type UpdateOpts struct {
 	// Labels represents an object containing a set of Kubernetes labels that will be applied
 	// for each node in the group. The keys must be user-defined.
 	Labels map[string]string `json:"labels"`
+
+	// EnableAutoscale reflects if the nodegroup is allowed to be scaled automatically.
+	EnableAutoscale *bool `json:"enable_autoscale,omitempty"`
+
+	// AutoscaleMinNodes represents minimum possible number of worker nodes in the nodegroup.
+	AutoscaleMinNodes *int `json:"autoscale_min_nodes,omitempty"`
+
+	// AutoscaleMaxNodes represents maximum possible number of worker nodes in the nodegroup.
+	AutoscaleMaxNodes *int `json:"autoscale_max_nodes,omitempty"`
 }

--- a/vendor/github.com/selectel/mks-go/pkg/v1/nodegroup/requests_opts.go
+++ b/vendor/github.com/selectel/mks-go/pkg/v1/nodegroup/requests_opts.go
@@ -40,6 +40,9 @@ type CreateOpts struct {
 	// Labels represents an object containing a set of Kubernetes labels that will be applied
 	// for each node in the group. The keys must be user-defined.
 	Labels map[string]string `json:"labels"`
+
+	// Taints represents a list of nodegroup taints.
+	Taints []Taint `json:"taints"`
 }
 
 // ResizeOpts represents options for the nodegroup Resize request.

--- a/vendor/github.com/selectel/mks-go/pkg/v1/nodegroup/schemas.go
+++ b/vendor/github.com/selectel/mks-go/pkg/v1/nodegroup/schemas.go
@@ -41,4 +41,28 @@ type View struct {
 	// Labels represents an object containing a set of Kubernetes labels that will be applied
 	// for each node in the group. The keys must be user-defined.
 	Labels map[string]string `json:"labels"`
+
+	// Taints represents a list of nodegroup taints.
+	Taints []Taint `json:"taints"`
+}
+
+// TaintEffect represents an effect of the node's taint.
+type TaintEffect string
+
+const (
+	NoScheduleEffect       TaintEffect = "NoSchedule"
+	NoExecuteEffect        TaintEffect = "NoExecute"
+	PreferNoScheduleEffect TaintEffect = "PreferNoSchedule"
+)
+
+// Taint represents k8s node's taint.
+type Taint struct {
+	// Key is the key of the taint.
+	Key string `json:"key"`
+
+	// Value is the value of the taint.
+	Value string `json:"value"`
+
+	// Effect is the effect of the taint.
+	Effect TaintEffect `json:"effect"`
 }

--- a/vendor/github.com/selectel/mks-go/pkg/v1/nodegroup/schemas.go
+++ b/vendor/github.com/selectel/mks-go/pkg/v1/nodegroup/schemas.go
@@ -6,6 +6,7 @@ import (
 	"github.com/selectel/mks-go/pkg/v1/node"
 )
 
+// nolint:maligned
 // View represents an unmarshalled nodegroup body from an API response.
 type View struct {
 	// ID is the identifier of the nodegroup.
@@ -44,6 +45,15 @@ type View struct {
 
 	// Taints represents a list of nodegroup taints.
 	Taints []Taint `json:"taints"`
+
+	// EnableAutoscale reflects if the nodegroup is allowed to be scaled automatically.
+	EnableAutoscale bool `json:"enable_autoscale"`
+
+	// AutoscaleMinNodes represents minimum possible number of worker nodes in the nodegroup.
+	AutoscaleMinNodes int `json:"autoscale_min_nodes"`
+
+	// AutoscaleMaxNodes represents maximum possible number of worker nodes in the nodegroup.
+	AutoscaleMaxNodes int `json:"autoscale_max_nodes"`
 }
 
 // TaintEffect represents an effect of the node's taint.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -182,7 +182,7 @@ github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/subnets
 github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/tokens
 github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/users
 github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/vrrpsubnets
-# github.com/selectel/mks-go v0.5.1-0.20200901133315-e90912ba57c3
+# github.com/selectel/mks-go v0.6.0
 ## explicit
 github.com/selectel/mks-go/pkg/v1
 github.com/selectel/mks-go/pkg/v1/cluster

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -182,7 +182,7 @@ github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/subnets
 github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/tokens
 github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/users
 github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/vrrpsubnets
-# github.com/selectel/mks-go v0.5.0
+# github.com/selectel/mks-go v0.5.1-0.20200901133315-e90912ba57c3
 ## explicit
 github.com/selectel/mks-go/pkg/v1
 github.com/selectel/mks-go/pkg/v1/cluster

--- a/website/docs/r/mks_nodegroup_v1.html.markdown
+++ b/website/docs/r/mks_nodegroup_v1.html.markdown
@@ -39,6 +39,21 @@ resource "selectel_mks_nodegroup_v1" "nodegroup_1" {
     "label-key1": "label-value1",
     "label-key2": "label-value2",
   }
+  taints {
+    key = "test-key-0"
+    value = "test-value-0"
+    effect = "NoSchedule"
+  }
+  taints {
+    key = "test-key-1"
+    value = "test-value-1"
+    effect = "NoExecute"
+  }
+  taints {
+    key = "test-key-2"
+    value = "test-value-2"
+    effect = "PreferNoSchedule"
+  }
 }
 ```
 
@@ -90,6 +105,9 @@ The following arguments are supported:
 
 * `labels` (Optional) Represents a map containing a set of Kubernetes labels that will be applied
   for each node in the group. The keys must be user-defined.
+
+* `taints` (Optional) Represents a list of Kubernetes taints that will be applied for each node in the group.
+  Changing this creates a new nodegroup.
 
 ## Attributes Reference
 


### PR DESCRIPTION
For #130 

Add 'taints' field into nodegroup resource.

Update tests and docs.

Vendor latest mks-go.