### PR TITLE
Use default value for the dbaas lc_* database fields

### DIFF
--- a/selectel/schema_selectel_dbaas_postgresql_database_v1.go
+++ b/selectel/schema_selectel_dbaas_postgresql_database_v1.go
@@ -11,26 +11,17 @@ func resourceDBaaSPostgreSQLDatabaseV1Schema() map[string]*schema.Schema {
 		Optional: true,
 	}
 	databaseSchema["lc_collate"] = &schema.Schema{
-		Type:             schema.TypeString,
-		Optional:         true,
-		ForceNew:         true,
-		DiffSuppressFunc: dbaasDatabaseV1LocaleDiffSuppressFunc,
+		Type:     schema.TypeString,
+		Optional: true,
+		ForceNew: true,
+		Default:  "C",
 	}
 	databaseSchema["lc_ctype"] = &schema.Schema{
-		Type:             schema.TypeString,
-		Optional:         true,
-		ForceNew:         true,
-		DiffSuppressFunc: dbaasDatabaseV1LocaleDiffSuppressFunc,
+		Type:     schema.TypeString,
+		Optional: true,
+		ForceNew: true,
+		Default:  "C",
 	}
 
 	return databaseSchema
-}
-
-func dbaasDatabaseV1LocaleDiffSuppressFunc(_, old, new string, _ *schema.ResourceData) bool {
-	// The default locale value - C is the same as null value, so we need to suppress
-	if old == "C" && new == "" {
-		return true
-	}
-
-	return false
 }


### PR DESCRIPTION
Use default value instead of DiffSuppressFunc because of different behavior of the PostgreSQL and PostgreSQL-1C databases