### PR TITLE
Add GPU without drivers and nvidia device plugin support to MKS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/selectel/domains-go v1.0.2
 	github.com/selectel/go-selvpcclient/v3 v3.1.1
 	github.com/selectel/iam-go v0.2.0
-	github.com/selectel/mks-go v0.14.0
+	github.com/selectel/mks-go v0.15.0
 	github.com/selectel/secretsmanager-go v0.2.1
 	github.com/stretchr/testify v1.8.4
 )

--- a/go.sum
+++ b/go.sum
@@ -172,8 +172,8 @@ github.com/selectel/go-selvpcclient/v3 v3.1.1 h1:C1q2LqqosiapoLpnGITGmysg0YCSQYD
 github.com/selectel/go-selvpcclient/v3 v3.1.1/go.mod h1:NM7IXhh1IzqZ88DOw1Qc5Ez3tULLViXo95l5+rKPuyQ=
 github.com/selectel/iam-go v0.2.0 h1:c6ldpbsa/8R3b29ML5B21FU9oyJ2A2AwBNzCbE+pGN8=
 github.com/selectel/iam-go v0.2.0/go.mod h1:OIAkW7MZK97YUm+uvUgYbgDhkI9SdzTCxwd4yZoOR1o=
-github.com/selectel/mks-go v0.14.0 h1:huNq/oTutPc3ezB8HRqlGN9WJubTDETpNKuIVqcZOn0=
-github.com/selectel/mks-go v0.14.0/go.mod h1:VxtV3dzwgOEzZc+9VMQb9DvxfSlej2ZQ8jnT8kqIGgU=
+github.com/selectel/mks-go v0.15.0 h1:0ytV5DiQAgbojKA0ukBjtwfWBSQh658nF3mhjZTrWj8=
+github.com/selectel/mks-go v0.15.0/go.mod h1:VxtV3dzwgOEzZc+9VMQb9DvxfSlej2ZQ8jnT8kqIGgU=
 github.com/selectel/secretsmanager-go v0.2.1 h1:OSBrA/07lm/Ecpwg59IJHFAoUHZR29oyfwUgTpr/dos=
 github.com/selectel/secretsmanager-go v0.2.1/go.mod h1:DUPexhiJWLTyZEvse7grJWdcA8p8TEI93gNu1dDu7Yg=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/selectel/resource_selectel_mks_nodegroup_v1.go
+++ b/selectel/resource_selectel_mks_nodegroup_v1.go
@@ -159,6 +159,11 @@ func resourceMKSNodegroupV1() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.StringLenBetween(0, 65535),
 			},
+			"install_nvidia_device_plugin": {
+				Type:     schema.TypeBool,
+				Required: true,
+				ForceNew: true,
+			},
 			"nodegroup_type": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -235,18 +240,20 @@ func resourceMKSNodegroupV1Create(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	// Prepare nodegroup create options.
+	installNvidiaDevicePlugin := d.Get("install_nvidia_device_plugin").(bool)
 	createOpts := &nodegroup.CreateOpts{
-		Count:            d.Get("nodes_count").(int),
-		FlavorID:         d.Get("flavor_id").(string),
-		CPUs:             d.Get("cpus").(int),
-		RAMMB:            d.Get("ram_mb").(int),
-		VolumeGB:         d.Get("volume_gb").(int),
-		VolumeType:       d.Get("volume_type").(string),
-		LocalVolume:      d.Get("local_volume").(bool),
-		KeypairName:      d.Get("keypair_name").(string),
-		AffinityPolicy:   d.Get("affinity_policy").(string),
-		AvailabilityZone: d.Get("availability_zone").(string),
-		UserData:         d.Get("user_data").(string),
+		Count:                     d.Get("nodes_count").(int),
+		FlavorID:                  d.Get("flavor_id").(string),
+		CPUs:                      d.Get("cpus").(int),
+		RAMMB:                     d.Get("ram_mb").(int),
+		VolumeGB:                  d.Get("volume_gb").(int),
+		VolumeType:                d.Get("volume_type").(string),
+		LocalVolume:               d.Get("local_volume").(bool),
+		KeypairName:               d.Get("keypair_name").(string),
+		AffinityPolicy:            d.Get("affinity_policy").(string),
+		AvailabilityZone:          d.Get("availability_zone").(string),
+		UserData:                  d.Get("user_data").(string),
+		InstallNvidiaDevicePlugin: &installNvidiaDevicePlugin,
 	}
 
 	projectQuotas, _, err := quotas.GetProjectQuotas(selvpcClient, projectID, region)
@@ -357,6 +364,7 @@ func resourceMKSNodegroupV1Read(ctx context.Context, d *schema.ResourceData, met
 	d.Set("autoscale_max_nodes", mksNodegroup.AutoscaleMaxNodes)
 	d.Set("nodegroup_type", mksNodegroup.NodegroupType)
 	d.Set("user_data", mksNodegroup.UserData)
+	d.Set("install_nvidia_device_plugin", mksNodegroup.InstallNvidiaDevicePlugin)
 
 	if err := d.Set("labels", mksNodegroup.Labels); err != nil {
 		log.Print(errSettingComplexAttr("labels", err))

--- a/selectel/resource_selectel_mks_nodegroup_v1_test.go
+++ b/selectel/resource_selectel_mks_nodegroup_v1_test.go
@@ -46,6 +46,7 @@ func TestAccMKSNodegroupV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "autoscale_min_nodes", "2"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "autoscale_max_nodes", "3"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "user_data", "IyEvYmluL2Jhc2ggLXYKYXB0IC15IHVwZGF0ZQphcHQgLXkgaW5zdGFsbCBtdHI="),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "install_nvidia_device_plugin", "false"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key0", "label-value0"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key1", "label-value1"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key2", "label-value2"),
@@ -76,6 +77,7 @@ func TestAccMKSNodegroupV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "autoscale_min_nodes", "1"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "autoscale_max_nodes", "4"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "user_data", "IyEvYmluL2Jhc2ggLXYKYXB0IC15IHVwZGF0ZQphcHQgLXkgaW5zdGFsbCBtdHI="),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "install_nvidia_device_plugin", "false"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key3", "label-value3"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key4", "label-value4"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.#", "3"),
@@ -104,6 +106,7 @@ func TestAccMKSNodegroupV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "autoscale_min_nodes", "1"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "autoscale_max_nodes", "4"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "user_data", "IyEvYmluL2Jhc2ggLXYKYXB0IC15IHVwZGF0ZQphcHQgLXkgaW5zdGFsbCBtdHI="),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "install_nvidia_device_plugin", "false"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key3", "label-value3"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key4", "label-value4"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.#", "3"),
@@ -132,6 +135,7 @@ func TestAccMKSNodegroupV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "autoscale_min_nodes", "1"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "autoscale_max_nodes", "4"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "user_data", "IyEvYmluL2Jhc2ggLXYKYXB0IC15IHVwZGF0ZQphcHQgLXkgaW5zdGFsbCBtdHI="),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "install_nvidia_device_plugin", "false"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key3", "label-value3"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key4", "label-value4"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.#", "3"),
@@ -216,6 +220,7 @@ resource "selectel_mks_nodegroup_v1" "nodegroup_tf_acc_test_1" {
   autoscale_min_nodes = 2
   autoscale_max_nodes = 3
   user_data           = "IyEvYmluL2Jhc2ggLXYKYXB0IC15IHVwZGF0ZQphcHQgLXkgaW5zdGFsbCBtdHI="
+  install_nvidia_device_plugin = false
   labels = {
     label-key0 = "label-value0"
     label-key1 = "label-value1"
@@ -267,6 +272,7 @@ resource "selectel_mks_nodegroup_v1" "nodegroup_tf_acc_test_1" {
   autoscale_min_nodes = 1
   autoscale_max_nodes = 4
   user_data           = "IyEvYmluL2Jhc2ggLXYKYXB0IC15IHVwZGF0ZQphcHQgLXkgaW5zdGFsbCBtdHI="
+  install_nvidia_device_plugin = false
   labels = {
     label-key3 = "label-value3"
     label-key4 = "label-value4"
@@ -316,6 +322,7 @@ resource "selectel_mks_nodegroup_v1" "nodegroup_tf_acc_test_1" {
   autoscale_min_nodes = 1
   autoscale_max_nodes = 4
   user_data           = "IyEvYmluL2Jhc2ggLXYKYXB0IC15IHVwZGF0ZQphcHQgLXkgaW5zdGFsbCBtdHI="
+  install_nvidia_device_plugin = false
   labels = {
     label-key3 = "label-value3"
     label-key4 = "label-value4"
@@ -363,6 +370,7 @@ resource "selectel_mks_nodegroup_v1" "nodegroup_tf_acc_test_1" {
   autoscale_min_nodes = 1
   autoscale_max_nodes = 4
   user_data           = "IyEvYmluL2Jhc2ggLXYKYXB0IC15IHVwZGF0ZQphcHQgLXkgaW5zdGFsbCBtdHI="
+  install_nvidia_device_plugin = false
   labels = {
     label-key3 = "label-value3"
     label-key4 = "label-value4"

--- a/website/docs/r/mks_nodegroup_v1.html.markdown
+++ b/website/docs/r/mks_nodegroup_v1.html.markdown
@@ -58,6 +58,8 @@ resource "selectel_mks_nodegroup_v1" "nodegroup_1" {
 
 * `nodes_count` - (Required) Number of worker nodes in the node group. Changing this resizes the node group if `enable_autoscale` is false.
 
+* `install_nvidia_device_plugin` - (Required) Boolean flag indicates if nvidia device plugin and GPU drivers installation was requested. Positive value is only suitable for `flavor_id` with GPU. In other cases with positive value - 400 (Bad request) status code will be returned from API.
+
 * `cpus` - (Optional) Number of vCPUs for each node. Can be skipped only when `flavor_id` is set. Changing this creates a new node group. Learn more about [Configurations](https://docs.selectel.ru/en/cloud/managed-kubernetes/node-groups/configurations/).
 
 * `ram_mb` - (Optional) Amount of RAM in MB for each node. Can be skipped only when `flavor_id` is set. Changing this creates a new node group. Learn more about [Configurations](https://docs.selectel.ru/en/cloud/managed-kubernetes/node-groups/configurations/).

--- a/website/docs/r/mks_nodegroup_v1.html.markdown
+++ b/website/docs/r/mks_nodegroup_v1.html.markdown
@@ -58,7 +58,10 @@ resource "selectel_mks_nodegroup_v1" "nodegroup_1" {
 
 * `nodes_count` - (Required) Number of worker nodes in the node group. Changing this resizes the node group if `enable_autoscale` is false.
 
-* `install_nvidia_device_plugin` - (Required) Boolean flag indicates if nvidia device plugin and GPU drivers installation was requested. Positive value is only suitable for `flavor_id` with GPU. In other cases with positive value - 400 (Bad request) status code will be returned from API.
+* `install_nvidia_device_plugin` - (Required) Enables or disables installation of the NVIDIA Device Plugin and GPU drivers.  
+Boolean flag: 
+  * `true` — for flavors with GPU enables installation of the NVIDIA Device Plugin and GPU drivers. 
+  * `false` — for flavors without GPU and flavors with GPU disables installation of the NVIDIA Device Plugin and GPU drivers. Learn more about [manual installation of GPU drivers](https://docs.selectel.ru/en/cloud/managed-kubernetes/node-groups/install-gpu-drivers/).
 
 * `cpus` - (Optional) Number of vCPUs for each node. Can be skipped only when `flavor_id` is set. Changing this creates a new node group. Learn more about [Configurations](https://docs.selectel.ru/en/cloud/managed-kubernetes/node-groups/configurations/).
 


### PR DESCRIPTION
* Add `install_nvidia_device_plugin` argument for `selectel_mks_nodegroup_v1`
* Add `install_nvidia_device_plugin` option to docs
* Update `mks-go` version to v0.15.0
* Update tests with nodegroup