### PR TITLE
fixes for golangci-lint job

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,7 +13,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.43
+          skip-go-installation: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,5 +21,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.43
+          version: v1.44
           skip-go-installation: true


### PR DESCRIPTION
Previously golangci-lint-action uses latest go version, but we need to use go1.17, because golangci-lint have some problems with go1.18. 
Now we will install configurable go version in additional step, and skip installing go in golangci-lint-action.