### PR TITLE
Added logical replication slots resources for PostgreSQL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/hashicorp/go-retryablehttp v0.6.6
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
-	github.com/selectel/dbaas-go v0.7.0
+	github.com/selectel/dbaas-go v0.8.0
 	github.com/selectel/domains-go v0.4.0
 	github.com/selectel/go-selvpcclient/v2 v2.1.1
 	github.com/selectel/mks-go v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -164,8 +164,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
-github.com/selectel/dbaas-go v0.7.0 h1:IBEU7EAPlkQ7wGjtIz9bppthpTZLGn3E6TVX7JWMtWk=
-github.com/selectel/dbaas-go v0.7.0/go.mod h1:8D945oFzpx94v08zIb4s1bRTPCdPoNVnBu4umMYFJrQ=
+github.com/selectel/dbaas-go v0.8.0 h1:9JBfCWTi6g6RGksyNtNwfrc8vQz9evtQ8zjx0wGrPTE=
+github.com/selectel/dbaas-go v0.8.0/go.mod h1:8D945oFzpx94v08zIb4s1bRTPCdPoNVnBu4umMYFJrQ=
 github.com/selectel/domains-go v0.4.0 h1:mVUeJK8oW9XMizft7Vu4OCyvjbzq4+o+zHgzJ2ZxnIY=
 github.com/selectel/domains-go v0.4.0/go.mod h1:AhXhwyMSTkpEWFiBLUvzFP76W+WN+ZblwmjLJLt7y58=
 github.com/selectel/go-selvpcclient/v2 v2.1.1 h1:dW8AEDeDkMCBb94NMCiNq/vK4n+f6kcGKsUuMwBcq+A=

--- a/selectel/dbaas.go
+++ b/selectel/dbaas.go
@@ -563,7 +563,8 @@ func dbaasUserV1DeleteStateRefreshFunc(ctx context.Context, client *dbaas.API, u
 // Slots
 
 func waitForDBaaSLogicalReplicationSlotV1ActiveState(
-	ctx context.Context, client *dbaas.API, slotID string, timeout time.Duration) error {
+	ctx context.Context, client *dbaas.API, slotID string, timeout time.Duration,
+) error {
 	pending := []string{
 		string(dbaas.StatusPendingCreate),
 		string(dbaas.StatusPendingUpdate),

--- a/selectel/dbaas.go
+++ b/selectel/dbaas.go
@@ -558,3 +558,61 @@ func dbaasUserV1DeleteStateRefreshFunc(ctx context.Context, client *dbaas.API, u
 		return d, strconv.Itoa(200), err
 	}
 }
+
+// Slots
+
+func waitForDBaaSLogicalReplicationSlotV1ActiveState(
+	ctx context.Context, client *dbaas.API, slotID string, timeout time.Duration) error {
+	pending := []string{
+		string(dbaas.StatusPendingCreate),
+		string(dbaas.StatusPendingUpdate),
+	}
+	target := []string{
+		string(dbaas.StatusActive),
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    pending,
+		Target:     target,
+		Refresh:    dbaasLogicalReplicationSlotV1StateRefreshFunc(ctx, client, slotID),
+		Timeout:    timeout,
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err := stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf(
+			"error waiting for the slot %s to become 'ACTIVE': %s",
+			slotID, err)
+	}
+
+	return nil
+}
+
+func dbaasLogicalReplicationSlotV1StateRefreshFunc(ctx context.Context, client *dbaas.API, slotID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		d, err := client.LogicalReplicationSlot(ctx, slotID)
+		if err != nil {
+			return nil, "", err
+		}
+
+		return d, string(d.Status), nil
+	}
+}
+
+func dbaasLogicalReplicationSlotV1DeleteStateRefreshFunc(ctx context.Context, client *dbaas.API, slotID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		d, err := client.LogicalReplicationSlot(ctx, slotID)
+		if err != nil {
+			var dbaasError *dbaas.DBaaSAPIError
+			if errors.As(err, &dbaasError) {
+				return d, strconv.Itoa(dbaasError.StatusCode()), nil
+			}
+
+			return nil, "", err
+		}
+
+		return d, strconv.Itoa(200), err
+	}
+}

--- a/selectel/dbaas.go
+++ b/selectel/dbaas.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"net/http"
 	"sort"
 	"strconv"
 	"strings"
@@ -206,7 +207,7 @@ func dbaasDatastoreV1DeleteStateRefreshFunc(ctx context.Context, client *dbaas.A
 			return nil, "", err
 		}
 
-		return d, strconv.Itoa(200), err
+		return d, strconv.Itoa(http.StatusOK), err
 	}
 }
 
@@ -487,7 +488,7 @@ func dbaasDatabaseV1DeleteStateRefreshFunc(ctx context.Context, client *dbaas.AP
 			return nil, "", err
 		}
 
-		return d, strconv.Itoa(200), err
+		return d, strconv.Itoa(http.StatusOK), err
 	}
 }
 
@@ -555,7 +556,7 @@ func dbaasUserV1DeleteStateRefreshFunc(ctx context.Context, client *dbaas.API, u
 			return nil, "", err
 		}
 
-		return d, strconv.Itoa(200), err
+		return d, strconv.Itoa(http.StatusOK), err
 	}
 }
 
@@ -613,6 +614,6 @@ func dbaasLogicalReplicationSlotV1DeleteStateRefreshFunc(ctx context.Context, cl
 			return nil, "", err
 		}
 
-		return d, strconv.Itoa(200), err
+		return d, strconv.Itoa(http.StatusOK), err
 	}
 }

--- a/selectel/import_selectel_dbaas_postgresql_logical_replication_slot_v1_test.go
+++ b/selectel/import_selectel_dbaas_postgresql_logical_replication_slot_v1_test.go
@@ -1,0 +1,36 @@
+package selectel
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDBaaSPostgreSQLLogicalReplicationSlotV1ImportBasic(t *testing.T) {
+	resourceName := "selectel_dbaas_postgresql_logical_replication_slot_v1.slot_tf_acc_test_1"
+	projectName := acctest.RandomWithPrefix("tf-acc")
+	datastoreName := acctest.RandomWithPrefix("tf-acc-ds")
+	userName := RandomWithPrefix("tf_acc_user")
+	userPassword := acctest.RandomWithPrefix("tf-acc-pass")
+	databaseName := RandomWithPrefix("tf_acc_db")
+	slotName := RandomWithPrefix("tf_acc_ds")
+	nodeCount := 1
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccSelectelPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckVPCV2ProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDBaaSPostgreSQLLogicalReplicationSlotV1Basic(projectName, datastoreName, userName, userPassword, databaseName, slotName, nodeCount),
+				Check:  testAccCheckSelectelImportEnv(resourceName),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/selectel/provider.go
+++ b/selectel/provider.go
@@ -35,6 +35,7 @@ const (
 	objectPrometheusMetricToken   = "prometheus-metric-token"
 	objectFeatureGates            = "feature-gates"
 	objectAdmissionControllers    = "admission-controllers"
+	objectLogicalReplicationSlot  = "logical-replication-slot"
 )
 
 // This is a global MutexKV for use within this plugin.
@@ -82,32 +83,33 @@ func Provider() *schema.Provider {
 			"selectel_mks_admission_controllers_v1":     dataSourceMKSAdmissionControllersV1(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
-			"selectel_vpc_floatingip_v2":                resourceVPCFloatingIPV2(),
-			"selectel_vpc_keypair_v2":                   resourceVPCKeypairV2(),
-			"selectel_vpc_license_v2":                   resourceVPCLicenseV2(),
-			"selectel_vpc_project_v2":                   resourceVPCProjectV2(),
-			"selectel_vpc_role_v2":                      resourceVPCRoleV2(),
-			"selectel_vpc_subnet_v2":                    resourceVPCSubnetV2(),
-			"selectel_vpc_token_v2":                     resourceVPCTokenV2(),
-			"selectel_vpc_user_v2":                      resourceVPCUserV2(),
-			"selectel_vpc_vrrp_subnet_v2":               resourceVPCVRRPSubnetV2(),        // DEPRECATED
-			"selectel_vpc_crossregion_subnet_v2":        resourceVPCCrossRegionSubnetV2(), // DEPRECATED
-			"selectel_mks_cluster_v1":                   resourceMKSClusterV1(),
-			"selectel_mks_nodegroup_v1":                 resourceMKSNodegroupV1(),
-			"selectel_domains_domain_v1":                resourceDomainsDomainV1(),
-			"selectel_domains_record_v1":                resourceDomainsRecordV1(),
-			"selectel_dbaas_datastore_v1":               resourceDBaaSDatastoreV1(), // DEPRECATED
-			"selectel_dbaas_postgresql_datastore_v1":    resourceDBaaSPostgreSQLDatastoreV1(),
-			"selectel_dbaas_mysql_datastore_v1":         resourceDBaaSMySQLDatastoreV1(),
-			"selectel_dbaas_redis_datastore_v1":         resourceDBaaSRedisDatastoreV1(),
-			"selectel_dbaas_user_v1":                    resourceDBaaSUserV1(),
-			"selectel_dbaas_database_v1":                resourceDBaaSDatabaseV1(), // DEPRECATED
-			"selectel_dbaas_postgresql_database_v1":     resourceDBaaSPostgreSQLDatabaseV1(),
-			"selectel_dbaas_mysql_database_v1":          resourceDBaaSMySQLDatabaseV1(),
-			"selectel_dbaas_grant_v1":                   resourceDBaaSGrantV1(),
-			"selectel_dbaas_extension_v1":               resourceDBaaSExtensionV1(), // DEPRECATED
-			"selectel_dbaas_postgresql_extension_v1":    resourceDBaaSPostgreSQLExtensionV1(),
-			"selectel_dbaas_prometheus_metric_token_v1": resourceDBaaSPrometheusMetricTokenV1(),
+			"selectel_vpc_floatingip_v2":                            resourceVPCFloatingIPV2(),
+			"selectel_vpc_keypair_v2":                               resourceVPCKeypairV2(),
+			"selectel_vpc_license_v2":                               resourceVPCLicenseV2(),
+			"selectel_vpc_project_v2":                               resourceVPCProjectV2(),
+			"selectel_vpc_role_v2":                                  resourceVPCRoleV2(),
+			"selectel_vpc_subnet_v2":                                resourceVPCSubnetV2(),
+			"selectel_vpc_token_v2":                                 resourceVPCTokenV2(),
+			"selectel_vpc_user_v2":                                  resourceVPCUserV2(),
+			"selectel_vpc_vrrp_subnet_v2":                           resourceVPCVRRPSubnetV2(),        // DEPRECATED
+			"selectel_vpc_crossregion_subnet_v2":                    resourceVPCCrossRegionSubnetV2(), // DEPRECATED
+			"selectel_mks_cluster_v1":                               resourceMKSClusterV1(),
+			"selectel_mks_nodegroup_v1":                             resourceMKSNodegroupV1(),
+			"selectel_domains_domain_v1":                            resourceDomainsDomainV1(),
+			"selectel_domains_record_v1":                            resourceDomainsRecordV1(),
+			"selectel_dbaas_datastore_v1":                           resourceDBaaSDatastoreV1(), // DEPRECATED
+			"selectel_dbaas_postgresql_datastore_v1":                resourceDBaaSPostgreSQLDatastoreV1(),
+			"selectel_dbaas_mysql_datastore_v1":                     resourceDBaaSMySQLDatastoreV1(),
+			"selectel_dbaas_redis_datastore_v1":                     resourceDBaaSRedisDatastoreV1(),
+			"selectel_dbaas_user_v1":                                resourceDBaaSUserV1(),
+			"selectel_dbaas_database_v1":                            resourceDBaaSDatabaseV1(), // DEPRECATED
+			"selectel_dbaas_postgresql_database_v1":                 resourceDBaaSPostgreSQLDatabaseV1(),
+			"selectel_dbaas_mysql_database_v1":                      resourceDBaaSMySQLDatabaseV1(),
+			"selectel_dbaas_grant_v1":                               resourceDBaaSGrantV1(),
+			"selectel_dbaas_extension_v1":                           resourceDBaaSExtensionV1(), // DEPRECATED
+			"selectel_dbaas_postgresql_extension_v1":                resourceDBaaSPostgreSQLExtensionV1(),
+			"selectel_dbaas_prometheus_metric_token_v1":             resourceDBaaSPrometheusMetricTokenV1(),
+			"selectel_dbaas_postgresql_logical_replication_slot_v1": resourceDBaaSPostgreSQLLogicalReplicationSlotV1(),
 		},
 		ConfigureContextFunc: configureProvider,
 	}

--- a/selectel/resource_selectel_dbaas_postgresql_logical_replication_slot_v1.go
+++ b/selectel/resource_selectel_dbaas_postgresql_logical_replication_slot_v1.go
@@ -1,0 +1,187 @@
+package selectel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/selectel/dbaas-go"
+)
+
+func resourceDBaaSPostgreSQLLogicalReplicationSlotV1() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDBaaSPostgreSQLLogicalReplicationSlotV1Create,
+		ReadContext:   resourceDBaaSPostgreSQLLogicalReplicationSlotV1Read,
+		DeleteContext: resourceDBaaSPostgreSQLLogicalReplicationSlotV1Delete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceDBaaSPostgreSQLLogicalReplicationSlotV1ImportState,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+			Update: schema.DefaultTimeout(60 * time.Minute),
+			Delete: schema.DefaultTimeout(60 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					ru1Region,
+					ru2Region,
+					ru3Region,
+					ru7Region,
+					ru8Region,
+					ru9Region,
+					nl1Region,
+				}, false),
+			},
+			"datastore_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"database_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceDBaaSPostgreSQLLogicalReplicationSlotV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	datastoreID := d.Get("datastore_id").(string)
+
+	selMutexKV.Lock(datastoreID)
+	defer selMutexKV.Unlock(datastoreID)
+
+	databaseID := d.Get("database_id").(string)
+
+	selMutexKV.Lock(databaseID)
+	defer selMutexKV.Unlock(databaseID)
+
+	dbaasClient, diagErr := getDBaaSClient(ctx, d, meta)
+	if diagErr != nil {
+		return diagErr
+	}
+
+	slotCreateOpts := dbaas.LogicalReplicationSlotCreateOpts{
+		Name:        d.Get("name").(string),
+		DatastoreID: datastoreID,
+		DatabaseID:  databaseID,
+	}
+
+	log.Print(msgCreate(objectLogicalReplicationSlot, slotCreateOpts))
+	slot, err := dbaasClient.CreateLogicalReplicationSlot(ctx, slotCreateOpts)
+	if err != nil {
+		return diag.FromErr(errCreatingObject(objectLogicalReplicationSlot, err))
+	}
+
+	log.Printf("[DEBUG] waiting for slot %s to become 'ACTIVE'", slot.ID)
+	timeout := d.Timeout(schema.TimeoutCreate)
+	err = waitForDBaaSLogicalReplicationSlotV1ActiveState(ctx, dbaasClient, slot.ID, timeout)
+	if err != nil {
+		return diag.FromErr(errCreatingObject(objectLogicalReplicationSlot, err))
+	}
+
+	d.SetId(slot.ID)
+
+	return resourceDBaaSPostgreSQLLogicalReplicationSlotV1Read(ctx, d, meta)
+}
+
+func resourceDBaaSPostgreSQLLogicalReplicationSlotV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	dbaasClient, diagErr := getDBaaSClient(ctx, d, meta)
+	if diagErr != nil {
+		return diagErr
+	}
+
+	log.Print(msgGet(objectLogicalReplicationSlot, d.Id()))
+	slot, err := dbaasClient.LogicalReplicationSlot(ctx, d.Id())
+	if err != nil {
+		return diag.FromErr(errGettingObject(objectLogicalReplicationSlot, d.Id(), err))
+	}
+
+	d.Set("name", slot.Name)
+	d.Set("datastore_id", slot.DatastoreID)
+	d.Set("database_id", slot.DatabaseID)
+
+	return nil
+}
+
+func resourceDBaaSPostgreSQLLogicalReplicationSlotV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	datastoreID := d.Get("datastore_id").(string)
+
+	selMutexKV.Lock(datastoreID)
+	defer selMutexKV.Unlock(datastoreID)
+
+	databaseID := d.Get("database_id").(string)
+
+	selMutexKV.Lock(databaseID)
+	defer selMutexKV.Unlock(databaseID)
+
+	dbaasClient, diagErr := getDBaaSClient(ctx, d, meta)
+	if diagErr != nil {
+		return diagErr
+	}
+
+	log.Print(msgDelete(objectLogicalReplicationSlot, d.Id()))
+	err := dbaasClient.DeleteLogicalReplicationSlot(ctx, d.Id())
+	if err != nil {
+		return diag.FromErr(errDeletingObject(objectLogicalReplicationSlot, d.Id(), err))
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{strconv.Itoa(http.StatusOK)},
+		Target:     []string{strconv.Itoa(http.StatusNotFound)},
+		Refresh:    dbaasLogicalReplicationSlotV1DeleteStateRefreshFunc(ctx, dbaasClient, d.Id()),
+		Timeout:    d.Timeout(schema.TimeoutDelete),
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	log.Printf("[DEBUG] waiting for slot %s to become deleted", d.Id())
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error waiting for the slot %s to become deleted: %s", d.Id(), err))
+	}
+
+	return nil
+}
+
+func resourceDBaaSPostgreSQLLogicalReplicationSlotV1ImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	config := meta.(*Config)
+	if config.ProjectID == "" {
+		return nil, errors.New("SEL_PROJECT_ID must be set for the resource import")
+	}
+	if config.Region == "" {
+		return nil, errors.New("SEL_REGION must be set for the resource import")
+	}
+
+	d.Set("project_id", config.ProjectID)
+	d.Set("region", config.Region)
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/selectel/resource_selectel_dbaas_postgresql_logical_replication_slot_v1.go
+++ b/selectel/resource_selectel_dbaas_postgresql_logical_replication_slot_v1.go
@@ -51,7 +51,7 @@ func resourceDBaaSPostgreSQLLogicalReplicationSlotV1() *schema.Resource {
 					ru7Region,
 					ru8Region,
 					ru9Region,
-					nl1Region,
+					uz1Region,
 				}, false),
 			},
 			"datastore_id": {

--- a/selectel/resource_selectel_dbaas_postgresql_logical_replication_slot_v1_test.go
+++ b/selectel/resource_selectel_dbaas_postgresql_logical_replication_slot_v1_test.go
@@ -1,0 +1,136 @@
+package selectel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/selectel/dbaas-go"
+	"github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/projects"
+)
+
+func TestAccDBaaSPostgreSQLLogicalReplicationSlotV1Basic(t *testing.T) {
+	var (
+		dbaasSlot dbaas.LogicalReplicationSlot
+		project   projects.Project
+	)
+
+	projectName := acctest.RandomWithPrefix("tf-acc")
+	datastoreName := acctest.RandomWithPrefix("tf-acc-ds")
+	userName := RandomWithPrefix("tf_acc_user")
+	userPassword := acctest.RandomWithPrefix("tf-acc-pass")
+	databaseName := RandomWithPrefix("tf_acc_db")
+	slotName := RandomWithPrefix("tf_acc_slot")
+	nodeCount := 1
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccSelectelPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckVPCV2ProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDBaaSPostgreSQLLogicalReplicationSlotV1Basic(projectName, datastoreName, userName, userPassword, databaseName, slotName, nodeCount),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVPCV2ProjectExists("selectel_vpc_project_v2.project_tf_acc_test_1", &project),
+					testAccCheckDBaaSLogicalReplicationSlotV1Exists("selectel_dbaas_postgresql_logical_replication_slot_v1.slot_tf_acc_test_1", &dbaasSlot),
+					resource.TestCheckResourceAttrSet("selectel_dbaas_postgresql_logical_replication_slot_v1.slot_tf_acc_test_1", "name"),
+					resource.TestCheckResourceAttrSet("selectel_dbaas_postgresql_logical_replication_slot_v1.slot_tf_acc_test_1", "datastore_id"),
+					resource.TestCheckResourceAttrSet("selectel_dbaas_postgresql_logical_replication_slot_v1.slot_tf_acc_test_1", "database_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDBaaSLogicalReplicationSlotV1Exists(n string, dbaasSlot *dbaas.LogicalReplicationSlot) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		ctx := context.Background()
+
+		dbaasClient, err := baseTestAccCheckDBaaSV1EntityExists(ctx, rs, testAccProvider)
+		if err != nil {
+			return err
+		}
+
+		slot, err := dbaasClient.LogicalReplicationSlot(ctx, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if slot.ID != rs.Primary.ID {
+			return errors.New("logical replication slot is not found")
+		}
+
+		*dbaasSlot = slot
+
+		return nil
+	}
+}
+
+func testAccDBaaSPostgreSQLLogicalReplicationSlotV1Basic(projectName, datastoreName, userName, userPassword, databaseName, slotName string, nodeCount int) string {
+	return fmt.Sprintf(`
+resource "selectel_vpc_project_v2" "project_tf_acc_test_1" {
+  name        = "%s"
+  auto_quotas = true
+}
+
+resource "selectel_vpc_subnet_v2" "subnet_tf_acc_test_1" {
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  region     = "ru-3"
+}
+
+data "selectel_dbaas_datastore_type_v1" "dt" {
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  region = "ru-3"
+  filter {
+    engine = "postgresql"
+    version = "12"
+  }
+}
+
+resource "selectel_dbaas_postgresql_datastore_v1" "datastore_tf_acc_test_1" {
+  name = "%s"
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  region = "ru-3"
+  type_id = "${data.selectel_dbaas_datastore_type_v1.dt.datastore_types[0].id}"
+  subnet_id = "${selectel_vpc_subnet_v2.subnet_tf_acc_test_1.subnet_id}"
+  node_count = "%d"
+  flavor {
+    vcpus = 2
+    ram = 4096
+    disk = 32
+  }
+}
+
+resource "selectel_dbaas_user_v1" "user_tf_acc_test_1" {
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  region = "ru-3"
+  datastore_id = "${selectel_dbaas_postgresql_datastore_v1.datastore_tf_acc_test_1.id}"
+  name = "%s"
+  password = "%s"
+}
+
+resource "selectel_dbaas_postgresql_database_v1" "database_tf_acc_test_1" {
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  region = "ru-3"
+  datastore_id = "${selectel_dbaas_postgresql_datastore_v1.datastore_tf_acc_test_1.id}"
+  name = "%s"
+  owner_id = "${selectel_dbaas_user_v1.user_tf_acc_test_1.id}"
+}
+
+resource "selectel_dbaas_postgresql_logical_replication_slot_v1" "slot_tf_acc_test_1" {
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  region = "ru-3"
+  name = "%s"
+  datastore_id = "${selectel_dbaas_postgresql_datastore_v1.datastore_tf_acc_test_1.id}"
+  database_id = "${selectel_dbaas_postgresql_database_v1.database_tf_acc_test_1.id}"
+}`, projectName, datastoreName, nodeCount, userName, userPassword, databaseName, slotName)
+}

--- a/selectel/resource_selectel_dbaas_postgresql_logical_replication_slot_v1_test.go
+++ b/selectel/resource_selectel_dbaas_postgresql_logical_replication_slot_v1_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/selectel/dbaas-go"
-	"github.com/selectel/go-selvpcclient/selvpcclient/resell/v2/projects"
+	"github.com/selectel/go-selvpcclient/v2/selvpcclient/resell/v2/projects"
 )
 
 func TestAccDBaaSPostgreSQLLogicalReplicationSlotV1Basic(t *testing.T) {
@@ -79,7 +79,6 @@ func testAccDBaaSPostgreSQLLogicalReplicationSlotV1Basic(projectName, datastoreN
 	return fmt.Sprintf(`
 resource "selectel_vpc_project_v2" "project_tf_acc_test_1" {
   name        = "%s"
-  auto_quotas = true
 }
 
 resource "selectel_vpc_subnet_v2" "subnet_tf_acc_test_1" {

--- a/website/docs/r/dbaas_postgresql_logical_replication_slot_v1.html.markdown.md
+++ b/website/docs/r/dbaas_postgresql_logical_replication_slot_v1.html.markdown.md
@@ -1,0 +1,110 @@
+---
+layout: "selectel"
+page_title: "Selectel: selectel_dbaas_postgresql_logical_replication_slot_v1"
+sidebar_current: "docs-selectel-resource-dbaas-postgresql-logical-replication-slot-v1"
+description: |-
+  Manages a V1 PostgreSQL logical replication slot resource within Selectel Managed Databases Service.
+---
+
+# selectel\_dbaas\_postgresql\_logical\_replication\_slot\_v1
+
+Manages a V1 PostgreSQL logical replication slot resource within Selectel Managed Databases Service. Can be installed only for PostgreSQL datastores.
+
+## Example usage
+
+```hcl
+resource "selectel_vpc_project_v2" "project_1" {
+  auto_quotas = true
+}
+
+resource "selectel_vpc_subnet_v2" "subnet" {
+  project_id   = "${selectel_vpc_project_v2.project_1.id}"
+  region       = "ru-3"
+}
+
+data "selectel_dbaas_datastore_type_v1" "dt" {
+  project_id   = "${selectel_vpc_project_v2.project_1.id}"
+  region       = "ru-3"
+  filter {
+    engine  = "postgresql"
+    version = "12"
+  }
+}
+
+resource "selectel_dbaas_postgresql_datastore_v1" "datastore_1" {
+  name         = "datastore-1"
+  project_id   = "${selectel_vpc_project_v2.project_1.id}"
+  region       = "ru-3"
+  type_id      = data.selectel_dbaas_datastore_type_v1.dt.datastore_types[0].id
+  subnet_id    = "${selectel_vpc_subnet_v2.subnet.subnet_id}"
+  node_count   = 3
+  flavor {
+    vcpus = 4
+    ram   = 4096
+    disk  = 32
+  }
+  pooler {
+    mode = "transaction"
+    size = 50
+  }
+}
+
+resource "selectel_dbaas_user_v1" "user_1" {
+  project_id   = "${selectel_vpc_project_v2.project_1.id}"
+  region       = "ru-3"
+  datastore_id = "${selectel_dbaas_datastore_v1.datastore_1.id}"
+  name         = "user"
+  password     = "secret"
+}
+
+resource "selectel_dbaas_postgresql_database_v1" "database_1" {
+  project_id   = "${selectel_vpc_project_v2.project_1.id}"
+  region       = "ru-3"
+  datastore_id = "${selectel_dbaas_datastore_v1.datastore_1.id}"
+  owner_id     = "${selectel_dbaas_user_v1.user_1.id}"
+  name         = "db"
+  lc_ctype     = "ru_RU.utf8"
+  lc_collate   = "ru_RU.utf8"
+}
+
+resource "selectel_dbaas_postgresql_logical_replication_slot_v1" "slot_1" {
+  project_id   = "${selectel_vpc_project_v2.project_1.id}"
+  region       = "ru-3"
+  datastore_id = "${selectel_dbaas_datastore_v1.datastore_1.id}"
+  database_id  = "${selectel_dbaas_database_v1.database_1.id}"
+  name         = "test_slot"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project_id` - (Required) An associated Selectel VPC project.
+  Changing this creates a new extension.
+
+* `region` - (Required) A Selectel VPC region of where the database is located.
+  Changing this creates a new extension.
+
+* `datastore_id` - (Required) An associated datastore.
+  Changing this creates a new slot.
+
+* `database_id` - (Required) An associated database.tele
+  Changing this creates a new slot.
+
+* `name` - (Required) A name of the slot. Can contain only  lower case letters, numbers and the underscore char.
+  Changing this creates a new slot.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `status` - Shows the current status of the extension.
+
+## Import
+
+Extension can be imported using the `id`, e.g.
+
+```shell
+$ env SEL_TOKEN=SELECTEL_API_TOKEN SEL_PROJECT_ID=SELECTEL_VPC_PROJECT_ID SEL_REGION=SELECTEL_VPC_REGION terraform import selectel_dbaas_postgresql_logical_replication_slot_v1.slot_1 b311ce58-2658-46b5-b733-7a0f418703f2
+```

--- a/website/docs/r/dbaas_postgresql_logical_replication_slot_v1.html.markdown.md
+++ b/website/docs/r/dbaas_postgresql_logical_replication_slot_v1.html.markdown.md
@@ -14,7 +14,6 @@ Manages a V1 PostgreSQL logical replication slot resource within Selectel Manage
 
 ```hcl
 resource "selectel_vpc_project_v2" "project_1" {
-  auto_quotas = true
 }
 
 resource "selectel_vpc_subnet_v2" "subnet" {

--- a/website/selectel.erb
+++ b/website/selectel.erb
@@ -136,6 +136,9 @@
             <li<%= sidebar_current("docs-selectel-resource-dbaas-prometheus-metric-token-v1") %>>
               <a href="/docs/providers/selectel/r/selectel_dbaas_prometheus_metric_token_v1.html">selectel_dbaas_prometheus_metric_token_v1</a>
             </li>
+            <li<%= sidebar_current("docs-selectel-resource-dbaas-logical-replication-slot-v1") %>>
+              <a href="/docs/providers/selectel/r/selectel_dbaas_logical-replication-slot_v1.html">selectel_dbaas_logical_replication_slot_v1</a>
+            </li>
           </ul>
         </li>
 


### PR DESCRIPTION
- Added resource to create logical replication slots for PostgreSQL - `selectel_dbaas_postgresql_logical_replication_slot_v1`
- Updated dbaas-go version to support logical replication slots API
- Added tests for logical replication slots resources

For: #214