### PR TITLE
Add audit logs parameters support to MKS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/selectel/domains-go v1.0.2
 	github.com/selectel/go-selvpcclient/v3 v3.1.1
 	github.com/selectel/iam-go v0.4.1
-	github.com/selectel/mks-go v0.15.0
+	github.com/selectel/mks-go v0.16.0
 	github.com/selectel/secretsmanager-go v0.2.1
 	github.com/stretchr/testify v1.8.4
 )

--- a/go.sum
+++ b/go.sum
@@ -172,8 +172,8 @@ github.com/selectel/go-selvpcclient/v3 v3.1.1 h1:C1q2LqqosiapoLpnGITGmysg0YCSQYD
 github.com/selectel/go-selvpcclient/v3 v3.1.1/go.mod h1:NM7IXhh1IzqZ88DOw1Qc5Ez3tULLViXo95l5+rKPuyQ=
 github.com/selectel/iam-go v0.4.1 h1:grncCGkPVCM6nwqSTk+q15M5ZO6S/Pe0AIbbmKtm6gU=
 github.com/selectel/iam-go v0.4.1/go.mod h1:OIAkW7MZK97YUm+uvUgYbgDhkI9SdzTCxwd4yZoOR1o=
-github.com/selectel/mks-go v0.15.0 h1:0ytV5DiQAgbojKA0ukBjtwfWBSQh658nF3mhjZTrWj8=
-github.com/selectel/mks-go v0.15.0/go.mod h1:VxtV3dzwgOEzZc+9VMQb9DvxfSlej2ZQ8jnT8kqIGgU=
+github.com/selectel/mks-go v0.16.0 h1:qE4kMKQQV6iluu1W0WTzu3NJhXghS8GF20fIzV+3FOU=
+github.com/selectel/mks-go v0.16.0/go.mod h1:VxtV3dzwgOEzZc+9VMQb9DvxfSlej2ZQ8jnT8kqIGgU=
 github.com/selectel/secretsmanager-go v0.2.1 h1:OSBrA/07lm/Ecpwg59IJHFAoUHZR29oyfwUgTpr/dos=
 github.com/selectel/secretsmanager-go v0.2.1/go.mod h1:DUPexhiJWLTyZEvse7grJWdcA8p8TEI93gNu1dDu7Yg=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/selectel/resource_selectel_mks_cluster_v1_test.go
+++ b/selectel/resource_selectel_mks_cluster_v1_test.go
@@ -56,6 +56,7 @@ func TestAccMKSClusterV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "status", "ACTIVE"),
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "feature_gates.0", defaultFeatureGates[0]),
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "admission_controllers.0", defaultAdmissionControllers[0]),
+					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "enable_audit_logs", "false"),
 				),
 			},
 			{
@@ -71,6 +72,7 @@ func TestAccMKSClusterV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "status", "ACTIVE"),
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "feature_gates.0", defaultFeatureGates[1]),
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "admission_controllers.0", defaultAdmissionControllers[1]),
+					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "enable_audit_logs", "true"),
 				),
 			},
 		},
@@ -107,6 +109,7 @@ func TestAccMKSClusterV1Zonal(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "private_kube_api", "false"),
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "maintenance_window_start", maintenanceWindowStart),
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "status", "ACTIVE"),
+					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "enable_audit_logs", "true"),
 				),
 			},
 		},
@@ -143,6 +146,7 @@ func TestAccMKSClusterV1PrivateKubeAPI(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "private_kube_api", "true"),
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "maintenance_window_start", maintenanceWindowStart),
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "status", "ACTIVE"),
+					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "enable_audit_logs", "false"),
 				),
 			},
 		},
@@ -290,6 +294,7 @@ resource "selectel_mks_cluster_v1" "cluster_tf_acc_test_1" {
   enable_pod_security_policy        = false
   feature_gates                     = [%s]
   admission_controllers             = [%s]
+  enable_audit_logs                 = true
 }`, projectName, clusterName, kubeVersion, maintenanceWindowStart, flatFeatureGates, flatAdmissionControllers)
 }
 
@@ -306,6 +311,7 @@ func testAccMKSClusterV1Zonal(projectName, clusterName, kubeVersion, maintenance
    maintenance_window_start          = "%s"
    enable_patch_version_auto_upgrade = false
    zonal                             = true
+   enable_audit_logs                 = true
  }`, projectName, clusterName, kubeVersion, maintenanceWindowStart)
 }
 
@@ -323,6 +329,7 @@ func testAccMKSClusterV1PrivateKubeAPI(projectName, clusterName, kubeVersion, ma
    enable_patch_version_auto_upgrade = false
    zonal                             = false
    private_kube_api                  = true
+   enable_audit_logs                 = false
  }`, projectName, clusterName, kubeVersion, maintenanceWindowStart)
 }
 

--- a/website/docs/r/mks_cluster_v1.html.markdown
+++ b/website/docs/r/mks_cluster_v1.html.markdown
@@ -72,7 +72,7 @@ resource "selectel_mks_cluster_v1" "basic_cluster" {
 
 * `feature_gates` - (Optional) Enables or disables feature gates for the cluster. You can retrieve the list of available feature gates with the [selectel_mks_feature_gates_v1](https://registry.terraform.io/providers/selectel/selectel/latest/docs/data-sources/mks_feature_gates_v1) data source. Learn more about [Feature gates](https://docs.selectel.ru/en/cloud/managed-kubernetes/clusters/feature-gates/).
 
-* `admission_controllers` - (Optional) Enables or disables admission controllers for the cluster. You can retrieve  the list of available admission controllers with the [selectel_mks_admission_controllers_v1](https://registry.terraform.io/providers/selectel/selectel/latest/docs/data-sources/mks_admission_controllers_v1) data source. Learn more about [Admission controllers](https://docs.selectel.ru/en/cloud/managed-kubernetes/clusters/admission-controllers/).
+* `admission_controllers` - (Optional) Enables or disables admission controllers for the cluster. You can retrieve the list of available admission controllers with the [selectel_mks_admission_controllers_v1](https://registry.terraform.io/providers/selectel/selectel/latest/docs/data-sources/mks_admission_controllers_v1) data source. Learn more about [Admission controllers](https://docs.selectel.ru/en/cloud/managed-kubernetes/clusters/admission-controllers/).
 
 * `private_kube_api` - (Optional) Specifies if Kube API is available from the Internet. Changing this creates a new cluster.
 
@@ -81,6 +81,14 @@ resource "selectel_mks_cluster_v1" "basic_cluster" {
   * `false` (default) - Kube API is available from the Internet;
   
   * `true` - Kube API is available only from the cluster network.
+
+* `enable_audit_logs` - (Optional) Specifies if audit logs should be collected. Learn how to [configure export of audit logs to the log storage and analysis system](https://docs.selectel.ru/en/cloud/managed-kubernetes/clusters/logs/#configure-export-of-audit-logs).
+
+  Boolean flag:
+
+  * `false` (default) - Audit logs are not collected and are not available for export;
+
+  * `true` - Audit logs are collected and available for export.
 
 ## Attributes Reference
 


### PR DESCRIPTION
- Add `enable_audit_logs` argument for selectel_mks_cluster_v1
- Add `enable_audit_logs` option to docs
- Update `mks-go` version to v0.16.0
- Update tests with cluster