### PR TITLE
Increase golang version to 1.16

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Import GPG key
         id: import_gpg

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Run test
         run: make test

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Requirements
 ------------
 
 -	[Terraform](https://www.terraform.io/downloads.html) 0.12.x
--	[Go](https://golang.org/doc/install) 1.15 (to build the provider plugin)
+-	[Go](https://golang.org/doc/install) 1.16 (to build the provider plugin)
 
 Building The Provider
 ---------------------
@@ -46,7 +46,7 @@ Also there are lots of examples in the [selectel/terraform-examples](https://git
 Developing the Provider
 ---------------------------
 
-If you wish to work on the provider, you'll first need [Go](https://golang.org) installed on your machine (version 1.15+ is *required*).
+If you wish to work on the provider, you'll first need [Go](https://golang.org) installed on your machine (version 1.16+ is *required*).
 
 To compile the provider, run `make build`. This will build the provider and put the provider binary in the current directory.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/terraform-providers/terraform-provider-selectel
 
-go 1.15
+go 1.16
 
 require (
 	github.com/hashicorp/go-retryablehttp v0.6.6


### PR DESCRIPTION
Hello. I am asking to increase golang version. It's need for [enabling darwin arm64 platform support](https://goreleaser.com/deprecations/#builds-for-darwinarm64).