### PR TITLE
Add support for ALIAS, CAA and SSHFP DNS records

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,7 +54,7 @@ linters:
 
 linters-settings:
   dupl:
-    threshold: 300
+    threshold: 425
   nlreturn:
     block-size: 3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ IMPROVEMENTS:
 
 * Added `nodegroup_type` attribute to `selectel_mks_nodegroup_v1` resource ([#202](https://github.com/selectel/terraform-provider-selectel/issues/202))
 * Added handling for private kube API clusters to `selectel_mks_cluster_v1` resource ([#204](https://github.com/selectel/terraform-provider-selectel/pull/204))
-* Added support for ALIAS, CAA and SSHFP dns records to `selectel_domains_record_v1` resource ([#210](https://github.com/selectel/terraform-provider-selectel/issues/210))
 
 DEPRECATED:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ IMPROVEMENTS:
 
 * Added `nodegroup_type` attribute to `selectel_mks_nodegroup_v1` resource ([#202](https://github.com/selectel/terraform-provider-selectel/issues/202))
 * Added handling for private kube API clusters to `selectel_mks_cluster_v1` resource ([#204](https://github.com/selectel/terraform-provider-selectel/pull/204))
+* Added support for ALIAS, CAA and SSHFP dns records to `selectel_domains_record_v1` resource ([#210](https://github.com/selectel/terraform-provider-selectel/issues/210))
 
 DEPRECATED:
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.6.6
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
 	github.com/selectel/dbaas-go v0.7.0
-	github.com/selectel/domains-go v0.3.0
+	github.com/selectel/domains-go v0.4.0
 	github.com/selectel/go-selvpcclient v1.12.0
 	github.com/selectel/mks-go v0.12.0
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -292,8 +292,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
 github.com/selectel/dbaas-go v0.7.0 h1:IBEU7EAPlkQ7wGjtIz9bppthpTZLGn3E6TVX7JWMtWk=
 github.com/selectel/dbaas-go v0.7.0/go.mod h1:8D945oFzpx94v08zIb4s1bRTPCdPoNVnBu4umMYFJrQ=
-github.com/selectel/domains-go v0.3.0 h1:0shjqQmpkWc6eM1SwgKqbTTNiT5G2BOEnvS7JvuF96g=
-github.com/selectel/domains-go v0.3.0/go.mod h1:AhXhwyMSTkpEWFiBLUvzFP76W+WN+ZblwmjLJLt7y58=
+github.com/selectel/domains-go v0.4.0 h1:mVUeJK8oW9XMizft7Vu4OCyvjbzq4+o+zHgzJ2ZxnIY=
+github.com/selectel/domains-go v0.4.0/go.mod h1:AhXhwyMSTkpEWFiBLUvzFP76W+WN+ZblwmjLJLt7y58=
 github.com/selectel/go-selvpcclient v1.12.0 h1:LsT074HOVF1dWYapsAWjaaJDQhmDPpcsVjSwQ1r1fj0=
 github.com/selectel/go-selvpcclient v1.12.0/go.mod h1:HNteVXevZMjUCRR6lImTsGZZSTeKu89S/qbEDWDqmgc=
 github.com/selectel/mks-go v0.12.0 h1:nLWHK8BXkhFlXvjFqf7WRrdAfvmrOhQzDSLx7BGa6aM=

--- a/selectel/domains.go
+++ b/selectel/domains.go
@@ -21,6 +21,9 @@ const (
 	TypeRecordSOA   string = "SOA"
 	TypeRecordMX    string = "MX"
 	TypeRecordSRV   string = "SRV"
+	TypeRecordCAA   string = "CAA"
+	TypeRecordSSHFP string = "SSHFP"
+	TypeRecordALIAS string = "ALIAS"
 )
 
 func domainsV1ParseDomainRecordIDsPair(id string) (int, int, error) {

--- a/selectel/resource_selectel_domains_record_v1.go
+++ b/selectel/resource_selectel_domains_record_v1.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"regexp"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -14,6 +15,7 @@ import (
 )
 
 func resourceDomainsRecordV1() *schema.Resource {
+	hexRegexp := regexp.MustCompile(`^[a-fA-F0-9]+$`)
 	return &schema.Resource{
 		CreateContext: resourceDomainsRecordV1Create,
 		ReadContext:   resourceDomainsRecordV1Read,
@@ -45,6 +47,9 @@ func resourceDomainsRecordV1() *schema.Resource {
 					TypeRecordSOA,
 					TypeRecordMX,
 					TypeRecordSRV,
+					TypeRecordCAA,
+					TypeRecordSSHFP,
+					TypeRecordALIAS,
 				}, false),
 			},
 			"ttl": {
@@ -82,6 +87,41 @@ func resourceDomainsRecordV1() *schema.Resource {
 				Optional:     true,
 				RequiredWith: []string{"port", "priority", "weight"},
 			},
+			"tag": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				RequiredWith: []string{"value", "flag"},
+				ValidateFunc: validation.StringInSlice([]string{"issue", "issuewild", "iodef", "auth", "path", "policy"}, false),
+			},
+			"flag": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				RequiredWith: []string{"tag", "value"},
+				ValidateFunc: validation.IntBetween(0, 255),
+			},
+			"value": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				RequiredWith: []string{"flag", "tag"},
+			},
+			"algorithm": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				RequiredWith: []string{"fingerprint_type", "fingerprint"},
+				ValidateFunc: validation.IntBetween(0, 4),
+			},
+			"fingerprint_type": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				RequiredWith: []string{"algorithm", "fingerprint"},
+				ValidateFunc: validation.IntBetween(0, 2),
+			},
+			"fingerprint": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				RequiredWith: []string{"algorithm", "fingerprint_type"},
+				ValidateFunc: validation.StringMatch(hexRegexp, "fingerprint must but valid hexadecimal"),
+			},
 		},
 	}
 }
@@ -95,15 +135,21 @@ func resourceDomainsRecordV1Create(ctx context.Context, d *schema.ResourceData, 
 	client := config.domainsV1Client()
 
 	createOpts := &record.CreateOpts{
-		Name:     d.Get("name").(string),
-		Type:     record.Type(d.Get("type").(string)),
-		TTL:      d.Get("ttl").(int),
-		Content:  d.Get("content").(string),
-		Email:    d.Get("email").(string),
-		Priority: getIntPtrOrNil(d.Get("priority")),
-		Weight:   getIntPtrOrNil(d.Get("weight")),
-		Port:     getIntPtrOrNil(d.Get("port")),
-		Target:   d.Get("target").(string),
+		Name:            d.Get("name").(string),
+		Type:            record.Type(d.Get("type").(string)),
+		TTL:             d.Get("ttl").(int),
+		Content:         d.Get("content").(string),
+		Email:           d.Get("email").(string),
+		Priority:        getIntPtrOrNil(d.Get("priority")),
+		Weight:          getIntPtrOrNil(d.Get("weight")),
+		Port:            getIntPtrOrNil(d.Get("port")),
+		Target:          d.Get("target").(string),
+		Tag:             d.Get("tag").(string),
+		Flag:            getIntPtrOrNil(d.Get("flag")),
+		Value:           d.Get("value").(string),
+		Algorithm:       getIntPtrOrNil(d.Get("algorithm")),
+		FingerprintType: getIntPtrOrNil(d.Get("fingerprint_type")),
+		Fingerprint:     d.Get("fingerprint").(string),
 	}
 
 	log.Print(msgCreate(objectRecord, createOpts))
@@ -153,6 +199,12 @@ func resourceDomainsRecordV1Read(ctx context.Context, d *schema.ResourceData, me
 	d.Set("weight", recordObj.Weight)
 	d.Set("port", recordObj.Port)
 	d.Set("target", recordObj.Target)
+	d.Set("tag", recordObj.Tag)
+	d.Set("flag", recordObj.Flag)
+	d.Set("value", recordObj.Value)
+	d.Set("algorithm", recordObj.Algorithm)
+	d.Set("fingerprint_type", recordObj.FingerprintType)
+	d.Set("fingerprint", recordObj.Fingerprint)
 
 	return nil
 }
@@ -169,17 +221,23 @@ func resourceDomainsRecordV1Update(ctx context.Context, d *schema.ResourceData, 
 	config := meta.(*Config)
 	client := config.domainsV1Client()
 
-	if d.HasChanges("name", "content", "email", "ttl", "priority", "weight", "port", "target") {
+	if d.HasChanges("name", "content", "email", "ttl", "priority", "weight", "port", "target", "tag", "flag", "value", "algorithm", "fingerprint_type", "fingerprint") {
 		updateOpts := &record.UpdateOpts{
-			Name:     d.Get("name").(string),
-			Type:     record.Type(d.Get("type").(string)),
-			TTL:      d.Get("ttl").(int),
-			Content:  d.Get("content").(string),
-			Email:    d.Get("email").(string),
-			Priority: getIntPtrOrNil(d.Get("priority")),
-			Weight:   getIntPtrOrNil(d.Get("weight")),
-			Port:     getIntPtrOrNil(d.Get("port")),
-			Target:   d.Get("target").(string),
+			Name:            d.Get("name").(string),
+			Type:            record.Type(d.Get("type").(string)),
+			TTL:             d.Get("ttl").(int),
+			Content:         d.Get("content").(string),
+			Email:           d.Get("email").(string),
+			Priority:        getIntPtrOrNil(d.Get("priority")),
+			Weight:          getIntPtrOrNil(d.Get("weight")),
+			Port:            getIntPtrOrNil(d.Get("port")),
+			Target:          d.Get("target").(string),
+			Tag:             d.Get("tag").(string),
+			Flag:            getIntPtrOrNil(d.Get("flag")),
+			Value:           d.Get("value").(string),
+			Algorithm:       getIntPtrOrNil(d.Get("algorithm")),
+			FingerprintType: getIntPtrOrNil(d.Get("fingerprint_type")),
+			Fingerprint:     d.Get("fingerprint").(string),
 		}
 		_, _, err = record.Update(ctx, client, domainID, recordID, updateOpts)
 		if err != nil {

--- a/selectel/resource_selectel_domains_record_v1_test.go
+++ b/selectel/resource_selectel_domains_record_v1_test.go
@@ -24,6 +24,9 @@ func TestAccDomainsRecordV1Basic(t *testing.T) {
 		testRecordNS    record.View
 		testRecordMX    record.View
 		testRecordSRV   record.View
+		testRecordCAA   record.View
+		testRecordALIAS record.View
+		testRecordSSHFP record.View
 	)
 
 	testDomainName := fmt.Sprintf("%s.xyz", acctest.RandomWithPrefix("tf-acc"))
@@ -34,6 +37,9 @@ func TestAccDomainsRecordV1Basic(t *testing.T) {
 	testRecordNameNS := fmt.Sprintf("ns.%s", testDomainName)
 	testRecordNameMX := fmt.Sprintf("mx.%s", testDomainName)
 	testRecordNameSRV := fmt.Sprintf("srv.%s", testDomainName)
+	testRecordNameCAA := fmt.Sprintf("caa.%s", testDomainName)
+	testRecordNameALIAS := fmt.Sprintf("alias.%s", testDomainName)
+	testRecordNameSSHFP := fmt.Sprintf("sshfp.%s", testDomainName)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccSelectelPreCheck(t) },
@@ -49,7 +55,11 @@ func TestAccDomainsRecordV1Basic(t *testing.T) {
 					testRecordNameTXT,
 					testRecordNameNS,
 					testRecordNameMX,
-					testRecordNameSRV),
+					testRecordNameSRV,
+					testRecordNameCAA,
+					testRecordNameALIAS,
+					testRecordNameSSHFP,
+				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainsDomainV1Exists("selectel_domains_domain_v1.domain_tf_acc_test_1",
 						&testDomain),
@@ -170,6 +180,63 @@ func TestAccDomainsRecordV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_srv_tf_acc_test_1",
 						"priority",
 						"0"),
+					// Record type CAA check
+					testAccCheckDomainsRecordV1Exists("selectel_domains_record_v1.record_caa_tf_acc_test_1",
+						&testRecordCAA),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_caa_tf_acc_test_1",
+						"name",
+						testRecordNameCAA),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_caa_tf_acc_test_1",
+						"type",
+						"CAA"),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_caa_tf_acc_test_1",
+						"ttl",
+						"60"),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_caa_tf_acc_test_1",
+						"tag",
+						"issue"),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_caa_tf_acc_test_1",
+						"flag",
+						"128"),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_caa_tf_acc_test_1",
+						"value",
+						"letsencrypt.com"),
+					// Record type ALIAS check
+					testAccCheckDomainsRecordV1Exists("selectel_domains_record_v1.record_alias_tf_acc_test_1",
+						&testRecordALIAS),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_alias_tf_acc_test_1",
+						"name",
+						testRecordNameALIAS),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_alias_tf_acc_test_1",
+						"type",
+						"ALIAS"),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_alias_tf_acc_test_1",
+						"ttl",
+						"60"),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_alias_tf_acc_test_1",
+						"content",
+						"tf-acc.xyz"),
+					// Record type SSHFP check
+					testAccCheckDomainsRecordV1Exists("selectel_domains_record_v1.record_sshfp_tf_acc_test_1",
+						&testRecordSSHFP),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_sshfp_tf_acc_test_1",
+						"name",
+						testRecordNameSSHFP),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_sshfp_tf_acc_test_1",
+						"type",
+						"SSHFP"),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_sshfp_tf_acc_test_1",
+						"ttl",
+						"60"),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_sshfp_tf_acc_test_1",
+						"algorithm",
+						"1"),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_sshfp_tf_acc_test_1",
+						"fingerprint_type",
+						"1"),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_sshfp_tf_acc_test_1",
+						"fingerprint",
+						"00AAFF"),
 				),
 			},
 			{
@@ -181,7 +248,11 @@ func TestAccDomainsRecordV1Basic(t *testing.T) {
 					testRecordNameTXT,
 					testRecordNameNS,
 					testRecordNameMX,
-					testRecordNameSRV),
+					testRecordNameSRV,
+					testRecordNameCAA,
+					testRecordNameALIAS,
+					testRecordNameSSHFP,
+				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDomainsDomainV1Exists("selectel_domains_domain_v1.domain_tf_acc_test_1",
 						&testDomain),
@@ -302,6 +373,63 @@ func TestAccDomainsRecordV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_srv_tf_acc_test_1",
 						"priority",
 						"10"),
+					// Record type CAA check
+					testAccCheckDomainsRecordV1Exists("selectel_domains_record_v1.record_caa_tf_acc_test_1",
+						&testRecordCAA),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_caa_tf_acc_test_1",
+						"name",
+						testRecordNameCAA),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_caa_tf_acc_test_1",
+						"type",
+						"CAA"),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_caa_tf_acc_test_1",
+						"ttl",
+						"120"),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_caa_tf_acc_test_1",
+						"tag",
+						"issuewild"),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_caa_tf_acc_test_1",
+						"flag",
+						"255"),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_caa_tf_acc_test_1",
+						"value",
+						"letsencrypt-2.com"),
+					// Record type ALIAS check
+					testAccCheckDomainsRecordV1Exists("selectel_domains_record_v1.record_alias_tf_acc_test_1",
+						&testRecordALIAS),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_alias_tf_acc_test_1",
+						"name",
+						testRecordNameALIAS),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_alias_tf_acc_test_1",
+						"type",
+						"ALIAS"),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_alias_tf_acc_test_1",
+						"ttl",
+						"120"),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_alias_tf_acc_test_1",
+						"content",
+						"tf-acc-2.xyz"),
+					// Record type SSHFP check
+					testAccCheckDomainsRecordV1Exists("selectel_domains_record_v1.record_sshfp_tf_acc_test_1",
+						&testRecordSSHFP),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_sshfp_tf_acc_test_1",
+						"name",
+						testRecordNameSSHFP),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_sshfp_tf_acc_test_1",
+						"type",
+						"SSHFP"),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_sshfp_tf_acc_test_1",
+						"ttl",
+						"120"),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_sshfp_tf_acc_test_1",
+						"algorithm",
+						"2"),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_sshfp_tf_acc_test_1",
+						"fingerprint_type",
+						"2"),
+					resource.TestCheckResourceAttr("selectel_domains_record_v1.record_sshfp_tf_acc_test_1",
+						"fingerprint",
+						"00BB"),
 				),
 			},
 		},
@@ -316,7 +444,10 @@ func testAccDomainsRecordV1Basic(
 	recordNameTXT,
 	recordNameNS,
 	recordNameMX,
-	recordNameSRV string) string {
+	recordNameSRV,
+	recordNameCAA,
+	recordNameALIAS,
+	recordNameSSHFP string) string {
 	return fmt.Sprintf(`
 resource "selectel_domains_domain_v1" "domain_tf_acc_test_1" {
   name = "%s"
@@ -382,6 +513,32 @@ resource "selectel_domains_record_v1" "record_srv_tf_acc_test_1" {
   weight = 10
   port = 5060
 }
+
+resource "selectel_domains_record_v1" "record_caa_tf_acc_test_1" {
+	domain_id = selectel_domains_domain_v1.domain_tf_acc_test_1.id
+	name = "%s"
+	type = "CAA"
+	ttl = 60
+	tag = "issue"
+	flag = 128
+	value = "letsencrypt.com"
+}
+resource "selectel_domains_record_v1" "record_alias_tf_acc_test_1" {
+	domain_id = selectel_domains_domain_v1.domain_tf_acc_test_1.id
+	name = "%s"
+	type = "ALIAS"
+	ttl = 60
+	content = "tf-acc.xyz"
+}
+resource "selectel_domains_record_v1" "record_sshfp_tf_acc_test_1" {
+	domain_id = selectel_domains_domain_v1.domain_tf_acc_test_1.id
+	name = "%s"
+	type = "SSHFP"
+	ttl = 60
+	algorithm = 1
+	fingerprint_type = 1
+	fingerprint = "00AAFF"
+}
 `,
 		domainName,
 		recordNameA,
@@ -390,7 +547,11 @@ resource "selectel_domains_record_v1" "record_srv_tf_acc_test_1" {
 		recordNameTXT,
 		recordNameNS,
 		recordNameMX,
-		recordNameSRV)
+		recordNameSRV,
+		recordNameCAA,
+		recordNameALIAS,
+		recordNameSSHFP,
+	)
 }
 
 func testAccDomainsRecordV1Update(
@@ -401,7 +562,10 @@ func testAccDomainsRecordV1Update(
 	recordNameTXT,
 	recordNameNS,
 	recordNameMX,
-	recordNameSRV string) string {
+	recordNameSRV,
+	recordNameCAA,
+	recordNameALIAS,
+	recordNameSSHFP string) string {
 	return fmt.Sprintf(`
 resource "selectel_domains_domain_v1" "domain_tf_acc_test_1" {
   name = "%s"
@@ -467,6 +631,32 @@ resource "selectel_domains_record_v1" "record_srv_tf_acc_test_1" {
   weight = 20
   port = 5061
 }
+
+resource "selectel_domains_record_v1" "record_caa_tf_acc_test_1" {
+	domain_id = selectel_domains_domain_v1.domain_tf_acc_test_1.id
+	name = "%s"
+	type = "CAA"
+	ttl = 120
+	tag = "issuewild"
+	flag = 255
+	value = "letsencrypt2.com"
+}
+resource "selectel_domains_record_v1" "record_alias_tf_acc_test_1" {
+	domain_id = selectel_domains_domain_v1.domain_tf_acc_test_1.id
+	name = "%s"
+	type = "ALIAS"
+	ttl = 120
+	content = "tf-acc-2.xyz"
+}
+resource "selectel_domains_record_v1" "record_sshfp_tf_acc_test_1" {
+	domain_id = selectel_domains_domain_v1.domain_tf_acc_test_1.id
+	name = "%s"
+	type = "SSHFP"
+	ttl = 120
+	algorithm = 2
+	fingerprint_type = 2
+	fingerprint = "00BB"
+}
 `,
 		domainName,
 		recordNameA,
@@ -475,7 +665,11 @@ resource "selectel_domains_record_v1" "record_srv_tf_acc_test_1" {
 		recordNameTXT,
 		recordNameNS,
 		recordNameMX,
-		recordNameSRV)
+		recordNameSRV,
+		recordNameCAA,
+		recordNameALIAS,
+		recordNameSSHFP,
+	)
 }
 
 func testAccCheckDomainsRecordV1Exists(n string, domainRecord *record.View) resource.TestCheckFunc {

--- a/selectel/resource_selectel_domains_record_v1_test.go
+++ b/selectel/resource_selectel_domains_record_v1_test.go
@@ -447,7 +447,8 @@ func testAccDomainsRecordV1Basic(
 	recordNameSRV,
 	recordNameCAA,
 	recordNameALIAS,
-	recordNameSSHFP string) string {
+	recordNameSSHFP string,
+) string {
 	return fmt.Sprintf(`
 resource "selectel_domains_domain_v1" "domain_tf_acc_test_1" {
   name = "%s"
@@ -565,7 +566,8 @@ func testAccDomainsRecordV1Update(
 	recordNameSRV,
 	recordNameCAA,
 	recordNameALIAS,
-	recordNameSSHFP string) string {
+	recordNameSSHFP string,
+) string {
 	return fmt.Sprintf(`
 resource "selectel_domains_domain_v1" "domain_tf_acc_test_1" {
   name = "%s"
@@ -639,7 +641,7 @@ resource "selectel_domains_record_v1" "record_caa_tf_acc_test_1" {
 	ttl = 120
 	tag = "issuewild"
 	flag = 255
-	value = "letsencrypt2.com"
+	value = "letsencrypt-2.com"
 }
 resource "selectel_domains_record_v1" "record_alias_tf_acc_test_1" {
 	domain_id = selectel_domains_domain_v1.domain_tf_acc_test_1.id

--- a/website/docs/r/domains_record_v1.html.markdown
+++ b/website/docs/r/domains_record_v1.html.markdown
@@ -77,6 +77,33 @@ resource "selectel_domains_record_v1" "srv_record_1" {
   weight = 20
   port = 100
 }
+
+resource "selectel_domains_record_v1" "caa_record_1" {
+  domain_id = selectel_domains_domain_v1.main_domain.id
+  name = format("caa.%s", selectel_domains_domain_v1.main_domain.name)
+  type = "CAA"
+  tag = "issue"
+  flag = 128
+  value = "letsencrypt.com"
+  ttl = 60
+}
+
+resource "selectel_domains_record_v1" "sshfp_record_1" {
+  domain_id = selectel_domains_domain_v1.main_domain.id
+  name = format("%s", selectel_domains_domain_v1.main_domain.name)
+  type = "SSHFP"
+  algorithm = 1
+  fingerprint_type = 1
+  fingerprint = "01AA"
+  ttl = 60
+}
+resource "selectel_domains_record_v1" "alias_record_1" {
+  domain_id = selectel_domains_domain_v1.main_domain.id
+  name = format("subc.%s", selectel_domains_domain_v1.main_domain.name)
+  type = "ALIAS"
+  content = format("%s", selectel_domains_domain_v1.main_domain.name)
+  ttl = 60
+}
 ```
 
 ## Argument Reference
@@ -113,6 +140,24 @@ The following arguments are supported:
 * `target` - (Optional) Represents a canonical hostname of the machine providing the service.
  For SRV records only.
 
+* `tag` - (Optional) Represents the identifier of the property represented by the record.
+ For CAA records only.
+
+* `flag` - (Optional) Represents the critical flag, that has a specific meaning per RFC.
+ For CAA records only.
+
+* `value` - (Optional) Represents a value associated with the tag.
+ For CAA records only.
+
+* `algorithm` - (Optional) Represents the algorithm of the public key.
+ For SSHFP records only.
+
+* `fingerprint_type` - (Optional) Represents an algorithm used to hash the public key.
+ For SSHFP records only.
+
+* `fingerprint` - (Optional) Represents a hexadecimal hash result, as text.
+ For SSHFP records only.
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -129,6 +174,18 @@ The following attributes are exported:
 * `port` - Represents TCP or UDP port on which the service is to be found.
 
 * `target` - Represents a canonical hostname of the machine providing the service.
+
+* `tag` - Represents the identifier of the property represented by the record.
+
+* `flag` - Represents the critical flag, that has a specific meaning per RFC.
+
+* `value` - Represents a value associated with the tag.
+
+* `algorithm` - Represents th algorithm of the public key.
+
+* `fingerprint_type` - Represents an algorithm used to hash the public key.
+
+* `fingerprint` - Represents a hexadecimal hash result, as text.
 
 ## Import
 


### PR DESCRIPTION
- Add support for ALIAS, CAA and SSHFP dns records
- Increase dupl threshold in golangci to pass test