### PR TITLE
Add audit logs parameters support to MKS

### DIFF
--- a/.github/workflows/secure.yml
+++ b/.github/workflows/secure.yml
@@ -21,7 +21,7 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@v4
-      - run: semgrep scan --sarif --output=semgrep.sarif --error --severity=WARNING
+      - run: semgrep scan --json --output=semgrep.json --error --severity=WARNING
         env:
           SEMGREP_RULES: >-
             p/command-injection

--- a/.github/workflows/secure.yml
+++ b/.github/workflows/secure.yml
@@ -14,25 +14,6 @@ jobs:
   # https://semgrep.dev/docs/cli-reference
   semgrep:
     runs-on: ubuntu-24.04
-    env:
-      SEMGREP_RULES: >-
-        p/command-injection
-        p/comment
-        p/cwe-top-25
-        p/default
-        p/gitlab
-        p/gitleaks
-        p/golang
-        p/gosec
-        p/insecure-transport
-        p/owasp-top-ten
-        p/r2c-best-practices
-        p/r2c-bug-scan
-        p/r2c-security-audit
-        p/secrets
-        p/security-audit
-        p/sql-injection
-        p/xss
     container:
       image: semgrep/semgrep
     permissions:
@@ -40,9 +21,25 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@v4
-      - run: semgrep scan --error --severity=WARNING
-      - uses: actions/checkout@v4
       - run: semgrep scan --sarif --output=semgrep.sarif --error --severity=WARNING
+        env:
+          SEMGREP_RULES: >-
+            p/command-injection
+            p/comment
+            p/cwe-top-25
+            p/default
+            p/gitleaks
+            p/golang
+            p/gosec
+            p/insecure-transport
+            p/owasp-top-ten
+            p/r2c-best-practices
+            p/r2c-bug-scan
+            p/r2c-security-audit
+            p/secrets
+            p/security-audit
+            p/sql-injection
+            p/xss
       - uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: semgrep.sarif

--- a/.github/workflows/secure.yml
+++ b/.github/workflows/secure.yml
@@ -14,6 +14,25 @@ jobs:
   # https://semgrep.dev/docs/cli-reference
   semgrep:
     runs-on: ubuntu-24.04
+    env:
+      SEMGREP_RULES: >-
+        p/command-injection
+        p/comment
+        p/cwe-top-25
+        p/default
+        p/gitlab
+        p/gitleaks
+        p/golang
+        p/gosec
+        p/insecure-transport
+        p/owasp-top-ten
+        p/r2c-best-practices
+        p/r2c-bug-scan
+        p/r2c-security-audit
+        p/secrets
+        p/security-audit
+        p/sql-injection
+        p/xss
     container:
       image: semgrep/semgrep
     permissions:
@@ -21,26 +40,9 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@v4
-      - run: semgrep scan --json --output=semgrep.json --error --severity=WARNING
-        env:
-          SEMGREP_RULES: >-
-            p/command-injection
-            p/comment
-            p/cwe-top-25
-            p/default
-            p/gitlab
-            p/gitleaks
-            p/golang
-            p/gosec
-            p/insecure-transport
-            p/owasp-top-ten
-            p/r2c-best-practices
-            p/r2c-bug-scan
-            p/r2c-security-audit
-            p/secrets
-            p/security-audit
-            p/sql-injection
-            p/xss
+      - run: semgrep scan --error --severity=WARNING
+      - uses: actions/checkout@v4
+      - run: semgrep scan --sarif --output=semgrep.sarif --error --severity=WARNING
       - uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: semgrep.sarif

--- a/.github/workflows/secure.yml
+++ b/.github/workflows/secure.yml
@@ -21,7 +21,7 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@v4
-      - run: semgrep scan --sarif --output=semgrep.sarif --error --severity=WARNING
+      - run: semgrep scan --sarif --output=semgrep.sarif --error --severity=WARNING --severity=ERROR
         env:
           SEMGREP_RULES: >-
             p/command-injection

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,1 +1,2 @@
 website/
+*_test.go

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -45,4 +45,27 @@ ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
 endif
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
-.PHONY: golangci-lint build test testacc fmt test-compile website website-test
+
+# CLI reference:
+# https://semgrep.dev/docs/cli-reference
+semgrep:
+	docker run --rm -v ${PWD}:/app:ro -w /app semgrep/semgrep semgrep scan --error --metrics=off \
+		--config=p/command-injection \
+		--config=p/comment \
+		--config=p/cwe-top-25 \
+		--config=p/default \
+		--config=p/gitleaks \
+		--config=p/golang \
+		--config=p/gosec \
+		--config=p/insecure-transport \
+		--config=p/owasp-top-ten \
+		--config=p/r2c-best-practices \
+		--config=p/r2c-bug-scan \
+		--config=p/r2c-security-audit \
+		--config=p/secrets \
+		--config=p/security-audit \
+		--config=p/sql-injection \
+		--config=p/xss \
+		.
+
+.PHONY: golangci-lint build test testacc fmt test-compile semgrep website website-test

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/selectel/domains-go v1.0.2
 	github.com/selectel/go-selvpcclient/v3 v3.1.1
 	github.com/selectel/iam-go v0.4.1
-	github.com/selectel/mks-go v0.15.0
+	github.com/selectel/mks-go v0.16.0
 	github.com/selectel/secretsmanager-go v0.2.1
 	github.com/stretchr/testify v1.8.4
 )

--- a/go.sum
+++ b/go.sum
@@ -172,8 +172,8 @@ github.com/selectel/go-selvpcclient/v3 v3.1.1 h1:C1q2LqqosiapoLpnGITGmysg0YCSQYD
 github.com/selectel/go-selvpcclient/v3 v3.1.1/go.mod h1:NM7IXhh1IzqZ88DOw1Qc5Ez3tULLViXo95l5+rKPuyQ=
 github.com/selectel/iam-go v0.4.1 h1:grncCGkPVCM6nwqSTk+q15M5ZO6S/Pe0AIbbmKtm6gU=
 github.com/selectel/iam-go v0.4.1/go.mod h1:OIAkW7MZK97YUm+uvUgYbgDhkI9SdzTCxwd4yZoOR1o=
-github.com/selectel/mks-go v0.15.0 h1:0ytV5DiQAgbojKA0ukBjtwfWBSQh658nF3mhjZTrWj8=
-github.com/selectel/mks-go v0.15.0/go.mod h1:VxtV3dzwgOEzZc+9VMQb9DvxfSlej2ZQ8jnT8kqIGgU=
+github.com/selectel/mks-go v0.16.0 h1:qE4kMKQQV6iluu1W0WTzu3NJhXghS8GF20fIzV+3FOU=
+github.com/selectel/mks-go v0.16.0/go.mod h1:VxtV3dzwgOEzZc+9VMQb9DvxfSlej2ZQ8jnT8kqIGgU=
 github.com/selectel/secretsmanager-go v0.2.1 h1:OSBrA/07lm/Ecpwg59IJHFAoUHZR29oyfwUgTpr/dos=
 github.com/selectel/secretsmanager-go v0.2.1/go.mod h1:DUPexhiJWLTyZEvse7grJWdcA8p8TEI93gNu1dDu7Yg=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/selectel/dbaas.go
+++ b/selectel/dbaas.go
@@ -1,6 +1,6 @@
 package selectel
 
-import (
+import ( // nosemgrep: gitlab.gosec.G501-1
 	"context"
 	"crypto/md5"
 	"errors"

--- a/selectel/dbaas.go
+++ b/selectel/dbaas.go
@@ -1,7 +1,6 @@
 package selectel
 
-//nolint:gci
-import ( // nosemgrep: gitlab.gosec.G501-1
+import (
 	"context"
 	"crypto/md5"
 	"errors"

--- a/selectel/dbaas.go
+++ b/selectel/dbaas.go
@@ -1,5 +1,6 @@
 package selectel
 
+//nolint:gci
 import ( // nosemgrep: gitlab.gosec.G501-1
 	"context"
 	"crypto/md5"

--- a/selectel/resource_selectel_mks_cluster_v1_test.go
+++ b/selectel/resource_selectel_mks_cluster_v1_test.go
@@ -56,6 +56,7 @@ func TestAccMKSClusterV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "status", "ACTIVE"),
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "feature_gates.0", defaultFeatureGates[0]),
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "admission_controllers.0", defaultAdmissionControllers[0]),
+					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "enable_audit_logs", "false"),
 				),
 			},
 			{
@@ -71,6 +72,7 @@ func TestAccMKSClusterV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "status", "ACTIVE"),
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "feature_gates.0", defaultFeatureGates[1]),
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "admission_controllers.0", defaultAdmissionControllers[1]),
+					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "enable_audit_logs", "true"),
 				),
 			},
 		},
@@ -107,6 +109,7 @@ func TestAccMKSClusterV1Zonal(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "private_kube_api", "false"),
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "maintenance_window_start", maintenanceWindowStart),
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "status", "ACTIVE"),
+					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "enable_audit_logs", "true"),
 				),
 			},
 		},
@@ -143,6 +146,7 @@ func TestAccMKSClusterV1PrivateKubeAPI(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "private_kube_api", "true"),
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "maintenance_window_start", maintenanceWindowStart),
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "status", "ACTIVE"),
+					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "enable_audit_logs", "false"),
 				),
 			},
 		},
@@ -290,6 +294,7 @@ resource "selectel_mks_cluster_v1" "cluster_tf_acc_test_1" {
   enable_pod_security_policy        = false
   feature_gates                     = [%s]
   admission_controllers             = [%s]
+  enable_audit_logs                 = true
 }`, projectName, clusterName, kubeVersion, maintenanceWindowStart, flatFeatureGates, flatAdmissionControllers)
 }
 
@@ -306,6 +311,7 @@ func testAccMKSClusterV1Zonal(projectName, clusterName, kubeVersion, maintenance
    maintenance_window_start          = "%s"
    enable_patch_version_auto_upgrade = false
    zonal                             = true
+   enable_audit_logs                 = true
  }`, projectName, clusterName, kubeVersion, maintenanceWindowStart)
 }
 
@@ -323,6 +329,7 @@ func testAccMKSClusterV1PrivateKubeAPI(projectName, clusterName, kubeVersion, ma
    enable_patch_version_auto_upgrade = false
    zonal                             = false
    private_kube_api                  = true
+   enable_audit_logs                 = false
  }`, projectName, clusterName, kubeVersion, maintenanceWindowStart)
 }
 

--- a/website/docs/r/mks_cluster_v1.html.markdown
+++ b/website/docs/r/mks_cluster_v1.html.markdown
@@ -72,7 +72,7 @@ resource "selectel_mks_cluster_v1" "basic_cluster" {
 
 * `feature_gates` - (Optional) Enables or disables feature gates for the cluster. You can retrieve the list of available feature gates with the [selectel_mks_feature_gates_v1](https://registry.terraform.io/providers/selectel/selectel/latest/docs/data-sources/mks_feature_gates_v1) data source. Learn more about [Feature gates](https://docs.selectel.ru/en/cloud/managed-kubernetes/clusters/feature-gates/).
 
-* `admission_controllers` - (Optional) Enables or disables admission controllers for the cluster. You can retrieve  the list of available admission controllers with the [selectel_mks_admission_controllers_v1](https://registry.terraform.io/providers/selectel/selectel/latest/docs/data-sources/mks_admission_controllers_v1) data source. Learn more about [Admission controllers](https://docs.selectel.ru/en/cloud/managed-kubernetes/clusters/admission-controllers/).
+* `admission_controllers` - (Optional) Enables or disables admission controllers for the cluster. You can retrieve the list of available admission controllers with the [selectel_mks_admission_controllers_v1](https://registry.terraform.io/providers/selectel/selectel/latest/docs/data-sources/mks_admission_controllers_v1) data source. Learn more about [Admission controllers](https://docs.selectel.ru/en/cloud/managed-kubernetes/clusters/admission-controllers/).
 
 * `private_kube_api` - (Optional) Specifies if Kube API is available from the Internet. Changing this creates a new cluster.
 
@@ -81,6 +81,14 @@ resource "selectel_mks_cluster_v1" "basic_cluster" {
   * `false` (default) - Kube API is available from the Internet;
   
   * `true` - Kube API is available only from the cluster network.
+
+* `enable_audit_logs` - (Optional) Specifies if audit logs should be collected. Learn how to [configure export of audit logs to the log storage and analysis system](https://docs.selectel.ru/en/cloud/managed-kubernetes/clusters/logs/#configure-export-of-audit-logs).
+
+  Boolean flag:
+
+  * `false` (default) - Audit logs are not collected and are not available for export;
+
+  * `true` - Audit logs are collected and available for export.
 
 ## Attributes Reference
 

--- a/website/docs/r/mks_cluster_v1.html.markdown
+++ b/website/docs/r/mks_cluster_v1.html.markdown
@@ -82,7 +82,7 @@ resource "selectel_mks_cluster_v1" "basic_cluster" {
   
   * `true` - Kube API is available only from the cluster network.
 
-* `enable_audit_logs` - (Optional) Specifies if audit logs should be collected. Learn how to [configure export of audit logs to the log storage and analysis system](https://docs.selectel.ru/en/cloud/managed-kubernetes/clusters/logs/#configure-export-of-audit-logs).
+* `enable_audit_logs` - (Optional) Enables or disables collection of audit logs. Learn how to [configure export of audit logs to a logging system](https://docs.selectel.ru/en/cloud/managed-kubernetes/clusters/logs/#configure-export-of-audit-logs).
 
   Boolean flag:
 


### PR DESCRIPTION
**MKS**:
- Add `enable_audit_logs` argument for selectel_mks_cluster_v1
- Add `enable_audit_logs` option to docs
- Update `mks-go` version to v0.16.0
- Update tests with MKS cluster

**CI & build**:
- Remove broken semgrep rule `p/gitlab`
- Add ERROR severity to semgrep in CI
- Add semgrep to Makefile
- Add tests to .semgrepignore