### PR TITLE
Added datasources for domains_v2 with docs

### DIFF
--- a/selectel/data_source_selectel_domains_rrset_v2.go
+++ b/selectel/data_source_selectel_domains_rrset_v2.go
@@ -1,0 +1,88 @@
+package selectel
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceDomainsRRSetV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDomainsRRSetV2Read,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"zone_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"comment": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"managed_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ttl": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"records": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"content": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"disabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceDomainsRRSetV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := getDomainsV2Client(d, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	rrsetName := d.Get("name").(string)
+	zoneID := d.Get("zone_id").(string)
+	rrsetType := d.Get("type").(string)
+
+	zoneIDWithRRSetNameAndType := fmt.Sprintf("zone_id: %s, rrset_name: %s, rrset_type: %s", zoneID, rrsetName, rrsetType)
+	log.Println(msgGet(objectRRSet, zoneIDWithRRSetNameAndType))
+
+	rrset, err := getRRSetByNameAndType(ctx, client, zoneID, rrsetName, rrsetType)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = setRRSetToResourceData(d, rrset)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}

--- a/selectel/data_source_selectel_domains_rrset_v2_test.go
+++ b/selectel/data_source_selectel_domains_rrset_v2_test.go
@@ -1,0 +1,48 @@
+package selectel
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	domainsV2 "github.com/selectel/domains-go/pkg/v2"
+)
+
+func TestAccDomainsRRSetV2DataSourceBasic(t *testing.T) {
+	testProjectName := acctest.RandomWithPrefix("tf-acc")
+	testZoneName := fmt.Sprintf("%s.ru.", acctest.RandomWithPrefix("tf-acc"))
+	testRRSetName := fmt.Sprintf("%[1]s.%[2]s", acctest.RandomWithPrefix("tf-acc"), testZoneName)
+	testRRSetType := domainsV2.TXT
+	testRRSetTTL := 60
+	testRRSetContent := fmt.Sprintf("\"%[1]s\"", acctest.RandString(16))
+	dataSourceRRSetName := fmt.Sprintf("data.selectel_domains_rrset_v2.%[1]s", resourceRRSetName)
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccSelectelPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckDomainsV2RRSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainsRRSetV2DataSourceBasic(testProjectName, resourceRRSetName, testRRSetName, string(testRRSetType), testRRSetContent, testRRSetTTL, resourceZoneName, testZoneName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDomainsRRSetV2ID(dataSourceRRSetName),
+					resource.TestCheckResourceAttr(dataSourceRRSetName, "name", testRRSetName),
+					resource.TestCheckResourceAttr(dataSourceRRSetName, "type", string(testRRSetType)),
+					resource.TestCheckResourceAttrSet(dataSourceRRSetName, "zone_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDomainsRRSetV2DataSourceBasic(projectName, resourceRRSetName, rrsetName, rrsetType, rrsetContent string, ttl int, resourceZoneName, zoneName string) string {
+	return fmt.Sprintf(`
+	%[1]s
+	data "selectel_domains_rrset_v2" %[2]q {
+	  name = selectel_domains_rrset_v2.%[2]s.name
+	  type = selectel_domains_rrset_v2.%[2]s.type
+	  zone_id = selectel_domains_zone_v2.%[3]s.id
+	  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+	}
+`, testAccDomainsRRSetV2WithZoneBasic(projectName, resourceRRSetName, rrsetName, rrsetType, rrsetContent, ttl, resourceZoneName, zoneName), resourceRRSetName, resourceZoneName)
+}

--- a/selectel/data_source_selectel_domains_zone_v2.go
+++ b/selectel/data_source_selectel_domains_zone_v2.go
@@ -1,0 +1,76 @@
+package selectel
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceDomainsZoneV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDomainsZoneV2Read,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"project_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"comment": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"delegation_checked_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"last_check_status": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"last_delegated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"disabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceDomainsZoneV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := getDomainsV2Client(d, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	zoneName := d.Get("name").(string)
+
+	log.Println(msgGet(objectZone, zoneName))
+
+	zone, err := getZoneByName(ctx, client, zoneName)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = setZoneToResourceData(d, zone)
+	if err != nil {
+		return diag.FromErr(errGettingObject(objectZone, zoneName, err))
+	}
+
+	return nil
+}

--- a/selectel/data_source_selectel_domains_zone_v2_test.go
+++ b/selectel/data_source_selectel_domains_zone_v2_test.go
@@ -1,0 +1,38 @@
+package selectel
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDomainsZoneV2DataSourceBasic(t *testing.T) {
+	testProjectName := acctest.RandomWithPrefix("tf-acc")
+	testZoneName := fmt.Sprintf("%s.ru.", acctest.RandomWithPrefix("tf-acc"))
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccSelectelPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckDomainsV2ZoneDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDomainsZoneV2DataSourceBasic(testProjectName, resourceZoneName, testZoneName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDomainsZoneV2Exists(fmt.Sprintf("data.selectel_domains_zone_v2.%[1]s", resourceZoneName)),
+					resource.TestCheckResourceAttr(fmt.Sprintf("data.selectel_domains_zone_v2.%[1]s", resourceZoneName), "name", testZoneName),
+				),
+			},
+		},
+	})
+}
+
+func testAccDomainsZoneV2DataSourceBasic(projectName, resourceName, zoneName string) string {
+	return fmt.Sprintf(`
+	%[1]s
+	data "selectel_domains_zone_v2" %[2]q {
+	  name = selectel_domains_zone_v2.%[2]s.name
+	  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+	}
+`, testAccDomainsZoneV2Basic(projectName, resourceName, zoneName), resourceName, zoneName)
+}

--- a/selectel/provider.go
+++ b/selectel/provider.go
@@ -102,6 +102,8 @@ func Provider() *schema.Provider {
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"selectel_domains_domain_v1":                dataSourceDomainsDomainV1(),
+			"selectel_domains_zone_v2":                  dataSourceDomainsZoneV2(),
+			"selectel_domains_rrset_v2":                 dataSourceDomainsRRSetV2(),
 			"selectel_dbaas_datastore_type_v1":          dataSourceDBaaSDatastoreTypeV1(),
 			"selectel_dbaas_available_extension_v1":     dataSourceDBaaSAvailableExtensionV1(),
 			"selectel_dbaas_flavor_v1":                  dataSourceDBaaSFlavorV1(),

--- a/website/docs/d/domains_rrset_v2.html.markdown
+++ b/website/docs/d/domains_rrset_v2.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # selectel\_domains\_rrset_v2
 
-Provides full information about an RRSet in DNS Hosting (actual). If you want manage an RRSet use [resource selectel_domains_rrset_v2](https://registry.terraform.io/providers/selectel/selectel/latest/docs/resources/domains_rrset_v2). For more information about RRSets, see the [official Selectel documentation](https://docs.selectel.ru/networks-services/dns/records/).
+Provides information about an RRSet in DNS Hosting (actual). For more information about RRSets, see the [official Selectel documentation](https://docs.selectel.ru/networks-services/dns/records/).
 
 ## Example Usage
 

--- a/website/docs/d/domains_rrset_v2.html.markdown
+++ b/website/docs/d/domains_rrset_v2.html.markdown
@@ -1,0 +1,46 @@
+---
+layout: "selectel"
+page_title: "Selectel: selectel_domains_rrset_v2"
+sidebar_current: "docs-selectel-datasource-domains-rrset-v2"
+description: |-
+  Provides information about an RRSet in Selectel DNS Hosting (actual).
+---
+
+# selectel\_domains\_rrset_v2
+
+Provides information about an RRSet in DNS Hosting (actual). For more information about RRSets, see the [official Selectel documentation](https://docs.selectel.ru/networks-services/dns/records/).
+
+## Example Usage
+
+```hcl
+data "selectel_domains_rrset_v2" "rrset_1" {
+  name       = "example.com."
+  type       = "A"
+  zone_id    = selectel_domains_zone_v2.zone_1.id
+  project_id = selectel_vpc_project_v2.project_1.id
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) RRSet name.
+
+* `type` - (Required) RRSet type. Available types are `A`, `AAAA`, `TXT`, `CNAME`, `NS`, `MX`, `SRV`, `SSHFP`, `ALIAS`, `CAA`.
+
+* `zone_id` - (Required) Unique identifier of the zone. Retrieved from the [selectel_domains_zone_v2](https://registry.terraform.io/providers/selectel/selectel/latest/docs/resources/domains_zone_v2) resource.
+
+* `project_id` - (Required) Unique identifier of the associated Cloud Platform project. Retrieved from the [selectel_vpc_project_v2](https://registry.terraform.io/providers/selectel/selectel/latest/docs/resources/vpc_project_v2) resource. Learn more about [Cloud Platform projects](https://docs.selectel.ru/cloud/servers/about/projects/).
+
+## Attributes Reference
+
+* `ttl` - RRSet time-to-live in seconds.
+
+* `comment` - Comment for the RRSet.
+
+* `managed_by` - RRSet owner.
+
+* `records` - List of records in the RRSet.
+  
+  * `content` - Record value.
+
+  * `disabled` - Shows if the record is enabled or disabled.

--- a/website/docs/d/domains_rrset_v2.html.markdown
+++ b/website/docs/d/domains_rrset_v2.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # selectel\_domains\_rrset_v2
 
-Provides information about an RRSet in DNS Hosting (actual). For more information about RRSets, see the [official Selectel documentation](https://docs.selectel.ru/networks-services/dns/records/).
+Provides full information about an RRSet in DNS Hosting (actual). If you want manage an RRSet use [resource selectel_domains_rrset_v2](https://registry.terraform.io/providers/selectel/selectel/latest/docs/resources/domains_rrset_v2). For more information about RRSets, see the [official Selectel documentation](https://docs.selectel.ru/networks-services/dns/records/).
 
 ## Example Usage
 

--- a/website/docs/d/domains_zone_v2.html.markdown
+++ b/website/docs/d/domains_zone_v2.html.markdown
@@ -1,0 +1,42 @@
+---
+layout: "selectel"
+page_title: "Selectel: selectel_domains_zone_v2"
+sidebar_current: "docs-selectel-datasource-domains-zone-v2"
+description: |-
+  Provides information about a zone in Selectel DNS Hosting (actual).
+---
+
+# selectel\_domains\_zone_v2
+
+Provides information about a zone in Selectel DNS Hosting (actual). For more information about zones, see the [official Selectel documentation](https://docs.selectel.ru/networks-services/dns/zones/).
+
+## Example Usage
+
+```hcl
+data "selectel_domains_zone_v2" "zone_1" {
+  name       = "example.com."
+  project_id = selectel_vpc_project_v2.project_1.id
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) Zone name.
+
+* `project_id` - (Required) Unique identifier of the associated Cloud Platform project. Retrieved from the [selectel_vpc_project_v2](https://registry.terraform.io/providers/selectel/selectel/latest/docs/resources/vpc_project_v2) resource. Learn more about [Cloud Platform projects](https://docs.selectel.ru/cloud/servers/about/projects/).
+
+## Attributes Reference
+
+* `comment` - Comment for the zone.
+
+* `created_at` - Time when the zone was created in the RFC 3339 timestamp format.
+
+* `updated_at` - Time when the zone was updated in the RFC 3339 timestamp format.
+
+* `delegation_checked_at` - Time when DNS Hosting checked if the zone was delegated to Selectel NS servers in the RFC 3339 timestamp format.
+
+* `last_check_status` - Zone status retrieved during the last delegation check.
+
+* `last_delegated_at` - Equals to the `delegation_check_at` argument value when the `last_check_status` is `true`.
+
+* `disabled` - Shows if the zone is enabled or disabled.

--- a/website/docs/d/domains_zone_v2.html.markdown
+++ b/website/docs/d/domains_zone_v2.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # selectel\_domains\_zone_v2
 
-Provides full information about a zone in Selectel DNS Hosting (actual). If you want manage a zone use [resource selectel_domains_zone_v2](https://registry.terraform.io/providers/selectel/selectel/latest/docs/resources/domains_zone_v2). For more information about zones, see the [official Selectel documentation](https://docs.selectel.ru/networks-services/dns/zones/).
+Provides information about a zone in Selectel DNS Hosting (actual). For more information about zones, see the [official Selectel documentation](https://docs.selectel.ru/networks-services/dns/zones/).
 
 ## Example Usage
 

--- a/website/docs/d/domains_zone_v2.html.markdown
+++ b/website/docs/d/domains_zone_v2.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # selectel\_domains\_zone_v2
 
-Provides information about a zone in Selectel DNS Hosting (actual). For more information about zones, see the [official Selectel documentation](https://docs.selectel.ru/networks-services/dns/zones/).
+Provides full information about a zone in Selectel DNS Hosting (actual). If you want manage a zone use [resource selectel_domains_zone_v2](https://registry.terraform.io/providers/selectel/selectel/latest/docs/resources/domains_zone_v2). For more information about zones, see the [official Selectel documentation](https://docs.selectel.ru/networks-services/dns/zones/).
 
 ## Example Usage
 

--- a/website/selectel.erb
+++ b/website/selectel.erb
@@ -16,6 +16,12 @@
             <li<%= sidebar_current("docs-selectel-datasource-domains-domain-v1") %>>
               <a href="/docs/providers/selectel/d/domains_domain_v1.html">selectel_domains_domain_v1</a>
             </li>
+            <li<%= sidebar_current("docs-selectel-datasource-domains-zone-v2") %>>
+              <a href="/docs/providers/selectel/d/domains_zone_v2.html">selectel_domains_zone_v2</a>
+            </li>
+            <li<%= sidebar_current("docs-selectel-datasource-domains-rrset-v2") %>>
+              <a href="/docs/providers/selectel/d/domains_rrset_v2.html">selectel_domains_rrset_v2</a>
+            </li>
             <li<%= sidebar_current("docs-selectel-datasource-dbaas-datastore-type-v1") %>>
               <a href="/docs/providers/selectel/d/dbaas_datastore_type_v1.html">selectel_dbaas_datastore_type_v1</a>
             </li>


### PR DESCRIPTION
В [прошлом ПР](https://github.com/selectel/terraform-provider-selectel/pull/249), который включал в себя datasources для работы с zones и rrsets в нашем [DNS Hosting (actual)](https://docs.selectel.ru/networks-services/dns/about-dns/) в последний момент нас заставили их убрать. 
Теперь пришел запрос, что данные сущности необходимы для комфортной работы с нашем терраформ провайдером. 
Делаем новый ПР с добавлением этих сущностей и документации к ним.

Результаты запуска тестов:
```
=== RUN   TestAccDomainsZoneV2DataSourceBasic
--- PASS: TestAccDomainsZoneV2DataSourceBasic (68.31s)
PASS
ok      github.com/terraform-providers/terraform-provider-selectel/selectel     68.317s

=== RUN   TestAccDomainsRRSetV2DataSourceBasic
--- PASS: TestAccDomainsRRSetV2DataSourceBasic (69.36s)
PASS
ok      github.com/terraform-providers/terraform-provider-selectel/selectel     69.372s
```