### PR TITLE
CRaaS V1: extend schema for registry resource

### DIFF
--- a/selectel/craas.go
+++ b/selectel/craas.go
@@ -11,8 +11,9 @@ import (
 )
 
 const (
-	craasV1Endpoint      = "https://cr.selcloud.ru/api/v1"
-	craasV1TokenUsername = "token"
+	craasV1Endpoint         = "https://cr.selcloud.ru/api/v1"
+	craasV1RegistryHostName = "cr.selcloud.ru"
+	craasV1TokenUsername    = "token"
 )
 
 func waitForCRaaSRegistryV1StableState(

--- a/selectel/resource_selectel_craas_registry_v1.go
+++ b/selectel/resource_selectel_craas_registry_v1.go
@@ -44,6 +44,10 @@ func resourceCRaaSRegistryV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -112,6 +116,7 @@ func resourceCRaaSRegistryV1Read(ctx context.Context, d *schema.ResourceData, me
 
 	d.Set("name", craasRegistry.Name)
 	d.Set("status", craasRegistry.Status)
+	d.Set("endpoint", fmt.Sprintf("%s/%s", craasV1RegistryHostName, craasRegistry.Name))
 
 	return nil
 }

--- a/selectel/resource_selectel_craas_registry_v1_test.go
+++ b/selectel/resource_selectel_craas_registry_v1_test.go
@@ -23,6 +23,7 @@ func TestAccCRaaSRegistryV1Basic(t *testing.T) {
 
 	projectName := acctest.RandomWithPrefix("tf-acc")
 	registryName := acctest.RandomWithPrefix("tf-acc-reg")
+	registryEndpoint := fmt.Sprintf("%s/%s", craasV1RegistryHostName, registryName)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccSelectelPreCheck(t) },
@@ -36,6 +37,7 @@ func TestAccCRaaSRegistryV1Basic(t *testing.T) {
 					testAccCheckCRaaSRegistryV1Exists("selectel_craas_registry_v1.registry_tf_acc_test_1", &craasRegistry),
 					resource.TestCheckResourceAttr("selectel_craas_registry_v1.registry_tf_acc_test_1", "name", registryName),
 					resource.TestCheckResourceAttr("selectel_craas_registry_v1.registry_tf_acc_test_1", "status", "ACTIVE"),
+					resource.TestCheckResourceAttr("selectel_craas_registry_v1.registry_tf_acc_test_1", "endpoint", registryEndpoint),
 				),
 			},
 		},

--- a/website/docs/r/craas_registry_v1.html.markdown
+++ b/website/docs/r/craas_registry_v1.html.markdown
@@ -39,6 +39,8 @@ The following attributes are exported:
 
 * `status` - Shows the current status of the registry.
 
+* `endpoint` - Represents the endpoint of the container registry. Ex: `cr.selcloud.ru/my-registry`
+
 ## Import
 
 Registry can be imported using the `id`, e.g.


### PR DESCRIPTION
Add `endpoint` attribute to the `selectel_craas_registry_v1` resource.

Update the related acceptance test.

Update the documentation.

For #218 