### PR TITLE
Add default value for backup_retention_days field

### DIFF
--- a/selectel/dbaas_base_schemas.go
+++ b/selectel/dbaas_base_schemas.go
@@ -47,11 +47,6 @@ func resourceDBaaSDatastoreV1BaseSchema() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Computed: true,
 		},
-		"backup_retention_days": {
-			Type:        schema.TypeInt,
-			Optional:    true,
-			Description: "Number of days to retain backups.",
-		},
 		"connections": {
 			Type:     schema.TypeMap,
 			Computed: true,

--- a/selectel/schema_selectel_dbaas_datastore_v1.go
+++ b/selectel/schema_selectel_dbaas_datastore_v1.go
@@ -11,6 +11,7 @@ func resourceDBaaSDatastoreV1Schema() map[string]*schema.Schema {
 		Type:        schema.TypeInt,
 		Optional:    true,
 		Description: "Number of days to retain backups.",
+		Default:     7,
 	}
 	datastoreSchema["pooler"] = &schema.Schema{
 		Type:     schema.TypeSet,

--- a/selectel/schema_selectel_dbaas_mysql_datastore_v1.go
+++ b/selectel/schema_selectel_dbaas_mysql_datastore_v1.go
@@ -8,6 +8,7 @@ func resourceDBaaSMySQLDatastoreV1Schema() map[string]*schema.Schema {
 		Type:        schema.TypeInt,
 		Optional:    true,
 		Description: "Number of days to retain backups.",
+		Default:     7,
 	}
 	datastoreSchema["restore"] = &schema.Schema{
 		Type:     schema.TypeSet,

--- a/selectel/schema_selectel_dbaas_postgresql_datastore_v1.go
+++ b/selectel/schema_selectel_dbaas_postgresql_datastore_v1.go
@@ -11,6 +11,7 @@ func resourceDBaaSPostgreSQLDatastoreV1Schema() map[string]*schema.Schema {
 		Type:        schema.TypeInt,
 		Optional:    true,
 		Description: "Number of days to retain backups.",
+		Default:     7,
 	}
 	datastoreSchema["pooler"] = &schema.Schema{
 		Type:     schema.TypeSet,

--- a/selectel/schema_selectel_dbaas_redis_datastore_v1.go
+++ b/selectel/schema_selectel_dbaas_redis_datastore_v1.go
@@ -8,6 +8,7 @@ func resourceDBaaSRedisDatastoreV1Schema() map[string]*schema.Schema {
 		Type:        schema.TypeInt,
 		Optional:    true,
 		Description: "Number of days to retain backups.",
+		Default:     7,
 	}
 	datastoreSchema["restore"] = &schema.Schema{
 		Type:     schema.TypeSet,

--- a/website/docs/r/dbaas_mysql_datastore_v1.html.markdown
+++ b/website/docs/r/dbaas_mysql_datastore_v1.html.markdown
@@ -68,6 +68,8 @@ resource "selectel_dbaas_mysql_datastore_v1" "datastore_1" {
 
   * replica - (Required) Number of public IPs associated with the replicas. The minimum value is `0`. The maximum value must be 1 less than the value of the `node_count` argument.
 
+* `backup_retention_days` - (Optional) Number of days to retain backups.
+
 ## Attributes Reference
 
 * `status` - Datastore status.

--- a/website/docs/r/dbaas_postgresql_datastore_v1.html.markdown
+++ b/website/docs/r/dbaas_postgresql_datastore_v1.html.markdown
@@ -98,6 +98,8 @@ resource "selectel_dbaas_postgresql_datastore_v1" "datastore_1" {
 
   * replica - (Required) Number of public IPs associated with the replicas. The minimum value is `0`. The maximum value must be 1 less than the value of the `node_count` argument.
 
+* `backup_retention_days` - (Optional) Number of days to retain backups.
+
 ## Attributes Reference
 
 * `status` - Datastore status.

--- a/website/docs/r/dbaas_redis_datastore_v1.html.markdown
+++ b/website/docs/r/dbaas_redis_datastore_v1.html.markdown
@@ -59,6 +59,8 @@ resource "selectel_dbaas_redis_datastore_v1" "datastore_1" {
 
   * replica - (Required) Number of public IPs associated with the replicas. The minimum value is `0`. The maximum value must be 1 less than the value of the `node_count` argument.
 
+* `backup_retention_days` - (Optional) Number of days to retain backups.
+
 ## Attributes Reference
 
 * `status` - Datastore status.


### PR DESCRIPTION
### Description
Set `7` as a default number of backup retention days for dbaas resources. It fixes a problem when after the second apply terraform tries to update `backup_retention_days` value to `null`

### Relations
Closes #296 