### PR TITLE
Add kubeconfig data provider

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -9,7 +9,7 @@ build: fmtcheck
 	go install
 
 test: fmtcheck
-	go test -i $(TEST) || exit 1
+	go test $(TEST) || exit 1
 	echo $(TEST) | \
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 

--- a/selectel/data_source_selectel_mks_cluster_kubeconfig_v1.go
+++ b/selectel/data_source_selectel_mks_cluster_kubeconfig_v1.go
@@ -1,0 +1,82 @@
+package selectel
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/tokens"
+	v1 "github.com/selectel/mks-go/pkg/v1"
+	"github.com/selectel/mks-go/pkg/v1/cluster"
+)
+
+func dataSourceMksClusterKubeconfigV1() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceMksClusterKubeconfigV1Read,
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					ru1Region,
+					ru2Region,
+					ru3Region,
+					ru7Region,
+					ru8Region,
+					ru9Region,
+				}, false),
+			},
+			"kubeconfig": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceMksClusterKubeconfigV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	resellV2Client := config.resellV2Client()
+	tokenOpts := tokens.TokenOpts{
+		ProjectID: d.Get("project_id").(string),
+	}
+
+	log.Print(msgCreate(objectToken, tokenOpts))
+	token, _, err := tokens.Create(ctx, resellV2Client, tokenOpts)
+	if err != nil {
+		return diag.FromErr(errCreatingObject(objectToken, err))
+	}
+
+	region := d.Get("region").(string)
+	endpoint := getMKSClusterV1Endpoint(region)
+	mksClient := v1.NewMKSClientV1(token.ID, endpoint)
+
+	clusterId := d.Get("cluster_id").(string)
+
+	mksCluster, _, err := cluster.Get(ctx, mksClient, clusterId)
+	if err != nil {
+		return diag.FromErr(errGettingObject(objectCluster, clusterId, err))
+	}
+
+	kubeconfig, _, err := cluster.GetKubeconfig(ctx, mksClient, mksCluster.ID)
+	if err != nil {
+		return diag.FromErr(errGettingObject(objectKubeConfig, clusterId, err))
+	}
+
+	d.SetId(clusterId)
+	d.Set("kubeconfig", string(kubeconfig))
+	return nil
+}

--- a/selectel/provider.go
+++ b/selectel/provider.go
@@ -21,6 +21,7 @@ const (
 	objectVRRPSubnet              = "VRRP subnet"
 	objectCluster                 = "cluster"
 	objectNodegroup               = "nodegroup"
+	objectKubeConfig              = "kubeconfig"
 	objectDomain                  = "domain"
 	objectRecord                  = "record"
 	objectDatastore               = "datastore"
@@ -73,6 +74,7 @@ func Provider() *schema.Provider {
 			"selectel_dbaas_flavor_v1":                  dataSourceDBaaSFlavorV1(),
 			"selectel_dbaas_configuration_parameter_v1": dataSourceDBaaSConfigurationParameterV1(),
 			"selectel_dbaas_prometheus_metric_token_v1": dataSourceDBaaSPrometheusMetricTokenV1(),
+			"selectel_mks_cluster_kubeconfig_v1":        dataSourceMksClusterKubeconfigV1(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"selectel_vpc_floatingip_v2":                resourceVPCFloatingIPV2(),


### PR DESCRIPTION
This PR adds kubeconfig data provider
This is required if you are managing HELM charts / Kubernetes resources using Terraform (then you need to take kubeconfig using Terraform as well)

This closes #145 