### PR TITLE
Add Redis to dbaas resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.6.6
 	github.com/hashicorp/terraform-json v0.12.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.6.1
-	github.com/selectel/dbaas-go v0.3.0
+	github.com/selectel/dbaas-go v0.4.0
 	github.com/selectel/domains-go v0.3.0
 	github.com/selectel/go-selvpcclient v1.12.0
 	github.com/selectel/mks-go v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -290,12 +290,8 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
-github.com/selectel/dbaas-go v0.1.1 h1:dop1ANq6NwZTJ9MOOVL9iRBl5JWCqeldngYs4WK9Cfo=
-github.com/selectel/dbaas-go v0.1.1/go.mod h1:H2NC+UrVQzKea92LYyHZj51uuX43sUiAc+iyx/yTCGw=
-github.com/selectel/dbaas-go v0.2.0 h1:LuQYA1M+ftcNRdcCD8p+CQQ4ejU364CHuB8S23jH6GU=
-github.com/selectel/dbaas-go v0.2.0/go.mod h1:H2NC+UrVQzKea92LYyHZj51uuX43sUiAc+iyx/yTCGw=
-github.com/selectel/dbaas-go v0.3.0 h1:zSZ4/+rDiAfZAVm70jvf84/u+DzTsnugMFTgTcaDSXU=
-github.com/selectel/dbaas-go v0.3.0/go.mod h1:H2NC+UrVQzKea92LYyHZj51uuX43sUiAc+iyx/yTCGw=
+github.com/selectel/dbaas-go v0.4.0 h1:6fZt4uhbqDf4C/ycRnJVffmgAH73GutTcJumlcXfGJg=
+github.com/selectel/dbaas-go v0.4.0/go.mod h1:H2NC+UrVQzKea92LYyHZj51uuX43sUiAc+iyx/yTCGw=
 github.com/selectel/domains-go v0.3.0 h1:0shjqQmpkWc6eM1SwgKqbTTNiT5G2BOEnvS7JvuF96g=
 github.com/selectel/domains-go v0.3.0/go.mod h1:AhXhwyMSTkpEWFiBLUvzFP76W+WN+ZblwmjLJLt7y58=
 github.com/selectel/go-selvpcclient v1.12.0 h1:LsT074HOVF1dWYapsAWjaaJDQhmDPpcsVjSwQ1r1fj0=

--- a/selectel/data_source_selectel_dbaas_flavor_v1_test.go
+++ b/selectel/data_source_selectel_dbaas_flavor_v1_test.go
@@ -34,6 +34,20 @@ func TestAccDBaaSFlavorsV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.selectel_dbaas_flavor_v1.flavor_tf_acc_test_1", "flavors.0.vcpus"),
 					resource.TestCheckResourceAttrSet("data.selectel_dbaas_flavor_v1.flavor_tf_acc_test_1", "flavors.0.ram"),
 					resource.TestCheckResourceAttrSet("data.selectel_dbaas_flavor_v1.flavor_tf_acc_test_1", "flavors.0.disk"),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_flavor_v1.flavor_tf_acc_test_1", "flavors.0.datastore_type_ids.#", "8"),
+				),
+			},
+			{
+				Config: testAccDBaaSFlavorsV1RedisFlavor(projectName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVPCV2ProjectExists("selectel_vpc_project_v2.project_tf_acc_test_1", &project),
+					testAccDBaaSFlavorsV1Exists("data.selectel_dbaas_flavor_v1.flavor_tf_acc_test_1", &dbaasFlavors),
+					resource.TestCheckResourceAttrSet("data.selectel_dbaas_flavor_v1.flavor_tf_acc_test_1", "flavors.0.id"),
+					resource.TestCheckResourceAttrSet("data.selectel_dbaas_flavor_v1.flavor_tf_acc_test_1", "flavors.0.name"),
+					resource.TestCheckResourceAttrSet("data.selectel_dbaas_flavor_v1.flavor_tf_acc_test_1", "flavors.0.vcpus"),
+					resource.TestCheckResourceAttrSet("data.selectel_dbaas_flavor_v1.flavor_tf_acc_test_1", "flavors.0.ram"),
+					resource.TestCheckResourceAttrSet("data.selectel_dbaas_flavor_v1.flavor_tf_acc_test_1", "flavors.0.disk"),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_flavor_v1.flavor_tf_acc_test_1", "flavors.0.datastore_type_ids.#", "1"),
 				),
 			},
 		},
@@ -75,6 +89,31 @@ resource "selectel_vpc_project_v2" "project_tf_acc_test_1" {
 data "selectel_dbaas_flavor_v1" "flavor_tf_acc_test_1" {
   project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
   region     = "ru-3"
+}
+`, projectName)
+}
+
+func testAccDBaaSFlavorsV1RedisFlavor(projectName string) string {
+	return fmt.Sprintf(`
+resource "selectel_vpc_project_v2" "project_tf_acc_test_1" {
+  name        = "%s"
+  auto_quotas = true
+}
+
+data "selectel_dbaas_datastore_type_v1" "dt" {
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  region     = "ru-3"
+  filter {
+    engine = "redis"
+  }
+}
+
+data "selectel_dbaas_flavor_v1" "flavor_tf_acc_test_1" {
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  region     = "ru-3"
+  filter {
+    datastore_type_id = "${data.selectel_dbaas_datastore_type_v1.dt.datastore_types[0].id}"
+  }
 }
 `, projectName)
 }

--- a/vendor/github.com/selectel/dbaas-go/README.md
+++ b/vendor/github.com/selectel/dbaas-go/README.md
@@ -21,6 +21,7 @@ You can use this library to work with the following objects of the Selectel Mana
 * extension
 * available extension
 * configuration parameter
+* prometheus metrics tokens
 
 ## Getting started
 

--- a/vendor/github.com/selectel/dbaas-go/datastore.go
+++ b/vendor/github.com/selectel/dbaas-go/datastore.go
@@ -67,15 +67,16 @@ type Datastore struct {
 
 // DatastoreCreateOpts represents options for the datastore Create request.
 type DatastoreCreateOpts struct {
-	Flavor    *Flavor                `json:"flavor,omitempty"`
-	Restore   *Restore               `json:"restore,omitempty"`
-	Pooler    *Pooler                `json:"pooler,omitempty"`
-	Config    map[string]interface{} `json:"config,omitempty"`
-	Name      string                 `json:"name"`
-	TypeID    string                 `json:"type_id"`
-	SubnetID  string                 `json:"subnet_id"`
-	FlavorID  string                 `json:"flavor_id,omitempty"`
-	NodeCount int                    `json:"node_count"`
+	Flavor        *Flavor                `json:"flavor,omitempty"`
+	Restore       *Restore               `json:"restore,omitempty"`
+	Pooler        *Pooler                `json:"pooler,omitempty"`
+	Config        map[string]interface{} `json:"config,omitempty"`
+	Name          string                 `json:"name"`
+	TypeID        string                 `json:"type_id"`
+	SubnetID      string                 `json:"subnet_id"`
+	FlavorID      string                 `json:"flavor_id,omitempty"`
+	RedisPassword string                 `json:"redis_password,omitempty"`
+	NodeCount     int                    `json:"node_count"`
 }
 
 // DatastoreUpdateOpts represents options for the datastore Update request.
@@ -96,13 +97,19 @@ type DatastorePoolerOpts struct {
 	Size int    `json:"size,omitempty"`
 }
 
-// DatastoreFirewallOpts represents options for the datastore's firewall rules Ureate request.
+// DatastoreFirewallOpts represents options for the datastore's firewall rules Update request.
 type DatastoreFirewallOpts struct {
 	IPs []string `json:"ips"`
 }
 
+// DatastoreConfigOpts represents options for the datastore's configuration parameters Update request.
 type DatastoreConfigOpts struct {
 	Config map[string]interface{} `json:"config"`
+}
+
+// DatastorePasswordOpts represents options for the Redis datastore's password Update request.
+type DatastorePasswordOpts struct {
+	RedisPassword string `json:"redis_password"`
 }
 
 // DatastoreQueryParams represents available query parameters for datastore.
@@ -317,10 +324,39 @@ func (api *API) FirewallDatastore(ctx context.Context, datastoreID string, opts 
 	return result.Datastore, nil
 }
 
-// ConfigDatastore updates firewall rules of an existing datastore.
+// ConfigDatastore updates configuration parameters rules of an existing datastore.
 func (api *API) ConfigDatastore(ctx context.Context, datastoreID string, opts DatastoreConfigOpts) (Datastore, error) { //nolint
 	uri := fmt.Sprintf("/datastores/%s/config", datastoreID)
 	requestBody, err := json.Marshal(opts)
+	if err != nil {
+		return Datastore{}, fmt.Errorf("Error marshalling params to JSON, %w", err)
+	}
+
+	resp, err := api.makeRequest(ctx, http.MethodPut, uri, requestBody)
+	if err != nil {
+		return Datastore{}, err
+	}
+
+	var result struct {
+		Datastore Datastore `json:"datastore"`
+	}
+	err = json.Unmarshal(resp, &result)
+	if err != nil {
+		return Datastore{}, fmt.Errorf("Error during Unmarshal, %w", err)
+	}
+
+	return result.Datastore, nil
+}
+
+// PasswordDatastore updates password of an existing Redis datastore.
+func (api *API) PasswordDatastore(ctx context.Context, datastoreID string, opts DatastorePasswordOpts) (Datastore, error) { //nolint
+	uri := fmt.Sprintf("/datastores/%s/password", datastoreID)
+	passwordDatastoreOpts := struct {
+		Datastore DatastorePasswordOpts `json:"password"`
+	}{
+		Datastore: opts,
+	}
+	requestBody, err := json.Marshal(passwordDatastoreOpts)
 	if err != nil {
 		return Datastore{}, fmt.Errorf("Error marshalling params to JSON, %w", err)
 	}

--- a/vendor/github.com/selectel/dbaas-go/flavor.go
+++ b/vendor/github.com/selectel/dbaas-go/flavor.go
@@ -9,12 +9,13 @@ import (
 
 // FlavorResponse is the API response for the flavors.
 type FlavorResponse struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Vcpus       int    `json:"vcpus"`
-	RAM         int    `json:"ram"`
-	Disk        int    `json:"disk"`
+	ID               string   `json:"id"`
+	Name             string   `json:"name"`
+	Description      string   `json:"description"`
+	DatastoreTypeIDs []string `json:"datastore_type_ids"`
+	Vcpus            int      `json:"vcpus"`
+	RAM              int      `json:"ram"`
+	Disk             int      `json:"disk"`
 }
 
 // Flavors returns all flavors.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -191,7 +191,7 @@ github.com/mitchellh/reflectwalk
 github.com/oklog/run
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
-# github.com/selectel/dbaas-go v0.3.0
+# github.com/selectel/dbaas-go v0.4.0
 ## explicit
 github.com/selectel/dbaas-go
 # github.com/selectel/domains-go v0.3.0

--- a/website/docs/d/dbaas_flavor_v1.html.markdown
+++ b/website/docs/d/dbaas_flavor_v1.html.markdown
@@ -43,6 +43,7 @@ The folowing arguments are supported
 - `vcpus` - (Optional) vCPU of the flavor to lookup.
 - `ram` - (Optional) RAM of the flavor to lookup.
 - `disk` - (Optional) Disk of the flavor to lookup.
+- `datastore_type_id` - (Optional) Datastore type ID of the flavor to lookup.
 
 ## Attributes Reference
 
@@ -58,3 +59,4 @@ The following attributes are exported:
 - `vcpus` - CPU count for the flavor.
 - `ram` - RAM count for the flavor.
 - `disk` - Disk size for the flavor.
+- `datastore_type_ids` - List of datastore types that support this flavor.

--- a/website/docs/r/dbaas_datastore_v1.html.markdown
+++ b/website/docs/r/dbaas_datastore_v1.html.markdown
@@ -91,6 +91,8 @@ The following arguments are supported:
 
 * `config` - (Optional) Configuration parameters for the datastore.
 
+* `redis_password` - (Optional) Password for the Redis datastore (only for Redis datastores)
+
 **flavor**
 
 - `vcpus` - (Required) CPU count for the flavor.


### PR DESCRIPTION
Add redis_password field to datastore resource to create Redis datastores.
Add datastore_type_ids field to flavors.
Vendor dbaas-go v0.4.0.

For #173