### PR TITLE
Added auth by Keystone credentials

### DIFF
--- a/selectel/config.go
+++ b/selectel/config.go
@@ -59,12 +59,12 @@ func (c *Config) resellV2Client() *selvpcclient.ServiceClient {
 }
 
 // Create Keystone token by Selectel token or Keystone credentials.
-func (c *Config) getToken(ctx context.Context, p string, r string) (string, error) {
+func (c *Config) getToken(ctx context.Context, projectID string) (string, error) {
 	if !c.hasKeystoneCredentials() {
-		return c.getTokenBySelectelToken(ctx, p, r)
+		return c.getTokenBySelectelToken(ctx, projectID)
 	}
 
-	return c.getTokenByCredentials(ctx, p, r)
+	return c.getTokenByCredentials(ctx, projectID)
 }
 
 // hasKeystoneCredentials determine Keystone credentials exists.
@@ -73,9 +73,9 @@ func (c *Config) hasKeystoneCredentials() bool {
 }
 
 // Create Keystone token by Selectel token.
-func (c *Config) getTokenBySelectelToken(ctx context.Context, p string, r string) (string, error) {
+func (c *Config) getTokenBySelectelToken(ctx context.Context, projectID string) (string, error) {
 	tokenOpts := tokens.TokenOpts{
-		ProjectID: p,
+		ProjectID: projectID,
 	}
 	resellV2Client := c.resellV2Client()
 	log.Print(msgCreate(objectToken, tokenOpts))
@@ -89,7 +89,7 @@ func (c *Config) getTokenBySelectelToken(ctx context.Context, p string, r string
 }
 
 // Create Keystone token by Keystone credentials.
-func (c *Config) getTokenByCredentials(ctx context.Context, p string, r string) (string, error) {
+func (c *Config) getTokenByCredentials(ctx context.Context, projectID string) (string, error) {
 	providerOpts := gophercloud.AuthOptions{
 		AllowReauth:      true,
 		IdentityEndpoint: c.IdentityEndpoint,
@@ -97,7 +97,7 @@ func (c *Config) getTokenByCredentials(ctx context.Context, p string, r string) 
 		Password:         c.Password,
 		DomainName:       c.DomainName,
 		Scope: &gophercloud.AuthScope{
-			ProjectID: p,
+			ProjectID: projectID,
 		},
 	}
 

--- a/selectel/config.go
+++ b/selectel/config.go
@@ -18,19 +18,19 @@ import (
 )
 
 const (
-	DefaultOSEndpoint = "https://api.selvpc.ru/identity/v3"
+	DefaultIdentityEndpoint = "https://api.selvpc.ru/identity/v3"
 )
 
 // Config contains all available configuration options.
 type Config struct {
-	Token      string
-	OSEndpoint string
-	Endpoint   string
-	ProjectID  string
-	DomainName string
-	Region     string
-	User       string
-	Password   string
+	Token            string
+	IdentityEndpoint string
+	Endpoint         string
+	ProjectID        string
+	DomainName       string
+	Region           string
+	User             string
+	Password         string
 }
 
 // Validate performs config validation.
@@ -46,8 +46,8 @@ func (c *Config) Validate() error {
 			return err
 		}
 	}
-	if c.OSEndpoint == "" {
-		c.OSEndpoint = DefaultOSEndpoint
+	if c.IdentityEndpoint == "" {
+		c.IdentityEndpoint = DefaultIdentityEndpoint
 	}
 
 	return nil
@@ -92,7 +92,7 @@ func (c *Config) getTokenBySelectelToken(ctx context.Context, p string, r string
 func (c *Config) getTokenByCredentials(ctx context.Context, p string, r string) (string, error) {
 	providerOpts := gophercloud.AuthOptions{
 		AllowReauth:      true,
-		IdentityEndpoint: c.OSEndpoint,
+		IdentityEndpoint: c.IdentityEndpoint,
 		Username:         c.User,
 		Password:         c.Password,
 		DomainName:       c.DomainName,

--- a/selectel/config.go
+++ b/selectel/config.go
@@ -35,7 +35,7 @@ type Config struct {
 
 // Validate performs config validation.
 func (c *Config) Validate() error {
-	if c.Token == "" && !c.isKeystoneCredentials() {
+	if c.Token == "" && !c.hasKeystoneCredentials() {
 		return errors.New("token or credentials with domain name must be specified")
 	}
 	if c.Endpoint == "" {
@@ -60,21 +60,16 @@ func (c *Config) resellV2Client() *selvpcclient.ServiceClient {
 
 // Create Keystone token by Selectel token or Keystone credentials.
 func (c *Config) getToken(ctx context.Context, p string, r string) (string, error) {
-	if !c.isKeystoneCredentials() {
+	if !c.hasKeystoneCredentials() {
 		return c.getTokenBySelectelToken(ctx, p, r)
 	}
 
 	return c.getTokenByCredentials(ctx, p, r)
 }
 
-// useSelectelToken will determine which auth type to use:
-// either the Selectel token or Keystone credentials.
-func (c *Config) isKeystoneCredentials() bool {
-	if c.User == "" || c.Password == "" || c.DomainName == "" {
-		return false
-	}
-
-	return true
+// hasKeystoneCredentials determine Keystone credentials exists.
+func (c *Config) hasKeystoneCredentials() bool {
+	return c.User != "" && c.Password != "" && c.DomainName != ""
 }
 
 // Create Keystone token by Selectel token.

--- a/selectel/config.go
+++ b/selectel/config.go
@@ -35,7 +35,7 @@ type Config struct {
 
 // Validate performs config validation.
 func (c *Config) Validate() error {
-	if c.Token == "" && c.useSelectelToken() {
+	if c.Token == "" && !c.isKeystoneCredentials() {
 		return errors.New("token or credentials with domain name must be specified")
 	}
 	if c.Endpoint == "" {
@@ -60,7 +60,7 @@ func (c *Config) resellV2Client() *selvpcclient.ServiceClient {
 
 // Create Keystone token by Selectel token or Keystone credentials.
 func (c *Config) getToken(ctx context.Context, p string, r string) (string, error) {
-	if c.useSelectelToken() {
+	if !c.isKeystoneCredentials() {
 		return c.getTokenBySelectelToken(ctx, p, r)
 	}
 
@@ -69,12 +69,12 @@ func (c *Config) getToken(ctx context.Context, p string, r string) (string, erro
 
 // useSelectelToken will determine which auth type to use:
 // either the Selectel token or Keystone credentials.
-func (c *Config) useSelectelToken() bool {
+func (c *Config) isKeystoneCredentials() bool {
 	if c.User == "" || c.Password == "" || c.DomainName == "" {
-		return true
+		return false
 	}
 
-	return false
+	return true
 }
 
 // Create Keystone token by Selectel token.

--- a/selectel/config.go
+++ b/selectel/config.go
@@ -82,10 +82,10 @@ func (c *Config) getTokenBySelectelToken(ctx context.Context, p string, r string
 
 	token, _, err := tokens.Create(ctx, resellV2Client, tokenOpts)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("create Keystone token by Selectel token: %w", err)
 	}
 
-	return token.ID, err
+	return token.ID, nil
 }
 
 // Create Keystone token by Keystone credentials.
@@ -103,20 +103,14 @@ func (c *Config) getTokenByCredentials(ctx context.Context, p string, r string) 
 
 	newProvider, err := openstack.AuthenticatedClient(providerOpts)
 	if err != nil {
-		fmt.Println(err)
+		return "", fmt.Errorf("keystone auth: %w", err)
+	}
+	tokenID, err := newProvider.GetAuthResult().ExtractTokenID()
+	if err != nil {
+		return "", fmt.Errorf("extract token id: %w", err)
 	}
 
-	var tokenID string
-	if newProvider != nil {
-		tokenID, err = newProvider.GetAuthResult().ExtractTokenID()
-		if err != nil {
-			fmt.Println(err)
-		}
-	} else {
-		return "", errors.New("authentication failed")
-	}
-
-	return tokenID, err
+	return tokenID, nil
 }
 
 // Initialize Selectel domains client.

--- a/selectel/config.go
+++ b/selectel/config.go
@@ -1,28 +1,42 @@
 package selectel
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"log"
 	"strings"
 
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/hashicorp/go-retryablehttp"
 	domainsV1 "github.com/selectel/domains-go/pkg/v1"
 	"github.com/selectel/go-selvpcclient/selvpcclient"
 	"github.com/selectel/go-selvpcclient/selvpcclient/resell"
 	resellV2 "github.com/selectel/go-selvpcclient/selvpcclient/resell/v2"
+	"github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/tokens"
+)
+
+const (
+	DefaultOSEndpoint = "https://api.selvpc.ru/identity/v3"
 )
 
 // Config contains all available configuration options.
 type Config struct {
-	Token     string
-	Endpoint  string
-	ProjectID string
-	Region    string
+	Token      string
+	OSEndpoint string
+	Endpoint   string
+	ProjectID  string
+	DomainName string
+	Region     string
+	User       string
+	Password   string
 }
 
 // Validate performs config validation.
 func (c *Config) Validate() error {
-	if c.Token == "" {
-		return errors.New("token must be specified")
+	if c.Token == "" && c.useSelectelToken() {
+		return errors.New("token or credentials with domain name must be specified")
 	}
 	if c.Endpoint == "" {
 		c.Endpoint = strings.Join([]string{resell.Endpoint, resellV2.APIVersion}, "/")
@@ -32,14 +46,85 @@ func (c *Config) Validate() error {
 			return err
 		}
 	}
+	if c.OSEndpoint == "" {
+		c.OSEndpoint = DefaultOSEndpoint
+	}
 
 	return nil
 }
 
+// Initialize Selectel resell client.
 func (c *Config) resellV2Client() *selvpcclient.ServiceClient {
 	return resellV2.NewV2ResellClientWithEndpoint(c.Token, c.Endpoint)
 }
 
+// Create Keystone token by Selectel token or Keystone credentials.
+func (c *Config) getToken(ctx context.Context, p string, r string) (string, error) {
+	if c.useSelectelToken() {
+		return c.getTokenBySelectelToken(ctx, p, r)
+	}
+
+	return c.getTokenByCredentials(ctx, p, r)
+}
+
+// useSelectelToken will determine which auth type to use:
+// either the Selectel token or Keystone credentials.
+func (c *Config) useSelectelToken() bool {
+	if c.User == "" || c.Password == "" || c.DomainName == "" {
+		return true
+	}
+
+	return false
+}
+
+// Create Keystone token by Selectel token.
+func (c *Config) getTokenBySelectelToken(ctx context.Context, p string, r string) (string, error) {
+	tokenOpts := tokens.TokenOpts{
+		ProjectID: p,
+	}
+	resellV2Client := c.resellV2Client()
+	log.Print(msgCreate(objectToken, tokenOpts))
+
+	token, _, err := tokens.Create(ctx, resellV2Client, tokenOpts)
+	if err != nil {
+		return "", err
+	}
+
+	return token.ID, err
+}
+
+// Create Keystone token by Keystone credentials.
+func (c *Config) getTokenByCredentials(ctx context.Context, p string, r string) (string, error) {
+	providerOpts := gophercloud.AuthOptions{
+		AllowReauth:      true,
+		IdentityEndpoint: c.OSEndpoint,
+		Username:         c.User,
+		Password:         c.Password,
+		DomainName:       c.DomainName,
+		Scope: &gophercloud.AuthScope{
+			ProjectID: p,
+		},
+	}
+
+	newProvider, err := openstack.AuthenticatedClient(providerOpts)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	var tokenID string
+	if newProvider != nil {
+		tokenID, err = newProvider.GetAuthResult().ExtractTokenID()
+		if err != nil {
+			fmt.Println(err)
+		}
+	} else {
+		return "", errors.New("authentication failed")
+	}
+
+	return tokenID, err
+}
+
+// Initialize Selectel domains client.
 func (c *Config) domainsV1Client() *domainsV1.ServiceClient {
 	domainsClient := domainsV1.NewDomainsClientV1WithDefaultEndpoint(c.Token)
 	retryClient := retryablehttp.NewClient()

--- a/selectel/config_test.go
+++ b/selectel/config_test.go
@@ -46,7 +46,7 @@ func TestValidateErrRegion(t *testing.T) {
 	assert.EqualError(t, actual, expected)
 }
 
-func TestIsKeystoneCredentials(t *testing.T) {
+func TestHasKeystoneCredentials(t *testing.T) {
 	type test struct {
 		config   *Config
 		expected bool

--- a/selectel/config_test.go
+++ b/selectel/config_test.go
@@ -46,22 +46,22 @@ func TestValidateErrRegion(t *testing.T) {
 	assert.EqualError(t, actual, expected)
 }
 
-func TestUseSelectelToken(t *testing.T) {
+func TestIsKeystoneCredentials(t *testing.T) {
 	type test struct {
 		config   *Config
 		expected bool
 	}
 
 	tests := []test{
-		{&Config{}, true},
-		{&Config{Token: "secret"}, true},
-		{&Config{User: "user"}, true},
-		{&Config{Token: "secret", User: "user"}, true},
-		{&Config{User: "user", Password: "password", DomainName: "domain"}, false},
-		{&Config{Token: "secret", User: "user", Password: "password", DomainName: "domain"}, false},
+		{&Config{}, false},
+		{&Config{Token: "secret"}, false},
+		{&Config{User: "user"}, false},
+		{&Config{Token: "secret", User: "user"}, false},
+		{&Config{User: "user", Password: "password", DomainName: "domain"}, true},
+		{&Config{Token: "secret", User: "user", Password: "password", DomainName: "domain"}, true},
 	}
 
 	for _, tc := range tests {
-		assert.Equal(t, tc.expected, tc.config.useSelectelToken())
+		assert.Equal(t, tc.expected, tc.config.isKeystoneCredentials())
 	}
 }

--- a/selectel/config_test.go
+++ b/selectel/config_test.go
@@ -62,6 +62,6 @@ func TestIsKeystoneCredentials(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		assert.Equal(t, tc.expected, tc.config.isKeystoneCredentials())
+		assert.Equal(t, tc.expected, tc.config.hasKeystoneCredentials())
 	}
 }

--- a/selectel/data_source_selectel_mks_kube_versions_v1.go
+++ b/selectel/data_source_selectel_mks_kube_versions_v1.go
@@ -2,13 +2,10 @@ package selectel
 
 import (
 	"context"
-	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/tokens"
-	v1 "github.com/selectel/mks-go/pkg/v1"
 	"github.com/selectel/mks-go/pkg/v1/kubeversion"
 )
 
@@ -56,21 +53,10 @@ func dataSourceMKSKubeVersionsV1() *schema.Resource {
 }
 
 func dataSourceMKSKubeVersionsV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*Config)
-	resellV2Client := config.resellV2Client()
-	tokenOpts := tokens.TokenOpts{
-		ProjectID: d.Get("project_id").(string),
+	mksClient, diagErr := getMKSClient(ctx, d, meta)
+	if diagErr != nil {
+		return diagErr
 	}
-
-	log.Print(msgCreate(objectToken, tokenOpts))
-	token, _, err := tokens.Create(ctx, resellV2Client, tokenOpts)
-	if err != nil {
-		return diag.FromErr(errCreatingObject(objectToken, err))
-	}
-
-	region := d.Get("region").(string)
-	endpoint := getMKSClusterV1Endpoint(region)
-	mksClient := v1.NewMKSClientV1(token.ID, endpoint)
 
 	mksKubeVersions, _, err := kubeversion.List(ctx, mksClient)
 	if err != nil {

--- a/selectel/data_source_selectel_mks_kubeconfig_v1.go
+++ b/selectel/data_source_selectel_mks_kubeconfig_v1.go
@@ -2,13 +2,10 @@ package selectel
 
 import (
 	"context"
-	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/tokens"
-	v1 "github.com/selectel/mks-go/pkg/v1"
 	"github.com/selectel/mks-go/pkg/v1/cluster"
 )
 
@@ -70,21 +67,10 @@ func dataSourceMKSKubeconfigV1() *schema.Resource {
 }
 
 func dataSourceMKSKubeconfigV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*Config)
-	resellV2Client := config.resellV2Client()
-	tokenOpts := tokens.TokenOpts{
-		ProjectID: d.Get("project_id").(string),
+	mksClient, diagErr := getMKSClient(ctx, d, meta)
+	if diagErr != nil {
+		return diagErr
 	}
-
-	log.Print(msgCreate(objectToken, tokenOpts))
-	token, _, err := tokens.Create(ctx, resellV2Client, tokenOpts)
-	if err != nil {
-		return diag.FromErr(errCreatingObject(objectToken, err))
-	}
-
-	region := d.Get("region").(string)
-	endpoint := getMKSClusterV1Endpoint(region)
-	mksClient := v1.NewMKSClientV1(token.ID, endpoint)
 
 	clusterID := d.Get("cluster_id").(string)
 

--- a/selectel/dbaas.go
+++ b/selectel/dbaas.go
@@ -5,6 +5,7 @@ import (
 	"crypto/md5"
 	"errors"
 	"fmt"
+	"log"
 	"math/rand"
 	"sort"
 	"strconv"
@@ -139,7 +140,8 @@ func flavorHashSetFunc() schema.SchemaSetFunc {
 }
 
 func waitForDBaaSDatastoreV1ActiveState(
-	ctx context.Context, client *dbaas.API, datastoreID string, timeout time.Duration) error {
+	ctx context.Context, client *dbaas.API, datastoreID string, timeout time.Duration,
+) error {
 	pending := []string{
 		string(dbaas.StatusPendingCreate),
 		string(dbaas.StatusPendingUpdate),
@@ -418,7 +420,8 @@ func validateDatastoreType(ctx context.Context, expectedDatastoreTypeEngine stri
 }
 
 func waitForDBaaSDatabaseV1ActiveState(
-	ctx context.Context, client *dbaas.API, databaseID string, timeout time.Duration) error {
+	ctx context.Context, client *dbaas.API, databaseID string, timeout time.Duration,
+) error {
 	pending := []string{
 		string(dbaas.StatusPendingCreate),
 		string(dbaas.StatusPendingUpdate),
@@ -487,7 +490,8 @@ func dbaasDatabaseV1LocaleDiffSuppressFunc(k, old, new string, d *schema.Resourc
 // Users
 
 func waitForDBaaSUserV1ActiveState(
-	ctx context.Context, client *dbaas.API, userID string, timeout time.Duration) error {
+	ctx context.Context, client *dbaas.API, userID string, timeout time.Duration,
+) error {
 	pending := []string{
 		string(dbaas.StatusPendingCreate),
 		string(dbaas.StatusPendingUpdate),

--- a/selectel/dbaas.go
+++ b/selectel/dbaas.go
@@ -54,7 +54,7 @@ func getDBaaSClient(ctx context.Context, d *schema.ResourceData, meta interface{
 	region := d.Get("region").(string)
 	projectID := d.Get("project_id").(string)
 	endpoint := getDBaaSV1Endpoint(region)
-	tokenID, err := config.getToken(ctx, projectID, region)
+	tokenID, err := config.getToken(ctx, projectID)
 	if err != nil {
 		return nil, diag.FromErr((errCreatingObject(objectToken, err)))
 	}
@@ -88,7 +88,7 @@ func stringListChecksum(s []string) (string, error) {
 }
 
 func baseTestAccCheckDBaaSV1EntityExists(ctx context.Context, rs *terraform.ResourceState, testAccProvider *schema.Provider) (*dbaas.API, error) {
-	var projectID, region, endpoint string
+	var projectID, endpoint string
 	if id, ok := rs.Primary.Attributes["project_id"]; ok {
 		projectID = id
 	}
@@ -96,7 +96,7 @@ func baseTestAccCheckDBaaSV1EntityExists(ctx context.Context, rs *terraform.Reso
 		endpoint = getDBaaSV1Endpoint(region)
 	}
 	config := testAccProvider.Meta().(*Config)
-	tokenID, err := config.getToken(ctx, projectID, region)
+	tokenID, err := config.getToken(ctx, projectID)
 	if err != nil {
 		return nil, errCreatingObject(objectToken, err)
 	}

--- a/selectel/mks.go
+++ b/selectel/mks.go
@@ -577,7 +577,7 @@ func getMKSClient(ctx context.Context, d *schema.ResourceData, meta interface{})
 	endpoint := getMKSClusterV1Endpoint(region)
 	tokenID, err := config.getToken(ctx, projectID)
 	if err != nil {
-		return nil, diag.FromErr((errCreatingObject(objectToken, err)))
+		return nil, diag.FromErr((errGettingObjects(objectToken, err)))
 	}
 	mksClient := v1.NewMKSClientV1(tokenID, endpoint)
 

--- a/selectel/mks.go
+++ b/selectel/mks.go
@@ -575,7 +575,7 @@ func getMKSClient(ctx context.Context, d *schema.ResourceData, meta interface{})
 	region := d.Get("region").(string)
 	projectID := d.Get("project_id").(string)
 	endpoint := getMKSClusterV1Endpoint(region)
-	tokenID, err := config.getToken(ctx, projectID, region)
+	tokenID, err := config.getToken(ctx, projectID)
 	if err != nil {
 		return nil, diag.FromErr((errCreatingObject(objectToken, err)))
 	}

--- a/selectel/provider.go
+++ b/selectel/provider.go
@@ -164,6 +164,9 @@ func configureProvider(_ context.Context, d *schema.ResourceData) (interface{}, 
 	if v, ok := d.GetOk("region"); ok {
 		config.Region = v.(string)
 	}
+	if v, ok := d.GetOk("project_id"); ok {
+		config.ProjectID = v.(string)
+	}
 	if err := config.Validate(); err != nil {
 		return nil, diag.FromErr(err)
 	}

--- a/selectel/provider.go
+++ b/selectel/provider.go
@@ -55,7 +55,7 @@ func Provider() *schema.Provider {
 				Type:         schema.TypeString,
 				Optional:     true,
 				RequiredWith: []string{"password", "domain_name"},
-				DefaultFunc:  schema.EnvDefaultFunc("SEL_USER", nil),
+				DefaultFunc:  schema.EnvDefaultFunc("OS_USERNAME", nil),
 				Description:  "Cloud user.",
 			},
 			"password": {
@@ -63,27 +63,27 @@ func Provider() *schema.Provider {
 				Optional:     true,
 				Sensitive:    true,
 				RequiredWith: []string{"user", "domain_name"},
-				DefaultFunc:  schema.EnvDefaultFunc("SEL_PASSWORD", nil),
+				DefaultFunc:  schema.EnvDefaultFunc("OS_PASSWORD", nil),
 				Description:  "Cloud user password.",
 			},
 			"domain_name": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				RequiredWith: []string{"user", "password"},
-				DefaultFunc:  schema.EnvDefaultFunc("SEL_DOMAIN_NAME", nil),
-				Description:  "Cloud domain ID to import resources that need the project scope auth token.",
-			},
-			"endpoint": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("SEL_ENDPOINT", nil),
-				Description: "Base endpoint to work with the Selectel API.",
+				DefaultFunc:  schema.EnvDefaultFunc("OS_DOMAIN_NAME", nil),
+				Description:  "Cloud domain name.",
 			},
 			"auth_url": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("OS_AUTH_URL", nil),
 				Description: "Base endpoint to work with the Keystone API.",
+			},
+			"endpoint": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("SEL_ENDPOINT", nil),
+				Description: "Base endpoint to work with the Selectel API.",
 			},
 			"region": {
 				Type:     schema.TypeString,
@@ -165,7 +165,7 @@ func configureProvider(_ context.Context, d *schema.ResourceData) (interface{}, 
 		config.Endpoint = v.(string)
 	}
 	if v, ok := d.GetOk("auth_url"); ok {
-		config.OSEndpoint = v.(string)
+		config.IdentityEndpoint = v.(string)
 	}
 	if v, ok := d.GetOk("domain_name"); ok {
 		config.DomainName = v.(string)

--- a/selectel/provider.go
+++ b/selectel/provider.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/terraform-providers/terraform-provider-selectel/selectel/internal/mutexkv"
 )
 
@@ -86,16 +85,8 @@ func Provider() *schema.Provider {
 				Description: "Base endpoint to work with the Selectel API.",
 			},
 			"region": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					ru1Region,
-					ru2Region,
-					ru3Region,
-					ru7Region,
-					ru8Region,
-					ru9Region,
-				}, false),
+				Type:        schema.TypeString,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("SEL_REGION", nil),
 				Description: "Cloud region to import resources associated with the specific region.",
 			},

--- a/selectel/provider_test.go
+++ b/selectel/provider_test.go
@@ -32,8 +32,8 @@ func TestProvider(t *testing.T) {
 }
 
 func testAccSelectelPreCheck(t *testing.T) {
-	if v := os.Getenv("SEL_TOKEN"); v == "" {
-		t.Fatal("SEL_TOKEN must be set for acceptance tests")
+	if os.Getenv("SEL_TOKEN") == "" && (os.Getenv("SEL_USER") == "" || os.Getenv("SEL_PASSWORD") == "" || os.Getenv("SEL_DOMAIN_NAME") == "") {
+		t.Fatal("Selectel token or Keystone credentials must be set for acceptance tests")
 	}
 }
 

--- a/selectel/resource_selectel_dbaas_extension_v1.go
+++ b/selectel/resource_selectel_dbaas_extension_v1.go
@@ -186,8 +186,7 @@ func resourceDBaaSExtensionV1ImportState(_ context.Context, d *schema.ResourceDa
 	return []*schema.ResourceData{d}, nil
 }
 
-func waitForDBaaSExtensionV1ActiveState(
-	ctx context.Context, client *dbaas.API, extensionID string, timeout time.Duration) error {
+func waitForDBaaSExtensionV1ActiveState(ctx context.Context, client *dbaas.API, extensionID string, timeout time.Duration) error {
 	pending := []string{
 		string(dbaas.StatusPendingCreate),
 		string(dbaas.StatusPendingUpdate),

--- a/selectel/resource_selectel_dbaas_grant_v1.go
+++ b/selectel/resource_selectel_dbaas_grant_v1.go
@@ -192,8 +192,7 @@ func resourceDBaaSGrantV1ImportState(_ context.Context, d *schema.ResourceData, 
 	return []*schema.ResourceData{d}, nil
 }
 
-func waitForDBaaSGrantV1ActiveState(
-	ctx context.Context, client *dbaas.API, grantID string, timeout time.Duration) error {
+func waitForDBaaSGrantV1ActiveState(ctx context.Context, client *dbaas.API, grantID string, timeout time.Duration) error {
 	pending := []string{
 		string(dbaas.StatusPendingCreate),
 		string(dbaas.StatusPendingUpdate),


### PR DESCRIPTION
Hi! Auth by Keystone credentials was added.
- New function getToken get Keystone token by Keystone credentials and Gophercloud
- Added TestHasKeystoneCredentials
- Changed TestValidate
- Changed testAccSelectelPreCheck
- getMKSClient will not use resellV2Client
- mksClient will not initialize by NewMKSClientV1 but getMKSClient
- newTestMKSClient will use not only resellV2Client
- getDBaaSClient will use not only resellV2Client
- baseTestAccCheckDBaaSV1EntityExists will use not only resellV2Client
- Keystone credentials was added to provider scheme
- Fixed testAccCheckMKSNodegroupV1Exists
- Fixed testAccCheckMKSClusterV1DefaultKubeVersion
- Fixed testAccCheckMKSClusterV1DefaultKubeVersionFeatureGates
- Fixed testAccCheckMKSClusterV1DefaultKubeVersionAdmissionControllers
- Linter