### PR TITLE
Add backup retention days parameter to datastore

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.6.6
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/selectel/craas-go v0.3.0
-	github.com/selectel/dbaas-go v0.8.0
+	github.com/selectel/dbaas-go v0.9.0
 	github.com/selectel/domains-go v0.4.0
 	github.com/selectel/go-selvpcclient/v2 v2.1.1
 	github.com/selectel/mks-go v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -168,6 +168,8 @@ github.com/selectel/craas-go v0.3.0 h1:tXiw3LNN+ZVV0wZdeBBXX6u8kMuA5PV/5W1uYqV0y
 github.com/selectel/craas-go v0.3.0/go.mod h1:9RAUn9PdMITP4I3GAade6v2hjB2j3lo3J2dDlG5SLYE=
 github.com/selectel/dbaas-go v0.8.0 h1:9JBfCWTi6g6RGksyNtNwfrc8vQz9evtQ8zjx0wGrPTE=
 github.com/selectel/dbaas-go v0.8.0/go.mod h1:8D945oFzpx94v08zIb4s1bRTPCdPoNVnBu4umMYFJrQ=
+github.com/selectel/dbaas-go v0.9.0 h1:IAmiyxkRtfLZg1JUdIhcsE5jpdBvsZibPCqyhB+yV30=
+github.com/selectel/dbaas-go v0.9.0/go.mod h1:8D945oFzpx94v08zIb4s1bRTPCdPoNVnBu4umMYFJrQ=
 github.com/selectel/domains-go v0.4.0 h1:mVUeJK8oW9XMizft7Vu4OCyvjbzq4+o+zHgzJ2ZxnIY=
 github.com/selectel/domains-go v0.4.0/go.mod h1:AhXhwyMSTkpEWFiBLUvzFP76W+WN+ZblwmjLJLt7y58=
 github.com/selectel/go-selvpcclient/v2 v2.1.1 h1:dW8AEDeDkMCBb94NMCiNq/vK4n+f6kcGKsUuMwBcq+A=

--- a/selectel/resource_selectel_dbaas_redis_datastore_v1.go
+++ b/selectel/resource_selectel_dbaas_redis_datastore_v1.go
@@ -83,6 +83,11 @@ func resourceDBaaSRedisDatastoreV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"backup_retention_days": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Number of days to retain backups.",
+			},
 			"connections": {
 				Type:     schema.TypeMap,
 				Computed: true,
@@ -202,6 +207,11 @@ func resourceDBaaSRedisDatastoreV1Create(ctx context.Context, d *schema.Resource
 		datastoreCreateOpts.RedisPassword = redisPassword.(string)
 	}
 
+	backupRetentionDays, ok := d.GetOk("backup_retention_days")
+	if ok {
+		datastoreCreateOpts.BackupRetentionDays = backupRetentionDays.(int)
+	}
+
 	log.Print(msgCreate(objectDatastore, datastoreCreateOpts))
 	datastore, err := dbaasClient.CreateDatastore(ctx, datastoreCreateOpts)
 	if err != nil {
@@ -292,6 +302,12 @@ func resourceDBaaSRedisDatastoreV1Update(ctx context.Context, d *schema.Resource
 	}
 	if d.HasChange("redis_password") {
 		err := updateRedisDatastorePassword(ctx, d, dbaasClient)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if d.HasChange("backup_retention_days") {
+		err := updateDatastoreBackups(ctx, d, dbaasClient)
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/website/docs/r/dbaas_datastore_v1.html.markdown
+++ b/website/docs/r/dbaas_datastore_v1.html.markdown
@@ -92,6 +92,8 @@ The following arguments are supported:
 
 * `config` - (Optional) Configuration parameters for the datastore.
 
+* `backup_retention_days` - (Optional) Number of days to retain backups.
+
 * `redis_password` - (Optional) Password for the Redis datastore (only for Redis datastores)
 
 **flavor**

--- a/website/docs/r/dbaas_mysql_datastore_v1.html.markdown
+++ b/website/docs/r/dbaas_mysql_datastore_v1.html.markdown
@@ -82,6 +82,8 @@ The following arguments are supported:
 
 * `config` - (Optional) Configuration parameters for the datastore.
 
+* `backup_retention_days` - (Optional) Number of days to retain backups.
+
 **flavor**
 
 - `vcpus` - (Required) CPU count for the flavor.

--- a/website/docs/r/dbaas_postgresql_datastore_v1.html.markdown
+++ b/website/docs/r/dbaas_postgresql_datastore_v1.html.markdown
@@ -90,6 +90,8 @@ The following arguments are supported:
 
 * `config` - (Optional) Configuration parameters for the datastore.
 
+* `backup_retention_days` - (Optional) Number of days to retain backups.
+
 **flavor**
 
 - `vcpus` - (Required) CPU count for the flavor.

--- a/website/docs/r/dbaas_redis_datastore_v1.html.markdown
+++ b/website/docs/r/dbaas_redis_datastore_v1.html.markdown
@@ -83,6 +83,8 @@ The following arguments are supported:
 
 * `config` - (Optional) Configuration parameters for the datastore.
 
+* `backup_retention_days` - (Optional) Number of days to retain backups.
+
 * `redis_password` - (Required) Password for the Redis datastore
 
 **restore**


### PR DESCRIPTION
To retain datastore backups more than seven days, we have to add new parameter that contains the number of backups retentions days