### PR TITLE
[MKS-4439]Add checking local_volume with volume_type

### DIFF
--- a/selectel/import_selectel_iam_user_v1_test.go
+++ b/selectel/import_selectel_iam_user_v1_test.go
@@ -9,7 +9,6 @@ import (
 
 func TestAccIAMV1UserImportBasic(t *testing.T) {
 	resourceName := "selectel_iam_user_v1.user_tf_acc_test_1"
-	//nolint:goconst
 	userEmail := acctest.RandomWithPrefix("tf-acc") + "@example.com"
 
 	resource.Test(t, resource.TestCase{

--- a/selectel/resource_selectel_mks_nodegroup_v1.go
+++ b/selectel/resource_selectel_mks_nodegroup_v1.go
@@ -88,10 +88,9 @@ func resourceMKSNodegroupV1() *schema.Resource {
 				Computed: true,
 			},
 			"volume_type": {
-				Type:          schema.TypeString,
-				ConflictsWith: []string{"local_volume"},
-				Optional:      true,
-				ForceNew:      true,
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
 			},
 			"local_volume": {
 				Type:     schema.TypeBool,
@@ -254,6 +253,10 @@ func resourceMKSNodegroupV1Create(ctx context.Context, d *schema.ResourceData, m
 		AvailabilityZone:          d.Get("availability_zone").(string),
 		UserData:                  d.Get("user_data").(string),
 		InstallNvidiaDevicePlugin: &installNvidiaDevicePlugin,
+	}
+
+	if createOpts.VolumeType != "" && !createOpts.LocalVolume {
+		return diag.FromErr(fmt.Errorf("can't use volume_type with local_volume: %w", err))
 	}
 
 	projectQuotas, _, err := quotas.GetProjectQuotas(selvpcClient, projectID, region)


### PR DESCRIPTION
This PR will resolve https://github.com/selectel/terraform-provider-selectel/issues/300

Changes:
1. Add checking that, we can't use local_volume = false with not empty value  for volume_type