### PR TITLE
Disable wrapper for Terraform in acc tests

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_wrapper: false
 
       - name: Run test
         run: make testacc


### PR DESCRIPTION
Use terraform_wrapper: false for hashicorp/setup-terraform@v1 in Acceptance tests.