### PR TITLE
update: golang to 1.20

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -14,15 +14,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: '1.20'
 
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_wrapper: false
 

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.20
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v1

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,7 +20,6 @@ jobs:
           check-latest: true
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.50.1
-          skip-go-installation: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.20
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.20
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.44
+          version: v1.50.1
           skip-go-installation: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: '1.20'
+          check-latest: true
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,9 +17,8 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: '1.20'
-          check-latest: true
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.50.1
+          version: v1.51.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,15 +15,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Unshallow
         run: git fetch --prune --unshallow
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: '1.20'
 
       - name: Import GPG key
         id: import_gpg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.20
 
       - name: Import GPG key
         id: import_gpg

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.20
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: '1.20'
 
       - name: Run test
         run: make test

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.20
 
       - name: Run test
         run: make test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ run:
 
 linters:
   fast: false
+  disable-all: true
   enable:
     - asciicheck
     - bodyclose

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,6 @@ linters:
   enable:
     - asciicheck
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - dupl
@@ -25,15 +24,12 @@ linters:
     - gofumpt
     - goheader
     - goimports
-    - golint
     - gomodguard
     - goprintffuncname
     - gosec
     - gosimple
     - govet
     - ineffassign
-    - interfacer
-    - maligned
     - misspell
     - nakedret
     - nlreturn
@@ -41,15 +37,13 @@ linters:
     - nolintlint
     - prealloc
     - rowserrcheck
-    - scopelint
+    - revive
     - sqlclosecheck
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unused
-    - varcheck
     - whitespace
 
 linters-settings:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Requirements
 ------------
 
 -	[Terraform](https://www.terraform.io/downloads.html) 0.12.x
--	[Go](https://golang.org/doc/install) 1.17 (to build the provider plugin)
+-	[Go](https://golang.org/doc/install) 1.20 (to build the provider plugin)
 
 Building The Provider
 ---------------------

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/terraform-providers/terraform-provider-selectel
 
-go 1.17
+go 1.20
 
 require (
 	github.com/hashicorp/go-retryablehttp v0.6.6

--- a/go.sum
+++ b/go.sum
@@ -219,7 +219,6 @@ github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/jarcoal/httpmock v1.2.0 h1:gSvTxxFR/MEMfsGrvRbdfpRUMBStovlSRLw0Ep1bwwc=
-github.com/jarcoal/httpmock v1.2.0/go.mod h1:oCoTsnAz4+UoOUIf5lJOWV2QQIW5UoeUI6aM2YnWAZk=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
@@ -257,7 +256,6 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW10=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
-github.com/maxatome/go-testdeep v1.11.0/go.mod h1:011SgQ6efzZYAen6fDn4BqQ+lUR72ysdyKe7Dyogw70=
 github.com/mitchellh/cli v1.1.2/go.mod h1:6iaV0fGdElS6dPBx0EApTxHrcWvmJphyh2n8YBLPPZ4=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=

--- a/scripts/golangci_lint_check.sh
+++ b/scripts/golangci_lint_check.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 echo "==> Running golangci-lint..."
-golangci-lint -v run ./...
+golangci-lint run ./...
 if [[ $? -ne 0 ]]; then
     echo ""
     echo "Golangci-lint found suspicious constructs."

--- a/scripts/golangci_lint_check.sh
+++ b/scripts/golangci_lint_check.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 echo "==> Running golangci-lint..."
-golangci-lint run ./...
+golangci-lint -v run ./...
 if [[ $? -ne 0 ]]; then
     echo ""
     echo "Golangci-lint found suspicious constructs."

--- a/selectel/dbaas.go
+++ b/selectel/dbaas.go
@@ -156,7 +156,8 @@ func flavorHashSetFunc() schema.SchemaSetFunc {
 }
 
 func waitForDBaaSDatastoreV1ActiveState(
-	ctx context.Context, client *dbaas.API, datastoreID string, timeout time.Duration) error {
+	ctx context.Context, client *dbaas.API, datastoreID string, timeout time.Duration,
+) error {
 	pending := []string{
 		string(dbaas.StatusPendingCreate),
 		string(dbaas.StatusPendingUpdate),
@@ -435,7 +436,8 @@ func validateDatastoreType(ctx context.Context, expectedDatastoreTypeEngine stri
 }
 
 func waitForDBaaSDatabaseV1ActiveState(
-	ctx context.Context, client *dbaas.API, databaseID string, timeout time.Duration) error {
+	ctx context.Context, client *dbaas.API, databaseID string, timeout time.Duration,
+) error {
 	pending := []string{
 		string(dbaas.StatusPendingCreate),
 		string(dbaas.StatusPendingUpdate),
@@ -504,7 +506,8 @@ func dbaasDatabaseV1LocaleDiffSuppressFunc(k, old, new string, d *schema.Resourc
 // Users
 
 func waitForDBaaSUserV1ActiveState(
-	ctx context.Context, client *dbaas.API, userID string, timeout time.Duration) error {
+	ctx context.Context, client *dbaas.API, userID string, timeout time.Duration,
+) error {
 	pending := []string{
 		string(dbaas.StatusPendingCreate),
 		string(dbaas.StatusPendingUpdate),

--- a/selectel/domains.go
+++ b/selectel/domains.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	domainsV1DefaultRetryWaitMin = time.Second
+	domainsV1DefaultRetryWaitMin = time.Second //nolint:revive
 	domainsV1DefaultRetryWaitMax = 5 * time.Second
 	domainsV1DefaultRetry        = 5
 )

--- a/selectel/mks.go
+++ b/selectel/mks.go
@@ -57,7 +57,8 @@ func getMKSClusterV1Endpoint(region string) (endpoint string) {
 }
 
 func waitForMKSClusterV1ActiveState(
-	ctx context.Context, client *v1.ServiceClient, clusterID string, timeout time.Duration) error {
+	ctx context.Context, client *v1.ServiceClient, clusterID string, timeout time.Duration,
+) error {
 	pending := []string{
 		string(cluster.StatusPendingCreate),
 		string(cluster.StatusPendingUpdate),
@@ -90,7 +91,8 @@ func waitForMKSClusterV1ActiveState(
 }
 
 func mksClusterV1StateRefreshFunc(
-	ctx context.Context, client *v1.ServiceClient, clusterID string) resource.StateRefreshFunc {
+	ctx context.Context, client *v1.ServiceClient, clusterID string,
+) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		c, _, err := cluster.Get(ctx, client, clusterID)
 		if err != nil {

--- a/selectel/resource_selectel_dbaas_extension_v1.go
+++ b/selectel/resource_selectel_dbaas_extension_v1.go
@@ -188,7 +188,8 @@ func resourceDBaaSExtensionV1ImportState(_ context.Context, d *schema.ResourceDa
 }
 
 func waitForDBaaSExtensionV1ActiveState(
-	ctx context.Context, client *dbaas.API, extensionID string, timeout time.Duration) error {
+	ctx context.Context, client *dbaas.API, extensionID string, timeout time.Duration,
+) error {
 	pending := []string{
 		string(dbaas.StatusPendingCreate),
 		string(dbaas.StatusPendingUpdate),

--- a/selectel/resource_selectel_dbaas_grant_v1.go
+++ b/selectel/resource_selectel_dbaas_grant_v1.go
@@ -194,7 +194,8 @@ func resourceDBaaSGrantV1ImportState(_ context.Context, d *schema.ResourceData, 
 }
 
 func waitForDBaaSGrantV1ActiveState(
-	ctx context.Context, client *dbaas.API, grantID string, timeout time.Duration) error {
+	ctx context.Context, client *dbaas.API, grantID string, timeout time.Duration,
+) error {
 	pending := []string{
 		string(dbaas.StatusPendingCreate),
 		string(dbaas.StatusPendingUpdate),


### PR DESCRIPTION
This PR closes #222

Changes:

- update: golang to v1.20,  golangci-lint to 1.51.1, updated to v3 actions: go-setup, checkout, golangci-lint-action
- change: golangci-lint.yml, remove deprecated linters
- fixed: linter issues

