### PR TITLE
Update test TestAccDBaaSFlavorsV1Basic

### DIFF
--- a/selectel/data_source_selectel_dbaas_flavor_v1_test.go
+++ b/selectel/data_source_selectel_dbaas_flavor_v1_test.go
@@ -34,7 +34,7 @@ func TestAccDBaaSFlavorsV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.selectel_dbaas_flavor_v1.flavor_tf_acc_test_1", "flavors.0.vcpus"),
 					resource.TestCheckResourceAttrSet("data.selectel_dbaas_flavor_v1.flavor_tf_acc_test_1", "flavors.0.ram"),
 					resource.TestCheckResourceAttrSet("data.selectel_dbaas_flavor_v1.flavor_tf_acc_test_1", "flavors.0.disk"),
-					resource.TestCheckResourceAttr("data.selectel_dbaas_flavor_v1.flavor_tf_acc_test_1", "flavors.0.datastore_type_ids.#", "8"),
+					resource.TestCheckResourceAttr("data.selectel_dbaas_flavor_v1.flavor_tf_acc_test_1", "flavors.0.datastore_type_ids.#", "9"),
 				),
 			},
 			{


### PR DESCRIPTION
Hi!
TestAccDBaaSFlavorsV1Basic was failed because redis datastore type was added.
```
TF_ACC=1 go test github.com/terraform-providers/terraform-provider-selectel/selectel -run "^TestAccDBaaSFlavorsV1Basic$" -count=1
--- FAIL: TestAccDBaaSFlavorsV1Basic (107.96s)
    data_source_selectel_dbaas_flavor_v1_test.go:23: Step 1/2 error: Check failed: Check 8/8 error: data.selectel_dbaas_flavor_v1.flavor_tf_acc_test_1: Attribute 'flavors.0.datastore_type_ids.#' expected "8", got "9"
FAIL
FAIL	github.com/terraform-providers/terraform-provider-selectel/selectel	108.278s
FAIL
```

Fixed it.
```
TF_ACC=1 go test github.com/terraform-providers/terraform-provider-selectel/selectel -run "^TestAccDBaaSFlavorsV1Basic$" -count=1
ok  	github.com/terraform-providers/terraform-provider-selectel/selectel	243.566s
```