### PR TITLE
MKS V1: add nodegroup autoscaling support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.tf
 *.tfstate
 *.tfstate.backup
+*.tfstate.lock.info
 *.log
 *.json
 *.yaml

--- a/selectel/resource_selectel_mks_nodegroup_v1_test.go
+++ b/selectel/resource_selectel_mks_nodegroup_v1_test.go
@@ -38,16 +38,18 @@ func TestAccMKSNodegroupV1Basic(t *testing.T) {
 					testAccCheckVPCV2ProjectExists("selectel_vpc_project_v2.project_tf_acc_test_1", &project),
 					testAccCheckMKSNodegroupV1Exists("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", &mksNodegroup),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "availability_zone", "ru-3a"),
-					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "nodes_count", "1"),
-					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "nodes.#", "1"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "nodes_count", "2"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "nodes.#", "2"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "cpus", "1"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "ram_mb", "1024"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "volume_gb", "10"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "volume_type", "fast.ru-3a"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "enable_autoscale", "true"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "autoscale_min_nodes", "2"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "autoscale_max_nodes", "3"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key0", "label-value0"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key1", "label-value1"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key2", "label-value2"),
-
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.#", "3"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.0.key", "test-key-0"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.0.value", "test-value-0"),
@@ -64,12 +66,15 @@ func TestAccMKSNodegroupV1Basic(t *testing.T) {
 				Config: testAccMKSNodegroupV1Update(projectName, clusterName, kubeVersion, maintenanceWindowStart),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "availability_zone", "ru-3a"),
-					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "nodes_count", "2"),
-					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "nodes.#", "2"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "nodes_count", "3"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "nodes.#", "3"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "cpus", "1"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "ram_mb", "1024"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "volume_gb", "10"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "volume_type", "fast.ru-3a"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "enable_autoscale", "false"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "autoscale_min_nodes", "1"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "autoscale_max_nodes", "4"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key3", "label-value3"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key4", "label-value4"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.#", "3"),
@@ -155,15 +160,18 @@ resource "selectel_mks_cluster_v1" "cluster_tf_acc_test_1" {
 }
 
 resource "selectel_mks_nodegroup_v1" "nodegroup_tf_acc_test_1" {
-  cluster_id        = "${selectel_mks_cluster_v1.cluster_tf_acc_test_1.id}"
-  project_id        = "${selectel_mks_cluster_v1.cluster_tf_acc_test_1.project_id}"
-  region            = "${selectel_mks_cluster_v1.cluster_tf_acc_test_1.region}"
-  availability_zone = "ru-3a"
-  nodes_count       = 1
-  cpus              = 1
-  ram_mb            = 1024
-  volume_gb         = 10
-  volume_type       = "fast.ru-3a"
+  cluster_id          = "${selectel_mks_cluster_v1.cluster_tf_acc_test_1.id}"
+  project_id          = "${selectel_mks_cluster_v1.cluster_tf_acc_test_1.project_id}"
+  region              = "${selectel_mks_cluster_v1.cluster_tf_acc_test_1.region}"
+  availability_zone   = "ru-3a"
+  nodes_count         = 2
+  cpus                = 1
+  ram_mb              = 1024
+  volume_gb           = 10
+  volume_type         = "fast.ru-3a"
+  enable_autoscale    = true
+  autoscale_min_nodes = 2
+  autoscale_max_nodes = 3
   labels = {
     label-key0 = "label-value0"
     label-key1 = "label-value1"
@@ -203,15 +211,18 @@ resource "selectel_mks_cluster_v1" "cluster_tf_acc_test_1" {
 }
 
 resource "selectel_mks_nodegroup_v1" "nodegroup_tf_acc_test_1" {
-  cluster_id        = "${selectel_mks_cluster_v1.cluster_tf_acc_test_1.id}"
-  project_id        = "${selectel_mks_cluster_v1.cluster_tf_acc_test_1.project_id}"
-  region            = "${selectel_mks_cluster_v1.cluster_tf_acc_test_1.region}"
-  availability_zone = "ru-3a"
-  nodes_count       = 2
-  cpus              = 1
-  ram_mb            = 1024
-  volume_gb         = 10
-  volume_type       = "fast.ru-3a"
+  cluster_id          = "${selectel_mks_cluster_v1.cluster_tf_acc_test_1.id}"
+  project_id          = "${selectel_mks_cluster_v1.cluster_tf_acc_test_1.project_id}"
+  region              = "${selectel_mks_cluster_v1.cluster_tf_acc_test_1.region}"
+  availability_zone   = "ru-3a"
+  nodes_count         = 3
+  cpus                = 1
+  ram_mb              = 1024
+  volume_gb           = 10
+  volume_type         = "fast.ru-3a"
+  enable_autoscale    = false
+  autoscale_min_nodes = 1
+  autoscale_max_nodes = 4
   labels = {
     label-key3 = "label-value3"
     label-key4 = "label-value4"

--- a/website/docs/r/mks_nodegroup_v1.html.markdown
+++ b/website/docs/r/mks_nodegroup_v1.html.markdown
@@ -75,6 +75,7 @@ The following arguments are supported:
 
 * `nodes_count` (Required) Count of worker nodes in the nodegroup.
   Changing this resizes the nodegroup according to the new nodes count.
+  As long as `enable_autoscale` is set to true, changing this will not affect the size of the nodegroup.
 
 * `keypair_name` (Optional) Name of the SSH key that will be added to all nodes.
   Changing this creates a new nodegroup.
@@ -108,6 +109,14 @@ The following arguments are supported:
 
 * `taints` (Optional) Represents a list of Kubernetes taints that will be applied for each node in the group.
   Changing this creates a new nodegroup.
+
+* `enable_autoscale` (Optional) Specifies if a nodegroup autoscaling option has to be turned on/off.
+  Accepts true or false. Default is false.
+  `autoscale_min_nodes` and `autoscale_max_nodes` must be specified.
+
+* `autoscale_min_nodes` (Optional) Represents a minimum possible number of worker nodes in the nodegroup.
+
+* `autoscale_max_nodes` (Optional) Represents a maximum possible number of worker nodes in the nodegroup.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Update selectel_mks_nodegroup_v1 resource with tests.
Update nodegroup resource documentation.

For #165
