### PR TITLE
MKS V1: add kube versions data source

### DIFF
--- a/selectel/data_source_selectel_mks_kube_versions_v1.go
+++ b/selectel/data_source_selectel_mks_kube_versions_v1.go
@@ -1,0 +1,99 @@
+package selectel
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/tokens"
+	v1 "github.com/selectel/mks-go/pkg/v1"
+	"github.com/selectel/mks-go/pkg/v1/kubeversion"
+)
+
+func dataSourceMKSKubeVersionsV1() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceMKSKubeVersionsV1Read,
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					ru1Region,
+					ru2Region,
+					ru3Region,
+					ru7Region,
+					ru8Region,
+					ru9Region,
+					uz1Region,
+				}, false),
+			},
+			"latest_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"default_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"versions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func dataSourceMKSKubeVersionsV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	resellV2Client := config.resellV2Client()
+	tokenOpts := tokens.TokenOpts{
+		ProjectID: d.Get("project_id").(string),
+	}
+
+	log.Print(msgCreate(objectToken, tokenOpts))
+	token, _, err := tokens.Create(ctx, resellV2Client, tokenOpts)
+	if err != nil {
+		return diag.FromErr(errCreatingObject(objectToken, err))
+	}
+
+	region := d.Get("region").(string)
+	endpoint := getMKSClusterV1Endpoint(region)
+	mksClient := v1.NewMKSClientV1(token.ID, endpoint)
+
+	mksKubeVersions, _, err := kubeversion.List(ctx, mksClient)
+	if err != nil {
+		return diag.FromErr(errGettingObjects(objectKubeVersions, err))
+	}
+
+	latestVersion, err := parseMKSKubeVersionsV1Latest(mksKubeVersions)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defaultVersion := parseMKSKubeVersionsV1Default(mksKubeVersions)
+	versions := flattenMKSKubeVersionsV1(mksKubeVersions)
+	if err := d.Set("versions", versions); err != nil {
+		return diag.FromErr(err)
+	}
+
+	checksum, err := stringListChecksum(versions)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.Set("latest_version", latestVersion)
+	d.Set("default_version", defaultVersion)
+	d.SetId(checksum)
+
+	return nil
+}

--- a/selectel/data_source_selectel_mks_kube_versions_v1_test.go
+++ b/selectel/data_source_selectel_mks_kube_versions_v1_test.go
@@ -1,0 +1,62 @@
+package selectel
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccMKSKubeVersionsV1DataSourceBasic(t *testing.T) {
+	projectName := acctest.RandomWithPrefix("tf-acc")
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccSelectelPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckVPCV2ProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMKSKubeVersionsV1Basic(projectName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMKSKubeVersionsV1("data.selectel_mks_kube_versions_v1.kube_versions_tf_acc_test_1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckMKSKubeVersionsV1(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("can't find kube versions data source: %s", name)
+		}
+		if _, ok := rs.Primary.Attributes["latest_version"]; !ok {
+			return errors.New("empty 'latest_version' field in kube versions data source")
+		}
+		if _, ok := rs.Primary.Attributes["default_version"]; !ok {
+			return errors.New("empty 'default_version' field in kube versions data source")
+		}
+		if _, ok := rs.Primary.Attributes["versions.#"]; !ok {
+			return errors.New("empty 'versions' field in kube versions data source")
+		}
+
+		return nil
+	}
+}
+
+func testAccMKSKubeVersionsV1Basic(projectName string) string {
+	return fmt.Sprintf(`
+resource "selectel_vpc_project_v2" "project_tf_acc_test_1" {
+  name        = "%s"
+  auto_quotas = true
+}
+
+data "selectel_mks_kube_versions_v1" "kube_versions_tf_acc_test_1" {
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  region     = "ru-3"
+}
+`, projectName)
+}

--- a/selectel/provider.go
+++ b/selectel/provider.go
@@ -21,6 +21,7 @@ const (
 	objectVRRPSubnet              = "VRRP subnet"
 	objectCluster                 = "cluster"
 	objectKubeConfig              = "kubeconfig"
+	objectKubeVersions            = "kube-versions"
 	objectNodegroup               = "nodegroup"
 	objectDomain                  = "domain"
 	objectRecord                  = "record"
@@ -77,6 +78,7 @@ func Provider() *schema.Provider {
 			"selectel_dbaas_configuration_parameter_v1": dataSourceDBaaSConfigurationParameterV1(),
 			"selectel_dbaas_prometheus_metric_token_v1": dataSourceDBaaSPrometheusMetricTokenV1(),
 			"selectel_mks_kubeconfig_v1":                dataSourceMKSKubeconfigV1(),
+			"selectel_mks_kube_versions_v1":             dataSourceMKSKubeVersionsV1(),
 			"selectel_mks_feature_gates_v1":             dataSourceMKSFeatureGatesV1(),
 			"selectel_mks_admission_controllers_v1":     dataSourceMKSAdmissionControllersV1(),
 		},

--- a/website/docs/d/mks_kube_versions_v1.html.markdown
+++ b/website/docs/d/mks_kube_versions_v1.html.markdown
@@ -1,0 +1,54 @@
+---
+layout: "selectel"
+page_title: "Selectel: selectel_mks_kube_versions_v1"
+sidebar_current: "docs-selectel-datasource-mks-kube-versions-v1"
+description: |-
+Get all supported kube versions for a Selectel Managed Kubernetes cluster.
+---
+
+# selectel\_mks\_kube_versions_v1
+
+Use this data source to get all supported kube versions for a Managed Kubernetes cluster.
+
+## Example Usage
+
+```hcl
+resource "selectel_vpc_project_v2" "project_1" {
+  auto_quotas = true
+}
+
+data "selectel_mks_kube_versions_v1" "versions" {
+  project_id = "${selectel_vpc_project_v2.project_1.id}"
+  region     = "ru-3"
+}
+
+output "latest_version" {
+  value = data.selectel_mks_kube_versions_v1.versions.latest_version
+}
+
+output "default_version" {
+  value = data.selectel_mks_kube_versions_v1.versions.default_version
+}
+
+output "versions" {
+  value = data.selectel_mks_kube_versions_v1.versions.versions
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project_id` - (Required) An associated Selectel VPC project.
+
+* `region` - (Required) A Selectel VPC region.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `latest_version` - The most recent version available.
+
+* `default_version` - The currently supported version that is suggested to be used by default.
+
+* `versions` - The list of all supported versions.

--- a/website/selectel.erb
+++ b/website/selectel.erb
@@ -37,6 +37,9 @@
             <li<%= sidebar_current("docs-selectel-datasource-mks-kubeconfig-v1") %>>
               <a href="/docs/providers/selectel/d/mks_kubeconfig_v1.html">selectel_mks_kubeconfig_v1</a>
             </li>
+            <li<%= sidebar_current("docs-selectel-datasource-mks-kube-versions-v1") %>>
+              <a href="/docs/providers/selectel/d/mks_kube_versions_v1.html">selectel_mks_kube_versions_v1</a>
+            </li>
           </ul>
         </li>
 


### PR DESCRIPTION
Implement `selectel_mks_kube_versions_v1` data source with acceptance test.

Add helper functions in `mks.go` with needed tests.

Add `mks_kube_versions_v1` website page.

For #183 