### PR TITLE
CRaaS V1: add registry resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.tfstate
 *.tfstate.backup
 *.tfstate.lock.info
+*.terraform.lock.hcl
 *.log
 *.json
 *.yaml

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,7 @@ linters:
     - bodyclose
     - depguard
     - dogsled
-    - dupl
+    # - dupl
     - errcheck
     - exhaustive
     - exportloopref

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,6 @@ linters:
     - bodyclose
     - depguard
     - dogsled
-    # - dupl
     - errcheck
     - exhaustive
     - exportloopref

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/hashicorp/go-retryablehttp v0.6.6
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
+	github.com/selectel/craas-go v0.3.0
 	github.com/selectel/dbaas-go v0.8.0
 	github.com/selectel/domains-go v0.4.0
 	github.com/selectel/go-selvpcclient/v2 v2.1.1

--- a/go.sum
+++ b/go.sum
@@ -164,6 +164,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
+github.com/selectel/craas-go v0.3.0 h1:tXiw3LNN+ZVV0wZdeBBXX6u8kMuA5PV/5W1uYqV0yXg=
+github.com/selectel/craas-go v0.3.0/go.mod h1:9RAUn9PdMITP4I3GAade6v2hjB2j3lo3J2dDlG5SLYE=
 github.com/selectel/dbaas-go v0.8.0 h1:9JBfCWTi6g6RGksyNtNwfrc8vQz9evtQ8zjx0wGrPTE=
 github.com/selectel/dbaas-go v0.8.0/go.mod h1:8D945oFzpx94v08zIb4s1bRTPCdPoNVnBu4umMYFJrQ=
 github.com/selectel/domains-go v0.4.0 h1:mVUeJK8oW9XMizft7Vu4OCyvjbzq4+o+zHgzJ2ZxnIY=

--- a/selectel/craas.go
+++ b/selectel/craas.go
@@ -1,0 +1,57 @@
+package selectel
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	v1 "github.com/selectel/craas-go/pkg"
+	"github.com/selectel/craas-go/pkg/v1/registry"
+)
+
+const craasV1Endpoint = "https://cr.selcloud.ru/api/v1"
+
+func waitForCRaaSRegistryV1StableState(
+	ctx context.Context, client *v1.ServiceClient, registryID string, timeout time.Duration,
+) error {
+	pending := []string{
+		string(registry.StatusCreating),
+		string(registry.StatusDeleting),
+		string(registry.StatusGC),
+	}
+	target := []string{
+		string(registry.StatusActive),
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      pending,
+		Target:       target,
+		Timeout:      timeout,
+		Refresh:      craasRegistryV1StateRefreshFunc(ctx, client, registryID),
+		Delay:        1 * time.Second,
+		PollInterval: 1 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmt.Errorf(
+			"error waiting for registry %s to achieve a stable state: %s",
+			registryID, err)
+	}
+
+	return nil
+}
+
+func craasRegistryV1StateRefreshFunc(
+	ctx context.Context, client *v1.ServiceClient, registryID string,
+) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		r, _, err := registry.Get(ctx, client, registryID)
+		if err != nil {
+			return nil, "", err
+		}
+
+		return r, string(r.Status), nil
+	}
+}

--- a/selectel/import_selectel_craas_registry_v1_test.go
+++ b/selectel/import_selectel_craas_registry_v1_test.go
@@ -1,9 +1,10 @@
 package selectel
 
 import (
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"testing"
 )
 
 func TestAccCRaaSRegistryV1ImportBasic(t *testing.T) {

--- a/selectel/import_selectel_craas_registry_v1_test.go
+++ b/selectel/import_selectel_craas_registry_v1_test.go
@@ -1,0 +1,30 @@
+package selectel
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"testing"
+)
+
+func TestAccCRaaSRegistryV1ImportBasic(t *testing.T) {
+	resourceName := "selectel_craas_registry_v1.registry_tf_acc_test_1"
+	projectName := acctest.RandomWithPrefix("tf-acc")
+	registryName := acctest.RandomWithPrefix("tf-acc-reg")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccSelectelPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckVPCV2ProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCRaaSRegistryV1Basic(projectName, registryName),
+				Check:  testAccCheckSelectelCRaaSImportEnv(resourceName),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/selectel/provider.go
+++ b/selectel/provider.go
@@ -36,6 +36,7 @@ const (
 	objectFeatureGates            = "feature-gates"
 	objectAdmissionControllers    = "admission-controllers"
 	objectLogicalReplicationSlot  = "logical-replication-slot"
+	objectRegistry                = "registry"
 )
 
 // This is a global MutexKV for use within this plugin.
@@ -110,6 +111,7 @@ func Provider() *schema.Provider {
 			"selectel_dbaas_postgresql_extension_v1":                resourceDBaaSPostgreSQLExtensionV1(),
 			"selectel_dbaas_prometheus_metric_token_v1":             resourceDBaaSPrometheusMetricTokenV1(),
 			"selectel_dbaas_postgresql_logical_replication_slot_v1": resourceDBaaSPostgreSQLLogicalReplicationSlotV1(),
+			"selectel_craas_registry_v1":                            resourceCRaaSRegistryV1(),
 		},
 		ConfigureContextFunc: configureProvider,
 	}

--- a/selectel/provider_test.go
+++ b/selectel/provider_test.go
@@ -65,3 +65,27 @@ func testAccCheckSelectelImportEnv(resourceName string) resource.TestCheckFunc {
 		return nil
 	}
 }
+
+func testAccCheckSelectelCRaaSImportEnv(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+		if rs.Primary.ID == "" {
+			return errors.New("no ID is set")
+		}
+
+		var projectID string
+
+		if v, ok := rs.Primary.Attributes["project_id"]; ok {
+			projectID = v
+		}
+
+		if err := os.Setenv("SEL_PROJECT_ID", projectID); err != nil {
+			return fmt.Errorf("error setting SEL_PROJECT_ID: %s", err)
+		}
+
+		return nil
+	}
+}

--- a/selectel/resource_selectel_craas_registry_v1.go
+++ b/selectel/resource_selectel_craas_registry_v1.go
@@ -1,0 +1,177 @@
+package selectel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	v1 "github.com/selectel/craas-go/pkg"
+	"github.com/selectel/craas-go/pkg/v1/registry"
+	"github.com/selectel/go-selvpcclient/v2/selvpcclient/resell/v2/tokens"
+)
+
+func resourceCRaaSRegistryV1() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCRaaSRegistryV1Create,
+		ReadContext:   resourceCRaaSRegistryV1Read,
+		DeleteContext: resourceCRaaSRegistryV1Delete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceCRaaSRegistryV1ImportState,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceCRaaSRegistryV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	resellV2Client := config.resellV2Client()
+	tokenOpts := tokens.TokenOpts{
+		ProjectID: d.Get("project_id").(string),
+	}
+
+	log.Print(msgCreate(objectToken, tokenOpts))
+	token, _, err := tokens.Create(ctx, resellV2Client, tokenOpts)
+	if err != nil {
+		return diag.FromErr(errCreatingObject(objectToken, err))
+	}
+
+	craasClient := v1.NewCRaaSClientV1(token.ID, craasV1Endpoint)
+	name := d.Get("name").(string)
+
+	log.Print(msgCreate(objectRegistry, name))
+	newRegistry, _, err := registry.Create(ctx, craasClient, name)
+	if err != nil {
+		return diag.FromErr(errCreatingObject(objectRegistry, err))
+	}
+
+	log.Printf("[DEBUG] Waiting for registry %s to achieve a stable state", newRegistry.ID)
+	timeout := d.Timeout(schema.TimeoutCreate)
+	err = waitForCRaaSRegistryV1StableState(ctx, craasClient, newRegistry.ID, timeout)
+	if err != nil {
+		return diag.FromErr(errCreatingObject(objectRegistry, err))
+	}
+
+	d.SetId(newRegistry.ID)
+
+	return resourceCRaaSRegistryV1Read(ctx, d, meta)
+}
+
+func resourceCRaaSRegistryV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	resellV2Client := config.resellV2Client()
+	tokenOpts := tokens.TokenOpts{
+		ProjectID: d.Get("project_id").(string),
+	}
+
+	log.Print(msgCreate(objectToken, tokenOpts))
+	token, _, err := tokens.Create(ctx, resellV2Client, tokenOpts)
+	if err != nil {
+		return diag.FromErr(errCreatingObject(objectToken, err))
+	}
+
+	craasClient := v1.NewCRaaSClientV1(token.ID, craasV1Endpoint)
+
+	log.Print(msgGet(objectRegistry, d.Id()))
+	craasRegistry, response, err := registry.Get(ctx, craasClient, d.Id())
+	if err != nil {
+		if response != nil {
+			if response.StatusCode == http.StatusNotFound {
+				d.SetId("")
+				return nil
+			}
+		}
+
+		return diag.FromErr(errGettingObject(objectRegistry, d.Id(), err))
+	}
+
+	d.Set("name", craasRegistry.Name)
+	d.Set("status", craasRegistry.Status)
+
+	return nil
+}
+
+func resourceCRaaSRegistryV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	resellV2Client := config.resellV2Client()
+	tokenOpts := tokens.TokenOpts{
+		ProjectID: d.Get("project_id").(string),
+	}
+
+	log.Print(msgCreate(objectToken, tokenOpts))
+	token, _, err := tokens.Create(ctx, resellV2Client, tokenOpts)
+	if err != nil {
+		return diag.FromErr(errCreatingObject(objectToken, err))
+	}
+
+	craasClient := v1.NewCRaaSClientV1(token.ID, craasV1Endpoint)
+
+	log.Print(msgDelete(objectRegistry, d.Id()))
+	_, err = registry.Delete(ctx, craasClient, d.Id())
+	if err != nil {
+		return diag.FromErr(errDeletingObject(objectRegistry, d.Id(), err))
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{strconv.Itoa(http.StatusOK)},
+		Target:  []string{strconv.Itoa(http.StatusNotFound)},
+		Timeout: d.Timeout(schema.TimeoutDelete),
+		Refresh: func() (result interface{}, state string, err error) {
+			result, response, err := registry.Get(ctx, craasClient, d.Id())
+			if err != nil {
+				if response != nil {
+					return result, strconv.Itoa(response.StatusCode), nil
+				}
+
+				return nil, "", err
+			}
+
+			return result, strconv.Itoa(response.StatusCode), err
+		},
+		Delay:        1 * time.Second,
+		PollInterval: 1 * time.Second,
+	}
+
+	log.Printf("[DEBUG] Waiting for registry %s to become deleted", d.Id())
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error waiting for registry %s to become deleted: %s", d.Id(), err))
+	}
+
+	return nil
+}
+
+func resourceCRaaSRegistryV1ImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	config := meta.(*Config)
+	if config.ProjectID == "" {
+		return nil, errors.New("SEL_PROJECT_ID must be set for the CRaaS registry resource import")
+	}
+	d.Set("project_id", config.ProjectID)
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/selectel/resource_selectel_craas_registry_v1_test.go
+++ b/selectel/resource_selectel_craas_registry_v1_test.go
@@ -1,0 +1,101 @@
+package selectel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	v1 "github.com/selectel/craas-go/pkg"
+	"github.com/selectel/craas-go/pkg/v1/registry"
+	"github.com/selectel/go-selvpcclient/v2/selvpcclient/resell/v2/projects"
+	"github.com/selectel/go-selvpcclient/v2/selvpcclient/resell/v2/tokens"
+	"testing"
+)
+
+func TestAccCRaaSRegistryV1Basic(t *testing.T) {
+	var (
+		project       projects.Project
+		craasRegistry registry.Registry
+	)
+
+	projectName := acctest.RandomWithPrefix("tf-acc")
+	registryName := acctest.RandomWithPrefix("tf-acc-reg")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccSelectelPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckVPCV2ProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCRaaSRegistryV1Basic(projectName, registryName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVPCV2ProjectExists("selectel_vpc_project_v2.project_tf_acc_test_1", &project),
+					testAccCheckCRaaSRegistryV1Exists("selectel_craas_registry_v1.registry_tf_acc_test_1", &craasRegistry),
+					resource.TestCheckResourceAttr("selectel_craas_registry_v1.registry_tf_acc_test_1", "name", registryName),
+					resource.TestCheckResourceAttr("selectel_craas_registry_v1.registry_tf_acc_test_1", "status", "ACTIVE"),
+				),
+			},
+		},
+	})
+
+}
+
+func testAccCheckCRaaSRegistryV1Exists(n string, craasRegistry *registry.Registry) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("no ID is set")
+		}
+
+		var projectID string
+		if id, ok := rs.Primary.Attributes["project_id"]; ok {
+			projectID = id
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		resellV2Client := config.resellV2Client()
+		ctx := context.Background()
+
+		tokenOpts := tokens.TokenOpts{
+			ProjectID: projectID,
+		}
+		token, _, err := tokens.Create(ctx, resellV2Client, tokenOpts)
+		if err != nil {
+			return errCreatingObject(objectToken, err)
+		}
+
+		craasClient := v1.NewCRaaSClientV1(token.ID, craasV1Endpoint)
+		foundRegistry, _, err := registry.Get(ctx, craasClient, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if foundRegistry.ID != rs.Primary.ID {
+			return errors.New("registry not found")
+		}
+
+		*craasRegistry = *foundRegistry
+
+		return nil
+	}
+}
+
+func testAccCRaaSRegistryV1Basic(projectName, registryName string) string {
+	return fmt.Sprintf(`
+resource "selectel_vpc_project_v2" "project_tf_acc_test_1" {
+  name = "%s"
+}
+
+resource "selectel_craas_registry_v1" "registry_tf_acc_test_1" {
+  name       = "%s"
+  project_id = selectel_vpc_project_v2.project_tf_acc_test_1.id
+}
+
+`, projectName, registryName)
+}

--- a/selectel/resource_selectel_craas_registry_v1_test.go
+++ b/selectel/resource_selectel_craas_registry_v1_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -11,7 +13,6 @@ import (
 	"github.com/selectel/craas-go/pkg/v1/registry"
 	"github.com/selectel/go-selvpcclient/v2/selvpcclient/resell/v2/projects"
 	"github.com/selectel/go-selvpcclient/v2/selvpcclient/resell/v2/tokens"
-	"testing"
 )
 
 func TestAccCRaaSRegistryV1Basic(t *testing.T) {
@@ -39,7 +40,6 @@ func TestAccCRaaSRegistryV1Basic(t *testing.T) {
 			},
 		},
 	})
-
 }
 
 func testAccCheckCRaaSRegistryV1Exists(n string, craasRegistry *registry.Registry) resource.TestCheckFunc {

--- a/website/docs/r/craas_registry_v1.html.markdown
+++ b/website/docs/r/craas_registry_v1.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "selectel"
+page_title: "Selectel: selectel_craas_registry_v1"
+sidebar_current: "docs-selectel-resource-craas-registry-v1"
+description: |-
+Manages a V1 registry resource within Selectel Container Registry Service.
+---
+
+# selectel\_craas\_registry\_v1
+
+Manages a V1 registry resource within Selectel Container Registry Service.
+
+## Example usage
+
+```hcl
+resource "selectel_vpc_project_v2" "project_1" {
+  name = "my-first-project"
+}
+
+resource "selectel_craas_registry_v1" "registry_1" {
+  name       = "my-first-registry"
+  project_id = selectel_vpc_project_v2.project_1.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the registry.
+  Changing this creates a new registry.
+
+* `project_id` - (Required) An associated Selectel VPC project.
+  Changing this creates a new registry.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `status` - Shows the current status of the registry.
+
+## Import
+
+Registry can be imported using the `id`, e.g.
+
+```shell
+$ env SEL_TOKEN=SELECTEL_API_TOKEN SEL_PROJECT_ID=SELECTEL_VPC_PROJECT_ID terraform import selectel_craas_registry_v1.registry_1 939506d6-7621-4581-b673-eacf3db30f5b
+```

--- a/website/selectel.erb
+++ b/website/selectel.erb
@@ -142,6 +142,15 @@
           </ul>
         </li>
 
+        <li<%= sidebar_current("docs-selectel-resource-craas") %>>
+          <a href="#">CRaaS Resources</a>
+          <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-selectel-resource-craas-registry-v1") %>>
+              <a href="/docs/providers/selectel/r/craas_registry_v1.html">selectel_craas_registry_v1</a>
+            </li>
+          </ul>
+        </li>
+
       </ul>
     </div>
   <% end %>


### PR DESCRIPTION
Implement `selectel_craas_registry_v1` resource with acceptance tests.

Add helper functions in `craas.go`.

Update the documentation.

Update .gitignore file.

All new acceptance tests are done:
```
=== RUN   TestAccCRaaSRegistryV1ImportBasic
--- PASS: TestAccCRaaSRegistryV1ImportBasic (55.13s)
=== RUN   TestAccCRaaSRegistryV1Basic
--- PASS: TestAccCRaaSRegistryV1Basic (62.31s)
PASS
ok      github.com/terraform-providers/terraform-provider-selectel/selectel     117.621s
```