### PR TITLE
Add support for configuration parameters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.6.6
 	github.com/hashicorp/terraform-json v0.12.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.6.1
-	github.com/selectel/dbaas-go v0.1.1
+	github.com/selectel/dbaas-go v0.2.0
 	github.com/selectel/domains-go v0.3.0
 	github.com/selectel/go-selvpcclient v1.12.0
 	github.com/selectel/mks-go v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -292,6 +292,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
 github.com/selectel/dbaas-go v0.1.1 h1:dop1ANq6NwZTJ9MOOVL9iRBl5JWCqeldngYs4WK9Cfo=
 github.com/selectel/dbaas-go v0.1.1/go.mod h1:H2NC+UrVQzKea92LYyHZj51uuX43sUiAc+iyx/yTCGw=
+github.com/selectel/dbaas-go v0.2.0 h1:LuQYA1M+ftcNRdcCD8p+CQQ4ejU364CHuB8S23jH6GU=
+github.com/selectel/dbaas-go v0.2.0/go.mod h1:H2NC+UrVQzKea92LYyHZj51uuX43sUiAc+iyx/yTCGw=
 github.com/selectel/domains-go v0.3.0 h1:0shjqQmpkWc6eM1SwgKqbTTNiT5G2BOEnvS7JvuF96g=
 github.com/selectel/domains-go v0.3.0/go.mod h1:AhXhwyMSTkpEWFiBLUvzFP76W+WN+ZblwmjLJLt7y58=
 github.com/selectel/go-selvpcclient v1.12.0 h1:LsT074HOVF1dWYapsAWjaaJDQhmDPpcsVjSwQ1r1fj0=

--- a/selectel/data_source_selectel_dbaas_configuration_parameter_v1.go
+++ b/selectel/data_source_selectel_dbaas_configuration_parameter_v1.go
@@ -198,30 +198,30 @@ func filterConfigurationParametersByName(configurationParameters []dbaas.Configu
 	return filteredConfigurationParameters
 }
 
-func flattenDBaaSConfigurationParameters(configyrationParameters []dbaas.ConfigurationParameter) []interface{} {
-	configyrationParametersList := make([]interface{}, len(configyrationParameters))
-	for i, param := range configyrationParameters {
-		configyrationParametersMap := make(map[string]interface{})
-		configyrationParametersMap["id"] = param.ID
-		configyrationParametersMap["datastore_type_id"] = param.DatastoreTypeID
-		configyrationParametersMap["name"] = param.Name
-		configyrationParametersMap["type"] = param.Type
-		configyrationParametersMap["unit"] = param.Unit
-		configyrationParametersMap["min"] = convertFieldToStringByType(param.Min)
-		configyrationParametersMap["max"] = convertFieldToStringByType(param.Max)
-		configyrationParametersMap["default_value"] = convertFieldToStringByType(param.DefaultValue)
+func flattenDBaaSConfigurationParameters(configurationParameters []dbaas.ConfigurationParameter) []interface{} {
+	configurationParametersList := make([]interface{}, len(configurationParameters))
+	for i, param := range configurationParameters {
+		configurationParametersMap := make(map[string]interface{})
+		configurationParametersMap["id"] = param.ID
+		configurationParametersMap["datastore_type_id"] = param.DatastoreTypeID
+		configurationParametersMap["name"] = param.Name
+		configurationParametersMap["type"] = param.Type
+		configurationParametersMap["unit"] = param.Unit
+		configurationParametersMap["min"] = convertFieldToStringByType(param.Min)
+		configurationParametersMap["max"] = convertFieldToStringByType(param.Max)
+		configurationParametersMap["default_value"] = convertFieldToStringByType(param.DefaultValue)
 		choicesList := make([]string, len(param.Choices))
 		for i, choice := range param.Choices {
 			choicesList[i] = convertFieldToStringByType(choice)
 		}
-		configyrationParametersMap["choices"] = choicesList
-		configyrationParametersMap["is_restart_required"] = param.IsRestartRequired
-		configyrationParametersMap["is_changeable"] = param.IsChangeable
+		configurationParametersMap["choices"] = choicesList
+		configurationParametersMap["is_restart_required"] = param.IsRestartRequired
+		configurationParametersMap["is_changeable"] = param.IsChangeable
 
-		configyrationParametersList[i] = configyrationParametersMap
+		configurationParametersList[i] = configurationParametersMap
 	}
 
-	return configyrationParametersList
+	return configurationParametersList
 }
 
 func convertFieldToStringByType(field interface{}) string {

--- a/selectel/data_source_selectel_dbaas_configuration_parameter_v1.go
+++ b/selectel/data_source_selectel_dbaas_configuration_parameter_v1.go
@@ -1,0 +1,242 @@
+package selectel
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/selectel/dbaas-go"
+)
+
+type configurationParameterSearchFilter struct {
+	datastoreTypeID string
+	name            string
+}
+
+func dataSourceDBaaSConfigurationParameterV1() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDBaaSConfigurationParameterV1Read,
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					ru1Region,
+					ru2Region,
+					ru3Region,
+					ru7Region,
+					ru8Region,
+					ru9Region,
+				}, false),
+			},
+			"filter": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"datastore_type_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"configuration_parameters": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"datastore_type_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"unit": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"min": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"max": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"default_value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"choices": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"is_restart_required": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_changeable": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceDBaaSConfigurationParameterV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	dbaasClient, diagErr := getDBaaSClient(ctx, d, meta)
+	if diagErr != nil {
+		return diagErr
+	}
+
+	configurationParameters, err := dbaasClient.ConfigurationParameters(ctx)
+	if err != nil {
+		return diag.FromErr(errGettingObjects(objectConfigurationParameters, err))
+	}
+
+	configurationParametersIDs := []string{}
+	for _, param := range configurationParameters {
+		configurationParametersIDs = append(configurationParametersIDs, param.ID)
+	}
+
+	filter, err := expandConfigurationParameterSearchFilter(d.Get("filter").(*schema.Set))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	configurationParameters = filterConfigurationParametersByDatastoreTypeID(configurationParameters, filter.datastoreTypeID)
+	configurationParameters = filterConfigurationParametersByName(configurationParameters, filter.name)
+
+	configurationParametersFlatter := flattenDBaaSConfigurationParameters(configurationParameters)
+	if err := d.Set("configuration_parameters", configurationParametersFlatter); err != nil {
+		return diag.FromErr(err)
+	}
+	checksum, err := stringListChecksum(configurationParametersIDs)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(checksum)
+
+	return nil
+}
+
+func expandConfigurationParameterSearchFilter(filterSet *schema.Set) (configurationParameterSearchFilter, error) {
+	filter := configurationParameterSearchFilter{}
+	if filterSet.Len() == 0 {
+		return filter, nil
+	}
+
+	resourceFilterMap := filterSet.List()[0].(map[string]interface{})
+
+	datastoreTypeID, ok := resourceFilterMap["datastore_type_id"]
+	if ok {
+		filter.datastoreTypeID = datastoreTypeID.(string)
+	}
+
+	name, ok := resourceFilterMap["name"]
+	if ok {
+		filter.name = name.(string)
+	}
+
+	return filter, nil
+}
+
+func filterConfigurationParametersByDatastoreTypeID(configurationParameters []dbaas.ConfigurationParameter, datastoreTypeID string) []dbaas.ConfigurationParameter {
+	if datastoreTypeID == "" {
+		return configurationParameters
+	}
+
+	var filteredConfigurationParameters []dbaas.ConfigurationParameter
+	for _, param := range configurationParameters {
+		if param.DatastoreTypeID == datastoreTypeID {
+			filteredConfigurationParameters = append(filteredConfigurationParameters, param)
+		}
+	}
+
+	return filteredConfigurationParameters
+}
+
+func filterConfigurationParametersByName(configurationParameters []dbaas.ConfigurationParameter, name string) []dbaas.ConfigurationParameter {
+	if name == "" {
+		return configurationParameters
+	}
+
+	var filteredConfigurationParameters []dbaas.ConfigurationParameter
+	for _, param := range configurationParameters {
+		if param.Name == name {
+			filteredConfigurationParameters = append(filteredConfigurationParameters, param)
+		}
+	}
+
+	return filteredConfigurationParameters
+}
+
+func flattenDBaaSConfigurationParameters(configyrationParameters []dbaas.ConfigurationParameter) []interface{} {
+	configyrationParametersList := make([]interface{}, len(configyrationParameters))
+	for i, param := range configyrationParameters {
+		configyrationParametersMap := make(map[string]interface{})
+		configyrationParametersMap["id"] = param.ID
+		configyrationParametersMap["datastore_type_id"] = param.DatastoreTypeID
+		configyrationParametersMap["name"] = param.Name
+		configyrationParametersMap["type"] = param.Type
+		configyrationParametersMap["unit"] = param.Unit
+		configyrationParametersMap["min"] = convertFieldToStringByType(param.Min)
+		configyrationParametersMap["max"] = convertFieldToStringByType(param.Max)
+		configyrationParametersMap["default_value"] = convertFieldToStringByType(param.DefaultValue)
+		choicesList := make([]string, len(param.Choices))
+		for i, choice := range param.Choices {
+			choicesList[i] = convertFieldToStringByType(choice)
+		}
+		configyrationParametersMap["choices"] = choicesList
+		configyrationParametersMap["is_restart_required"] = param.IsRestartRequired
+		configyrationParametersMap["is_changeable"] = param.IsChangeable
+
+		configyrationParametersList[i] = configyrationParametersMap
+	}
+
+	return configyrationParametersList
+}
+
+func convertFieldToStringByType(field interface{}) string {
+	switch fieldValue := field.(type) {
+	case int:
+		return strconv.Itoa(fieldValue)
+	case float64:
+		return strconv.FormatFloat(fieldValue, 'f', -1, 64)
+	case float32:
+		return strconv.FormatFloat(float64(fieldValue), 'f', -1, 32)
+	case string:
+		return fieldValue
+	case bool:
+		return strconv.FormatBool(fieldValue)
+	default:
+		return ""
+	}
+}

--- a/selectel/data_source_selectel_dbaas_configuration_parameter_v1_test.go
+++ b/selectel/data_source_selectel_dbaas_configuration_parameter_v1_test.go
@@ -33,35 +33,35 @@ func TestAccDBaaSConfigurationParametersV1Basic(t *testing.T) {
 				Config: testAccDBaaSConfigurationParametersV1Basic(projectName, datastoreTypeEngine, datastoreTypeVersion, parameterName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCV2ProjectExists("selectel_vpc_project_v2.project_tf_acc_test_1", &project),
-					testAccDBaaSConfigurationParametersV1Exists("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", &dbaasConfigurationParameters),
-					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.name", parameterName),
-					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.type", "int"),
-					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.unit", "kB"),
-					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.min", "64"),
-					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.max", "2147483647"),
-					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.default_value", "32768"),
-					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.choices.#", "0"),
-					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.is_restart_required", "false"),
-					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.is_changeable", "true"),
+					testAccDBaaSConfigurationParametersV1Exists("data.selectel_dbaas_configuration_parameter_v1.configuration_param_tf_acc_test_1", &dbaasConfigurationParameters),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameter_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.name", parameterName),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameter_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.type", "int"),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameter_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.unit", "kB"),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameter_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.min", "64"),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameter_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.max", "2147483647"),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameter_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.default_value", "32768"),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameter_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.choices.#", "0"),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameter_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.is_restart_required", "false"),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameter_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.is_changeable", "true"),
 				),
 			},
 			{
 				Config: testAccDBaaSConfigurationParametersV1Basic(projectName, datastoreTypeEngine, datastoreTypeVersion, parameterNameWithChoices),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVPCV2ProjectExists("selectel_vpc_project_v2.project_tf_acc_test_1", &project),
-					testAccDBaaSConfigurationParametersV1Exists("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", &dbaasConfigurationParameters),
-					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.name", parameterNameWithChoices),
-					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.type", "str"),
-					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.unit", ""),
-					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.min", ""),
-					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.max", ""),
-					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.default_value", "origin"),
-					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.choices.#", "3"),
-					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.choices.0", "origin"),
-					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.choices.1", "replica"),
-					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.choices.2", "local"),
-					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.is_restart_required", "false"),
-					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.is_changeable", "true"),
+					testAccDBaaSConfigurationParametersV1Exists("data.selectel_dbaas_configuration_parameter_v1.configuration_param_tf_acc_test_1", &dbaasConfigurationParameters),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameter_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.name", parameterNameWithChoices),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameter_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.type", "str"),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameter_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.unit", ""),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameter_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.min", ""),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameter_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.max", ""),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameter_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.default_value", "origin"),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameter_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.choices.#", "3"),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameter_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.choices.0", "origin"),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameter_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.choices.1", "replica"),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameter_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.choices.2", "local"),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameter_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.is_restart_required", "false"),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameter_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.is_changeable", "true"),
 				),
 			},
 		},
@@ -109,7 +109,7 @@ data "selectel_dbaas_datastore_type_v1" "dt" {
   }
 }
 
-data "selectel_dbaas_configuration_parameters_v1" "configuration_param_tf_acc_test_1" {
+data "selectel_dbaas_configuration_parameter_v1" "configuration_param_tf_acc_test_1" {
   project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
   region     = "ru-3"
   filter {
@@ -119,7 +119,7 @@ data "selectel_dbaas_configuration_parameters_v1" "configuration_param_tf_acc_te
 }
 
 output "config" {
-  value = data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1.configuration_parameters[0]
+  value = data.selectel_dbaas_configuration_parameter_v1.configuration_param_tf_acc_test_1.configuration_parameters[0]
 }
 `, projectName, engine, version, name)
 }

--- a/selectel/data_source_selectel_dbaas_configuration_parameter_v1_test.go
+++ b/selectel/data_source_selectel_dbaas_configuration_parameter_v1_test.go
@@ -1,0 +1,125 @@
+package selectel
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/selectel/dbaas-go"
+	"github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/projects"
+)
+
+func TestAccDBaaSConfigurationParametersV1Basic(t *testing.T) {
+	var (
+		dbaasConfigurationParameters []dbaas.ConfigurationParameter
+		project                      projects.Project
+	)
+
+	projectName := acctest.RandomWithPrefix("tf-acc")
+	datastoreTypeEngine := "postgresql"
+	datastoreTypeVersion := "12"
+	parameterName := "work_mem"
+	parameterNameWithChoices := "session_replication_role"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccSelectelPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckVPCV2ProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDBaaSConfigurationParametersV1Basic(projectName, datastoreTypeEngine, datastoreTypeVersion, parameterName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVPCV2ProjectExists("selectel_vpc_project_v2.project_tf_acc_test_1", &project),
+					testAccDBaaSConfigurationParametersV1Exists("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", &dbaasConfigurationParameters),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.name", parameterName),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.type", "int"),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.unit", "kB"),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.min", "64"),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.max", "2147483647"),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.default_value", "32768"),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.choices.#", "0"),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.is_restart_required", "false"),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.is_changeable", "true"),
+				),
+			},
+			{
+				Config: testAccDBaaSConfigurationParametersV1Basic(projectName, datastoreTypeEngine, datastoreTypeVersion, parameterNameWithChoices),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVPCV2ProjectExists("selectel_vpc_project_v2.project_tf_acc_test_1", &project),
+					testAccDBaaSConfigurationParametersV1Exists("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", &dbaasConfigurationParameters),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.name", parameterNameWithChoices),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.type", "str"),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.unit", ""),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.min", ""),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.max", ""),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.default_value", "origin"),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.choices.#", "3"),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.choices.0", "origin"),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.choices.1", "replica"),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.choices.2", "local"),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.is_restart_required", "false"),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1", "configuration_parameters.0.is_changeable", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDBaaSConfigurationParametersV1Exists(n string, dbaasConfigurationParameters *[]dbaas.ConfigurationParameter) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		ctx := context.Background()
+
+		dbaasClient, err := baseTestAccCheckDBaaSV1EntityExists(ctx, rs, testAccProvider)
+		if err != nil {
+			return err
+		}
+
+		configurationParameters, err := dbaasClient.ConfigurationParameters(ctx)
+		if err != nil {
+			return err
+		}
+
+		*dbaasConfigurationParameters = configurationParameters
+
+		return nil
+	}
+}
+
+func testAccDBaaSConfigurationParametersV1Basic(projectName, engine, version, name string) string {
+	return fmt.Sprintf(`
+resource "selectel_vpc_project_v2" "project_tf_acc_test_1" {
+  name        = "%s"
+  auto_quotas = true
+}
+
+data "selectel_dbaas_datastore_type_v1" "dt" {
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  region     = "ru-3"
+  filter {
+	engine = "%s"
+	version = "%s"
+  }
+}
+
+data "selectel_dbaas_configuration_parameters_v1" "configuration_param_tf_acc_test_1" {
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  region     = "ru-3"
+  filter {
+    datastore_type_id = "${data.selectel_dbaas_datastore_type_v1.dt.datastore_types[0].id}"
+    name = "%s"
+  }
+}
+
+output "config" {
+  value = data.selectel_dbaas_configuration_parameters_v1.configuration_param_tf_acc_test_1.configuration_parameters[0]
+}
+`, projectName, engine, version, name)
+}

--- a/selectel/data_source_selectel_dbaas_configuration_parameter_v1_test.go
+++ b/selectel/data_source_selectel_dbaas_configuration_parameter_v1_test.go
@@ -104,8 +104,8 @@ data "selectel_dbaas_datastore_type_v1" "dt" {
   project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
   region     = "ru-3"
   filter {
-	engine = "%s"
-	version = "%s"
+    engine = "%s"
+    version = "%s"
   }
 }
 

--- a/selectel/provider.go
+++ b/selectel/provider.go
@@ -9,27 +9,28 @@ import (
 )
 
 const (
-	objectFloatingIP          = "floating IP"
-	objectKeypair             = "keypair"
-	objectLicense             = "license"
-	objectProject             = "project"
-	objectProjectQuotas       = "quotas for project"
-	objectRole                = "role"
-	objectSubnet              = "subnet"
-	objectToken               = "token"
-	objectUser                = "user"
-	objectVRRPSubnet          = "VRRP subnet"
-	objectCluster             = "cluster"
-	objectNodegroup           = "nodegroup"
-	objectDomain              = "domain"
-	objectRecord              = "record"
-	objectDatastore           = "datastore"
-	objectDatabase            = "database"
-	objectGrant               = "grant"
-	objectExtension           = "extension"
-	objectDatastoreTypes      = "datastore-types"
-	objectAvailableExtensions = "available-extensions"
-	objectFlavors             = "flavors"
+	objectFloatingIP              = "floating IP"
+	objectKeypair                 = "keypair"
+	objectLicense                 = "license"
+	objectProject                 = "project"
+	objectProjectQuotas           = "quotas for project"
+	objectRole                    = "role"
+	objectSubnet                  = "subnet"
+	objectToken                   = "token"
+	objectUser                    = "user"
+	objectVRRPSubnet              = "VRRP subnet"
+	objectCluster                 = "cluster"
+	objectNodegroup               = "nodegroup"
+	objectDomain                  = "domain"
+	objectRecord                  = "record"
+	objectDatastore               = "datastore"
+	objectDatabase                = "database"
+	objectGrant                   = "grant"
+	objectExtension               = "extension"
+	objectDatastoreTypes          = "datastore-types"
+	objectAvailableExtensions     = "available-extensions"
+	objectFlavors                 = "flavors"
+	objectConfigurationParameters = "configuration-parameters"
 )
 
 // This is a global MutexKV for use within this plugin.
@@ -65,10 +66,11 @@ func Provider() *schema.Provider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"selectel_domains_domain_v1":            dataSourceDomainsDomainV1(),
-			"selectel_dbaas_datastore_type_v1":      dataSourceDBaaSDatastoreTypeV1(),
-			"selectel_dbaas_available_extension_v1": dataSourceDBaaSAvailableExtensionV1(),
-			"selectel_dbaas_flavor_v1":              dataSourceDBaaSFlavorV1(),
+			"selectel_domains_domain_v1":                dataSourceDomainsDomainV1(),
+			"selectel_dbaas_datastore_type_v1":          dataSourceDBaaSDatastoreTypeV1(),
+			"selectel_dbaas_available_extension_v1":     dataSourceDBaaSAvailableExtensionV1(),
+			"selectel_dbaas_flavor_v1":                  dataSourceDBaaSFlavorV1(),
+			"selectel_dbaas_configuration_parameter_v1": dataSourceDBaaSConfigurationParameterV1(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"selectel_vpc_floatingip_v2":         resourceVPCFloatingIPV2(),

--- a/selectel/resource_selectel_dbaas_database_v1_test.go
+++ b/selectel/resource_selectel_dbaas_database_v1_test.go
@@ -91,8 +91,8 @@ data "selectel_dbaas_datastore_type_v1" "dt" {
   project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
   region = "ru-3"
   filter {
-	engine = "postgresql"
-	version = "12"
+    engine = "postgresql"
+    version = "12"
   }
 }
 
@@ -104,9 +104,9 @@ resource "selectel_dbaas_datastore_v1" "datastore_tf_acc_test_1" {
   subnet_id = "${selectel_vpc_subnet_v2.subnet_tf_acc_test_1.subnet_id}"
   node_count = "%d"
   flavor {
-	vcpus = 2
-	ram = 4096
-	disk = 32
+    vcpus = 2
+    ram = 4096
+    disk = 32
   }
 }
 

--- a/selectel/resource_selectel_dbaas_datastore_v1_test.go
+++ b/selectel/resource_selectel_dbaas_datastore_v1_test.go
@@ -214,8 +214,8 @@ data "selectel_dbaas_datastore_type_v1" "dt" {
   project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
   region = "ru-3"
   filter {
-	engine = "postgresql"
-	version = "12"
+    engine = "postgresql"
+    version = "12"
   }
 }
 
@@ -232,10 +232,10 @@ resource "selectel_dbaas_datastore_v1" "datastore_tf_acc_test_1" {
     disk = 32
   }
   config = {
-	xmloption = "content"
-	work_mem = 128
-	vacuum_cost_delay = 25
-	transform_null_equals = true
+    xmloption = "content"
+    work_mem = 128
+    vacuum_cost_delay = 25
+    transform_null_equals = true
   }
 }`, projectName, datastoreName, nodeCount)
 }
@@ -256,8 +256,8 @@ data "selectel_dbaas_datastore_type_v1" "dt" {
   project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
   region = "ru-3"
   filter {
-	engine = "postgresql"
-	version = "12"
+    engine = "postgresql"
+    version = "12"
   }
 }
 
@@ -274,10 +274,10 @@ resource "selectel_dbaas_datastore_v1" "datastore_tf_acc_test_1" {
     disk = 32
   }
   config = {
-	xmloption = "content"
-	work_mem = 128
-	vacuum_cost_delay = 25
-	transform_null_equals = true
+    xmloption = "content"
+    work_mem = 128
+    vacuum_cost_delay = 25
+    transform_null_equals = true
   }
 }`, projectName, datastoreName, nodeCount)
 }
@@ -298,8 +298,8 @@ data "selectel_dbaas_datastore_type_v1" "dt" {
   project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
   region = "ru-3"
   filter {
-	engine = "postgresql"
-	version = "12"
+    engine = "postgresql"
+    version = "12"
   }
 }
 
@@ -316,14 +316,14 @@ resource "selectel_dbaas_datastore_v1" "datastore_tf_acc_test_1" {
     disk = 32
   }
   config = {
-	xmloption = "content"
-	work_mem = 128
-	vacuum_cost_delay = 25
-	transform_null_equals = true
+    xmloption = "content"
+    work_mem = 128
+    vacuum_cost_delay = 25
+    transform_null_equals = true
   }
   pooler {
-	mode = "session"
-	size = 50
+    mode = "session"
+    size = 50
   }
 }`, projectName, datastoreName, nodeCount)
 }
@@ -344,8 +344,8 @@ data "selectel_dbaas_datastore_type_v1" "dt" {
   project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
   region = "ru-3"
   filter {
-	engine = "postgresql"
-	version = "12"
+    engine = "postgresql"
+    version = "12"
   }
 }
 
@@ -362,17 +362,17 @@ resource "selectel_dbaas_datastore_v1" "datastore_tf_acc_test_1" {
     disk = 32
   }
   config = {
-	xmloption = "content"
-	work_mem = 128
-	vacuum_cost_delay = 25
-	transform_null_equals = true
+    xmloption = "content"
+    work_mem = 128
+    vacuum_cost_delay = 25
+    transform_null_equals = true
   }
   pooler {
-	mode = "session"
-	size = 50
+    mode = "session"
+    size = 50
   }
   firewall {
-	ips = [ "127.0.0.1", "127.0.0.2" ]
+    ips = [ "127.0.0.1", "127.0.0.2" ]
   }
 }`, projectName, datastoreName, nodeCount)
 }
@@ -393,8 +393,8 @@ data "selectel_dbaas_datastore_type_v1" "dt" {
   project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
   region = "ru-3"
   filter {
-	engine = "postgresql"
-	version = "12"
+    engine = "postgresql"
+    version = "12"
   }
 }
 
@@ -411,17 +411,17 @@ resource "selectel_dbaas_datastore_v1" "datastore_tf_acc_test_1" {
     disk = 32
   }
   config = {
-	xmloption = "content"
-	work_mem = 128
-	vacuum_cost_delay = 25
-	transform_null_equals = true
+    xmloption = "content"
+    work_mem = 128
+    vacuum_cost_delay = 25
+    transform_null_equals = true
   }
   pooler {
-	mode = "session"
-	size = 50
+    mode = "session"
+    size = 50
   }
   firewall {
-	ips = [ "127.0.0.1", "127.0.0.2" ]
+    ips = [ "127.0.0.1", "127.0.0.2" ]
   }
 }`, projectName, datastoreName, nodeCount)
 }
@@ -442,8 +442,8 @@ data "selectel_dbaas_datastore_type_v1" "dt" {
   project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
   region = "ru-3"
   filter {
-	engine = "postgresql"
-	version = "12"
+    engine = "postgresql"
+    version = "12"
   }
 }
 
@@ -460,16 +460,16 @@ resource "selectel_dbaas_datastore_v1" "datastore_tf_acc_test_1" {
     disk = 32
   }
   config = {
-	xmloption = "content"
-	work_mem = 256
-	vacuum_cost_delay = 20
+    xmloption = "content"
+    work_mem = 256
+    vacuum_cost_delay = 20
   }
   pooler {
-	mode = "session"
-	size = 50
+    mode = "session"
+    size = 50
   }
   firewall {
-	ips = [ "127.0.0.1", "127.0.0.2" ]
+    ips = [ "127.0.0.1", "127.0.0.2" ]
   }
 }`, projectName, datastoreName, nodeCount)
 }

--- a/selectel/resource_selectel_dbaas_datastore_v1_test.go
+++ b/selectel/resource_selectel_dbaas_datastore_v1_test.go
@@ -24,6 +24,8 @@ func TestAccDBaaSDatastoreV1Basic(t *testing.T) {
 	datastoreName := acctest.RandomWithPrefix("tf-acc-ds")
 	nodeCount := 1
 
+	updatedDatastoreName := acctest.RandomWithPrefix("tf-acc-ds-updated")
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccSelectelPreCheck(t) },
 		ProviderFactories: testAccProviders,
@@ -42,6 +44,120 @@ func TestAccDBaaSDatastoreV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "flavor.0.vcpus", strconv.Itoa(2)),
 					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "flavor.0.ram", strconv.Itoa(4096)),
 					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "flavor.0.disk", strconv.Itoa(32)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "config.xmloption", "content"),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "config.work_mem", strconv.Itoa(128)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "config.vacuum_cost_delay", strconv.Itoa(25)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "config.transform_null_equals", "true"),
+					resource.TestCheckResourceAttrSet("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "connections.master"),
+				),
+			},
+			{
+				Config: testAccDBaaSDatastoreV1UpdateName(projectName, updatedDatastoreName, nodeCount),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVPCV2ProjectExists("selectel_vpc_project_v2.project_tf_acc_test_1", &project),
+					testAccCheckDBaaSDatastoreV1Exists("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", &dbaasDatastore),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "name", updatedDatastoreName),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "region", "ru-3"),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "node_count", strconv.Itoa(nodeCount)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "enabled", "true"),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "status", string(dbaas.StatusActive)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "flavor.0.vcpus", strconv.Itoa(2)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "flavor.0.ram", strconv.Itoa(4096)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "flavor.0.disk", strconv.Itoa(32)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "config.xmloption", "content"),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "config.work_mem", strconv.Itoa(128)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "config.vacuum_cost_delay", strconv.Itoa(25)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "config.transform_null_equals", "true"),
+					resource.TestCheckResourceAttrSet("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "connections.master"),
+				),
+			},
+			{
+				Config: testAccDBaaSDatastoreV1UpdatePooler(projectName, updatedDatastoreName, nodeCount),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVPCV2ProjectExists("selectel_vpc_project_v2.project_tf_acc_test_1", &project),
+					testAccCheckDBaaSDatastoreV1Exists("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", &dbaasDatastore),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "name", updatedDatastoreName),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "region", "ru-3"),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "node_count", strconv.Itoa(nodeCount)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "enabled", "true"),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "status", string(dbaas.StatusActive)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "flavor.0.vcpus", strconv.Itoa(2)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "flavor.0.ram", strconv.Itoa(4096)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "flavor.0.disk", strconv.Itoa(32)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "config.xmloption", "content"),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "config.work_mem", strconv.Itoa(128)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "config.vacuum_cost_delay", strconv.Itoa(25)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "config.transform_null_equals", "true"),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "pooler.0.mode", "session"),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "pooler.0.size", strconv.Itoa(50)),
+					resource.TestCheckResourceAttrSet("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "connections.master"),
+				),
+			},
+			{
+				Config: testAccDBaaSDatastoreV1UpdateFirewall(projectName, updatedDatastoreName, nodeCount),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVPCV2ProjectExists("selectel_vpc_project_v2.project_tf_acc_test_1", &project),
+					testAccCheckDBaaSDatastoreV1Exists("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", &dbaasDatastore),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "name", updatedDatastoreName),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "region", "ru-3"),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "node_count", strconv.Itoa(nodeCount)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "enabled", "true"),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "status", string(dbaas.StatusActive)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "flavor.0.vcpus", strconv.Itoa(2)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "flavor.0.ram", strconv.Itoa(4096)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "flavor.0.disk", strconv.Itoa(32)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "pooler.0.mode", "session"),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "pooler.0.size", strconv.Itoa(50)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "config.xmloption", "content"),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "config.work_mem", strconv.Itoa(128)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "config.vacuum_cost_delay", strconv.Itoa(25)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "config.transform_null_equals", "true"),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "firewall.0.ips.#", "2"),
+					resource.TestCheckResourceAttrSet("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "connections.master"),
+				),
+			},
+			{
+				Config: testAccDBaaSDatastoreV1Resize(projectName, updatedDatastoreName, nodeCount),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVPCV2ProjectExists("selectel_vpc_project_v2.project_tf_acc_test_1", &project),
+					testAccCheckDBaaSDatastoreV1Exists("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", &dbaasDatastore),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "name", updatedDatastoreName),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "region", "ru-3"),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "node_count", strconv.Itoa(nodeCount)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "enabled", "true"),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "status", string(dbaas.StatusActive)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "flavor.0.vcpus", strconv.Itoa(2)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "flavor.0.ram", strconv.Itoa(8192)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "flavor.0.disk", strconv.Itoa(32)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "pooler.0.mode", "session"),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "pooler.0.size", strconv.Itoa(50)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "config.xmloption", "content"),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "config.work_mem", strconv.Itoa(128)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "config.vacuum_cost_delay", strconv.Itoa(25)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "config.transform_null_equals", "true"),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "firewall.0.ips.#", "2"),
+					resource.TestCheckResourceAttrSet("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "connections.master"),
+				),
+			},
+			{
+				Config: testAccDBaaSDatastoreV1UpdateConfig(projectName, updatedDatastoreName, nodeCount),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVPCV2ProjectExists("selectel_vpc_project_v2.project_tf_acc_test_1", &project),
+					testAccCheckDBaaSDatastoreV1Exists("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", &dbaasDatastore),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "name", updatedDatastoreName),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "region", "ru-3"),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "node_count", strconv.Itoa(nodeCount)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "enabled", "true"),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "status", string(dbaas.StatusActive)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "flavor.0.vcpus", strconv.Itoa(2)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "flavor.0.ram", strconv.Itoa(8192)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "flavor.0.disk", strconv.Itoa(32)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "pooler.0.mode", "session"),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "pooler.0.size", strconv.Itoa(50)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "config.xmloption", "content"),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "config.work_mem", strconv.Itoa(256)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "config.vacuum_cost_delay", strconv.Itoa(20)),
+					resource.TestCheckResourceAttr("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "firewall.0.ips.#", "2"),
 					resource.TestCheckResourceAttrSet("selectel_dbaas_datastore_v1.datastore_tf_acc_test_1", "connections.master"),
 				),
 			},
@@ -114,6 +230,246 @@ resource "selectel_dbaas_datastore_v1" "datastore_tf_acc_test_1" {
     vcpus = 2
     ram = 4096
     disk = 32
+  }
+  config = {
+	xmloption = "content"
+	work_mem = 128
+	vacuum_cost_delay = 25
+	transform_null_equals = true
+  }
+}`, projectName, datastoreName, nodeCount)
+}
+
+func testAccDBaaSDatastoreV1UpdateName(projectName, datastoreName string, nodeCount int) string {
+	return fmt.Sprintf(`
+resource "selectel_vpc_project_v2" "project_tf_acc_test_1" {
+  name        = "%s"
+  auto_quotas = true
+}
+
+resource "selectel_vpc_subnet_v2" "subnet_tf_acc_test_1" {
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  region     = "ru-3"
+}
+
+data "selectel_dbaas_datastore_type_v1" "dt" {
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  region = "ru-3"
+  filter {
+	engine = "postgresql"
+	version = "12"
+  }
+}
+
+resource "selectel_dbaas_datastore_v1" "datastore_tf_acc_test_1" {
+  name = "%s"
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  region = "ru-3"
+  type_id = "${data.selectel_dbaas_datastore_type_v1.dt.datastore_types[0].id}"
+  subnet_id = "${selectel_vpc_subnet_v2.subnet_tf_acc_test_1.subnet_id}"
+  node_count = "%d"
+  flavor {
+    vcpus = 2
+    ram = 4096
+    disk = 32
+  }
+  config = {
+	xmloption = "content"
+	work_mem = 128
+	vacuum_cost_delay = 25
+	transform_null_equals = true
+  }
+}`, projectName, datastoreName, nodeCount)
+}
+
+func testAccDBaaSDatastoreV1UpdatePooler(projectName, datastoreName string, nodeCount int) string {
+	return fmt.Sprintf(`
+resource "selectel_vpc_project_v2" "project_tf_acc_test_1" {
+  name        = "%s"
+  auto_quotas = true
+}
+
+resource "selectel_vpc_subnet_v2" "subnet_tf_acc_test_1" {
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  region     = "ru-3"
+}
+
+data "selectel_dbaas_datastore_type_v1" "dt" {
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  region = "ru-3"
+  filter {
+	engine = "postgresql"
+	version = "12"
+  }
+}
+
+resource "selectel_dbaas_datastore_v1" "datastore_tf_acc_test_1" {
+  name = "%s"
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  region = "ru-3"
+  type_id = "${data.selectel_dbaas_datastore_type_v1.dt.datastore_types[0].id}"
+  subnet_id = "${selectel_vpc_subnet_v2.subnet_tf_acc_test_1.subnet_id}"
+  node_count = "%d"
+  flavor {
+    vcpus = 2
+    ram = 4096
+    disk = 32
+  }
+  config = {
+	xmloption = "content"
+	work_mem = 128
+	vacuum_cost_delay = 25
+	transform_null_equals = true
+  }
+  pooler {
+	mode = "session"
+	size = 50
+  }
+}`, projectName, datastoreName, nodeCount)
+}
+
+func testAccDBaaSDatastoreV1UpdateFirewall(projectName, datastoreName string, nodeCount int) string {
+	return fmt.Sprintf(`
+resource "selectel_vpc_project_v2" "project_tf_acc_test_1" {
+  name        = "%s"
+  auto_quotas = true
+}
+
+resource "selectel_vpc_subnet_v2" "subnet_tf_acc_test_1" {
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  region     = "ru-3"
+}
+
+data "selectel_dbaas_datastore_type_v1" "dt" {
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  region = "ru-3"
+  filter {
+	engine = "postgresql"
+	version = "12"
+  }
+}
+
+resource "selectel_dbaas_datastore_v1" "datastore_tf_acc_test_1" {
+  name = "%s"
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  region = "ru-3"
+  type_id = "${data.selectel_dbaas_datastore_type_v1.dt.datastore_types[0].id}"
+  subnet_id = "${selectel_vpc_subnet_v2.subnet_tf_acc_test_1.subnet_id}"
+  node_count = "%d"
+  flavor {
+    vcpus = 2
+    ram = 4096
+    disk = 32
+  }
+  config = {
+	xmloption = "content"
+	work_mem = 128
+	vacuum_cost_delay = 25
+	transform_null_equals = true
+  }
+  pooler {
+	mode = "session"
+	size = 50
+  }
+  firewall {
+	ips = [ "127.0.0.1", "127.0.0.2" ]
+  }
+}`, projectName, datastoreName, nodeCount)
+}
+
+func testAccDBaaSDatastoreV1Resize(projectName, datastoreName string, nodeCount int) string {
+	return fmt.Sprintf(`
+resource "selectel_vpc_project_v2" "project_tf_acc_test_1" {
+  name        = "%s"
+  auto_quotas = true
+}
+
+resource "selectel_vpc_subnet_v2" "subnet_tf_acc_test_1" {
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  region     = "ru-3"
+}
+
+data "selectel_dbaas_datastore_type_v1" "dt" {
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  region = "ru-3"
+  filter {
+	engine = "postgresql"
+	version = "12"
+  }
+}
+
+resource "selectel_dbaas_datastore_v1" "datastore_tf_acc_test_1" {
+  name = "%s"
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  region = "ru-3"
+  type_id = "${data.selectel_dbaas_datastore_type_v1.dt.datastore_types[0].id}"
+  subnet_id = "${selectel_vpc_subnet_v2.subnet_tf_acc_test_1.subnet_id}"
+  node_count = "%d"
+  flavor {
+    vcpus = 2
+    ram = 8192
+    disk = 32
+  }
+  config = {
+	xmloption = "content"
+	work_mem = 128
+	vacuum_cost_delay = 25
+	transform_null_equals = true
+  }
+  pooler {
+	mode = "session"
+	size = 50
+  }
+  firewall {
+	ips = [ "127.0.0.1", "127.0.0.2" ]
+  }
+}`, projectName, datastoreName, nodeCount)
+}
+
+func testAccDBaaSDatastoreV1UpdateConfig(projectName, datastoreName string, nodeCount int) string {
+	return fmt.Sprintf(`
+resource "selectel_vpc_project_v2" "project_tf_acc_test_1" {
+  name        = "%s"
+  auto_quotas = true
+}
+
+resource "selectel_vpc_subnet_v2" "subnet_tf_acc_test_1" {
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  region     = "ru-3"
+}
+
+data "selectel_dbaas_datastore_type_v1" "dt" {
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  region = "ru-3"
+  filter {
+	engine = "postgresql"
+	version = "12"
+  }
+}
+
+resource "selectel_dbaas_datastore_v1" "datastore_tf_acc_test_1" {
+  name = "%s"
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  region = "ru-3"
+  type_id = "${data.selectel_dbaas_datastore_type_v1.dt.datastore_types[0].id}"
+  subnet_id = "${selectel_vpc_subnet_v2.subnet_tf_acc_test_1.subnet_id}"
+  node_count = "%d"
+  flavor {
+    vcpus = 2
+    ram = 8192
+    disk = 32
+  }
+  config = {
+	xmloption = "content"
+	work_mem = 256
+	vacuum_cost_delay = 20
+  }
+  pooler {
+	mode = "session"
+	size = 50
+  }
+  firewall {
+	ips = [ "127.0.0.1", "127.0.0.2" ]
   }
 }`, projectName, datastoreName, nodeCount)
 }

--- a/selectel/resource_selectel_dbaas_extension_v1_test.go
+++ b/selectel/resource_selectel_dbaas_extension_v1_test.go
@@ -92,8 +92,8 @@ data "selectel_dbaas_datastore_type_v1" "dt" {
   project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
   region = "ru-3"
   filter {
-	engine = "postgresql"
-	version = "12"
+    engine = "postgresql"
+    version = "12"
   }
 }
 
@@ -105,9 +105,9 @@ resource "selectel_dbaas_datastore_v1" "datastore_tf_acc_test_1" {
   subnet_id = "${selectel_vpc_subnet_v2.subnet_tf_acc_test_1.subnet_id}"
   node_count = "%d"
   flavor {
-	vcpus = 2
-	ram = 4096
-	disk = 32
+    vcpus = 2
+    ram = 4096
+    disk = 32
   }
 }
 

--- a/selectel/resource_selectel_dbaas_grant_v1_test.go
+++ b/selectel/resource_selectel_dbaas_grant_v1_test.go
@@ -91,8 +91,8 @@ data "selectel_dbaas_datastore_type_v1" "dt" {
   project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
   region = "ru-3"
   filter {
-	engine = "postgresql"
-	version = "12"
+    engine = "postgresql"
+    version = "12"
   }
 }
 
@@ -104,9 +104,9 @@ resource "selectel_dbaas_datastore_v1" "datastore_tf_acc_test_1" {
   subnet_id = "${selectel_vpc_subnet_v2.subnet_tf_acc_test_1.subnet_id}"
   node_count = "%d"
   flavor {
-	vcpus = 2
-	ram = 4096
-	disk = 32
+    vcpus = 2
+    ram = 4096
+    disk = 32
   }
 }
 

--- a/selectel/resource_selectel_dbaas_user_v1_test.go
+++ b/selectel/resource_selectel_dbaas_user_v1_test.go
@@ -89,8 +89,8 @@ data "selectel_dbaas_datastore_type_v1" "dt" {
   project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
   region = "ru-3"
   filter {
-	engine = "postgresql"
-	version = "12"
+    engine = "postgresql"
+    version = "12"
   }
 }
 
@@ -102,9 +102,9 @@ resource "selectel_dbaas_datastore_v1" "datastore_tf_acc_test_1" {
   subnet_id = "${selectel_vpc_subnet_v2.subnet_tf_acc_test_1.subnet_id}"
   node_count = "%d"
   flavor {
-	vcpus = 2
-	ram = 4096
-	disk = 32
+    vcpus = 2
+    ram = 4096
+    disk = 32
   }
 }
 

--- a/vendor/github.com/selectel/dbaas-go/configuration_parameter.go
+++ b/vendor/github.com/selectel/dbaas-go/configuration_parameter.go
@@ -1,0 +1,66 @@
+package dbaas
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// ConfigurationParameter is the API response for the configuration parameters.
+type ConfigurationParameter struct {
+	ID                string        `json:"id"`
+	DatastoreTypeID   string        `json:"datastore_type_id"`
+	Name              string        `json:"name"`
+	Type              string        `json:"type"`
+	Unit              string        `json:"unit"`
+	Min               interface{}   `json:"min"`
+	Max               interface{}   `json:"max"`
+	DefaultValue      interface{}   `json:"default_value"`
+	Choices           []interface{} `json:"choices"`
+	IsRestartRequired bool          `json:"is_restart_required"`
+	IsChangeable      bool          `json:"is_changeable"`
+}
+
+// ConfigurationParameters returns all configuration parameters.
+func (api *API) ConfigurationParameters(ctx context.Context) ([]ConfigurationParameter, error) {
+	uri := "/configuration-parameters"
+
+	resp, err := api.makeRequest(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return []ConfigurationParameter{}, err
+	}
+
+	var result struct {
+		ConfigurationParameters []ConfigurationParameter `json:"configuration-parameters"`
+	}
+	err = json.Unmarshal(resp, &result)
+	if err != nil {
+		return []ConfigurationParameter{}, fmt.Errorf("Error during Unmarshal, %w", err)
+	}
+
+	return result.ConfigurationParameters, nil
+}
+
+// ConfigurationParameter returns a configuration parameter based on the ID.
+func (api *API) ConfigurationParameter(
+	ctx context.Context,
+	configurationParameterID string,
+) (ConfigurationParameter, error) {
+	uri := fmt.Sprintf("/configuration-parameters/%s", configurationParameterID)
+
+	resp, err := api.makeRequest(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return ConfigurationParameter{}, err
+	}
+
+	var result struct {
+		ConfigurationParameter ConfigurationParameter `json:"configuration-parameter"`
+	}
+	err = json.Unmarshal(resp, &result)
+	if err != nil {
+		return ConfigurationParameter{}, fmt.Errorf("Error during Unmarshal, %w", err)
+	}
+
+	return result.ConfigurationParameter, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -191,7 +191,7 @@ github.com/mitchellh/reflectwalk
 github.com/oklog/run
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
-# github.com/selectel/dbaas-go v0.1.1
+# github.com/selectel/dbaas-go v0.2.0
 ## explicit
 github.com/selectel/dbaas-go
 # github.com/selectel/domains-go v0.3.0

--- a/website/docs/d/dbaas_configuration_parameter_v1.html.markdown
+++ b/website/docs/d/dbaas_configuration_parameter_v1.html.markdown
@@ -27,12 +27,12 @@ data "selectel_dbaas_datastore_type_v1" "dt" {
 }
 
 data "selectel_dbaas_configuration_parameter_v1" "config" {
-    project_id   = "${selectel_vpc_project_v2.project_1.id}"
-    region       = "ru-3"
-    filter {
-        datastore_type_id = data.selectel_dbaas_datastore_type_v1.dt.datastore_types[0].id
-        name = "work_mem"
-    }
+  project_id   = "${selectel_vpc_project_v2.project_1.id}"
+  region       = "ru-3"
+  filter {
+    datastore_type_id = data.selectel_dbaas_datastore_type_v1.dt.datastore_types[0].id
+    name = "work_mem"
+  }
 }
 ```
 

--- a/website/docs/d/dbaas_configuration_parameter_v1.html.markdown
+++ b/website/docs/d/dbaas_configuration_parameter_v1.html.markdown
@@ -1,0 +1,72 @@
+---
+layout: "selectel"
+page_title: "Selectel: selectel_dbaas_configuration_parameter_v1"
+sidebar_current: "docs-selectel-datasource-dbaas-configuration_parameter-v1"
+description: |-
+  Get information on Selectel DBaaS configuration parameters.
+---
+
+# selectel\_dbaas\_configuration_parameter_v1
+
+Use this data source to get all available confguration parameters within Selectel DBaaS API Service
+
+## Example Usage
+
+```hcl
+resource "selectel_vpc_project_v2" "project_1" {
+  auto_quotas = true
+}
+
+data "selectel_dbaas_datastore_type_v1" "dt" {
+  project_id   = "${selectel_vpc_project_v2.project_1.id}"
+  region       = "ru-3"
+  filter {
+    engine  = "postgresql"
+    version = "12"
+  }
+}
+
+data "selectel_dbaas_configuration_parameter_v1" "config" {
+    project_id   = "${selectel_vpc_project_v2.project_1.id}"
+    region       = "ru-3"
+    filter {
+        datastore_type_id = data.selectel_dbaas_datastore_type_v1.dt.datastore_types[0].id
+        name = "work_mem"
+    }
+}
+```
+
+## Argument Reference
+
+The folowing arguments are supported
+
+* `project_id` - (Required) An associated Selectel VPC project.
+
+* `region` - (Required) A Selectel VPC region.
+
+* `filter` - (Optional) One or more values used to look up configuration parameters
+
+**filter**
+
+- `datastore_type_id` - (Optional) Datastore type id to lookup all available parameters for this type.
+- `name` - (Optional) Name of the parameter to lookup.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `configuration_parameters` - Contains a list of the found configuration parameters.
+
+**datastore_types**
+
+- `id` - ID of the configuration parameter.
+- `datastore_type_id` - Datastore type id for which the configuration parameter is availabe.
+- `name` - Name of the configuration parameter.
+- `type` - Type of the configuration parameter.
+- `unit` - Unit of the configuration parameter. Might be empty.
+- `min` - Min value of the configuration parameter. Might be empty.
+- `max` - Max value of the configuration parameter. Might be empty.
+- `default_value` - Default value of the configuration parameter. Might be empty.
+- `choices` - Available choices for the configuration parameter. Some parameters have list of available options.
+- `is_restart_required` - Shows if database needs a restart to apply changes of this parameter.
+- `is_changeable` - Shows if parameter can be changed.

--- a/website/docs/r/dbaas_datastore_v1.html.markdown
+++ b/website/docs/r/dbaas_datastore_v1.html.markdown
@@ -47,7 +47,7 @@ resource "selectel_dbaas_datastore_v1" "datastore_1" {
     mode = "transaction"
     size = 50
   }
-  config {
+  config = {
     xmloption = "content"
     work_mem = 512
     session_replication_role = "replica"

--- a/website/docs/r/dbaas_datastore_v1.html.markdown
+++ b/website/docs/r/dbaas_datastore_v1.html.markdown
@@ -47,6 +47,13 @@ resource "selectel_dbaas_datastore_v1" "datastore_1" {
     mode = "transaction"
     size = 50
   }
+  config {
+    xmloption = "content"
+    work_mem = 512
+    session_replication_role = "replica"
+    vacuum_cost_delay = 25
+    transform_null_equals = false
+  }
 }
 ```
 
@@ -63,7 +70,7 @@ The following arguments are supported:
 * `region` - (Required) A Selectel VPC region of where the datastore is located.
   Changing this creates a new datastore.
 
-* `subnet_id` - (Required) associated OpenStack Networking service subnet ID.
+* `subnet_id` - (Required) Associated OpenStack Networking service subnet ID.
   Changing this creates a new datastore.
 
 * `type_id` - (Required) The datastore type for the datastore.
@@ -81,6 +88,8 @@ The following arguments are supported:
 
 * `restore` - (Optional) Restore parameters for the datastore. It's a complex value. See description below.
   Changing this creates a new datastore.
+
+* `config` - (Optional) Configuration parameters for the datastore.
 
 **flavor**
 

--- a/website/selectel.erb
+++ b/website/selectel.erb
@@ -22,6 +22,9 @@
             <li<%= sidebar_current("docs-selectel-datasource-dbaas-available-extension-v1") %>>
               <a href="/docs/providers/selectel/d/dbaas_available_extension_v1.html">selectel_dbaas_available_extension_v1</a>
             </li>
+            <li<%= sidebar_current("docs-selectel-datasource-dbaas-configuration_parameter-v1") %>>
+              <a href="/docs/providers/selectel/d/dbaas_configuration_parameter_v1.html">selectel_dbaas_configuration_parameter_v1</a>
+            </li>
           </ul>
         </li>
 


### PR DESCRIPTION
Implement 'selectel_dbaas_configuration_parameter_v1' data source with acceptance test.
Add config options to create and update context for the datastore resource.
Vendor dbaas-go v0.2.0

For #162