### PR TITLE
Add preemptible nodegroups support to MKS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/selectel/domains-go v1.0.2
 	github.com/selectel/go-selvpcclient/v3 v3.2.1
 	github.com/selectel/iam-go v0.4.1
-	github.com/selectel/mks-go v0.16.0
+	github.com/selectel/mks-go v0.17.0
 	github.com/selectel/secretsmanager-go v0.2.1
 	github.com/stretchr/testify v1.8.4
 )

--- a/go.sum
+++ b/go.sum
@@ -172,8 +172,6 @@ github.com/selectel/go-selvpcclient/v3 v3.2.1 h1:ny6WIAMiHzKxOgOEnwcWE79wIQij1AH
 github.com/selectel/go-selvpcclient/v3 v3.2.1/go.mod h1:3EfSf8aEWyhspOGbvZ6mvnFg7JN5uckxNyBFPGWsXNQ=
 github.com/selectel/iam-go v0.4.1 h1:grncCGkPVCM6nwqSTk+q15M5ZO6S/Pe0AIbbmKtm6gU=
 github.com/selectel/iam-go v0.4.1/go.mod h1:OIAkW7MZK97YUm+uvUgYbgDhkI9SdzTCxwd4yZoOR1o=
-github.com/selectel/mks-go v0.16.0 h1:qE4kMKQQV6iluu1W0WTzu3NJhXghS8GF20fIzV+3FOU=
-github.com/selectel/mks-go v0.16.0/go.mod h1:VxtV3dzwgOEzZc+9VMQb9DvxfSlej2ZQ8jnT8kqIGgU=
 github.com/selectel/mks-go v0.17.0 h1:fYyIuB/K+TJJDy50Bl7z52SrogYCdekpKPaRc0pDi+M=
 github.com/selectel/mks-go v0.17.0/go.mod h1:VxtV3dzwgOEzZc+9VMQb9DvxfSlej2ZQ8jnT8kqIGgU=
 github.com/selectel/secretsmanager-go v0.2.1 h1:OSBrA/07lm/Ecpwg59IJHFAoUHZR29oyfwUgTpr/dos=

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ github.com/selectel/iam-go v0.4.1 h1:grncCGkPVCM6nwqSTk+q15M5ZO6S/Pe0AIbbmKtm6gU
 github.com/selectel/iam-go v0.4.1/go.mod h1:OIAkW7MZK97YUm+uvUgYbgDhkI9SdzTCxwd4yZoOR1o=
 github.com/selectel/mks-go v0.16.0 h1:qE4kMKQQV6iluu1W0WTzu3NJhXghS8GF20fIzV+3FOU=
 github.com/selectel/mks-go v0.16.0/go.mod h1:VxtV3dzwgOEzZc+9VMQb9DvxfSlej2ZQ8jnT8kqIGgU=
+github.com/selectel/mks-go v0.17.0 h1:fYyIuB/K+TJJDy50Bl7z52SrogYCdekpKPaRc0pDi+M=
+github.com/selectel/mks-go v0.17.0/go.mod h1:VxtV3dzwgOEzZc+9VMQb9DvxfSlej2ZQ8jnT8kqIGgU=
 github.com/selectel/secretsmanager-go v0.2.1 h1:OSBrA/07lm/Ecpwg59IJHFAoUHZR29oyfwUgTpr/dos=
 github.com/selectel/secretsmanager-go v0.2.1/go.mod h1:DUPexhiJWLTyZEvse7grJWdcA8p8TEI93gNu1dDu7Yg=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/selectel/resource_selectel_mks_nodegroup_v1.go
+++ b/selectel/resource_selectel_mks_nodegroup_v1.go
@@ -164,6 +164,11 @@ func resourceMKSNodegroupV1() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"preemptible": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
 			"nodegroup_type": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -241,6 +246,7 @@ func resourceMKSNodegroupV1Create(ctx context.Context, d *schema.ResourceData, m
 
 	// Prepare nodegroup create options.
 	installNvidiaDevicePlugin := d.Get("install_nvidia_device_plugin").(bool)
+	preemptible := d.Get("preemptible").(bool)
 	createOpts := &nodegroup.CreateOpts{
 		Count:                     d.Get("nodes_count").(int),
 		FlavorID:                  d.Get("flavor_id").(string),
@@ -254,6 +260,7 @@ func resourceMKSNodegroupV1Create(ctx context.Context, d *schema.ResourceData, m
 		AvailabilityZone:          d.Get("availability_zone").(string),
 		UserData:                  d.Get("user_data").(string),
 		InstallNvidiaDevicePlugin: &installNvidiaDevicePlugin,
+		Preemptible:               &preemptible,
 	}
 
 	projectQuotas, _, err := quotas.GetProjectQuotas(selvpcClient, projectID, region)
@@ -365,6 +372,7 @@ func resourceMKSNodegroupV1Read(ctx context.Context, d *schema.ResourceData, met
 	d.Set("nodegroup_type", mksNodegroup.NodegroupType)
 	d.Set("user_data", mksNodegroup.UserData)
 	d.Set("install_nvidia_device_plugin", mksNodegroup.InstallNvidiaDevicePlugin)
+	d.Set("preemptible", mksNodegroup.Preemptible)
 
 	if err := d.Set("labels", mksNodegroup.Labels); err != nil {
 		log.Print(errSettingComplexAttr("labels", err))

--- a/selectel/resource_selectel_mks_nodegroup_v1_test.go
+++ b/selectel/resource_selectel_mks_nodegroup_v1_test.go
@@ -155,6 +155,40 @@ func TestAccMKSNodegroupV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "nodegroup_type", "STANDARD"),
 				),
 			},
+			{
+				Config: testAccMKSNodegroupV1Preemptible(projectName, clusterName, kubeVersion, maintenanceWindowStart),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVPCV2ProjectExists("selectel_vpc_project_v2.project_tf_acc_test_1", &project),
+					testAccCheckMKSNodegroupV1Exists("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", &mksNodegroup),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "availability_zone", "ru-9a"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "nodes_count", "2"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "nodes.#", "2"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "cpus", "1"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "ram_mb", "1024"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "volume_gb", "10"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "volume_type", "fast.ru-9a"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "enable_autoscale", "true"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "autoscale_min_nodes", "2"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "autoscale_max_nodes", "3"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "user_data", "IyEvYmluL2Jhc2ggLXYKYXB0IC15IHVwZGF0ZQphcHQgLXkgaW5zdGFsbCBtdHI="),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "install_nvidia_device_plugin", "false"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "preemptible", "true"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key0", "label-value0"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key1", "label-value1"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key2", "label-value2"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.#", "3"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.0.key", "test-key-0"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.0.value", "test-value-0"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.0.effect", "NoSchedule"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.1.key", "test-key-1"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.1.value", "test-value-1"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.1.effect", "NoExecute"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.2.key", "test-key-2"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.2.value", "test-value-2"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.2.effect", "PreferNoSchedule"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "nodegroup_type", "STANDARD"),
+				),
+			},
 		},
 	})
 }
@@ -397,6 +431,59 @@ resource "selectel_mks_nodegroup_v1" "nodegroup_tf_acc_test_1" {
     key = "test-key-3"
     value = "test-value-3"
     effect = "NoSchedule"
+  }
+}`, projectName, clusterName, kubeVersion, maintenanceWindowStart)
+}
+
+func testAccMKSNodegroupV1Preemptible(projectName, clusterName, kubeVersion, maintenanceWindowStart string) string {
+	return fmt.Sprintf(`
+resource "selectel_vpc_project_v2" "project_tf_acc_test_1" {
+  name        = "%s"
+}
+
+resource "selectel_mks_cluster_v1" "cluster_tf_acc_test_1" {
+  name                     = "%s"
+  kube_version             = "%s"
+  project_id               = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  region                   = "ru-9"
+  maintenance_window_start = "%s"
+}
+
+resource "selectel_mks_nodegroup_v1" "nodegroup_tf_acc_test_1" {
+  cluster_id          = "${selectel_mks_cluster_v1.cluster_tf_acc_test_1.id}"
+  project_id          = "${selectel_mks_cluster_v1.cluster_tf_acc_test_1.project_id}"
+  region              = "${selectel_mks_cluster_v1.cluster_tf_acc_test_1.region}"
+  availability_zone   = "ru-9a"
+  nodes_count         = 2
+  cpus                = 1
+  ram_mb              = 1024
+  volume_gb           = 10
+  volume_type         = "fast.ru-9a"
+  enable_autoscale    = true
+  autoscale_min_nodes = 2
+  autoscale_max_nodes = 3
+  user_data           = "IyEvYmluL2Jhc2ggLXYKYXB0IC15IHVwZGF0ZQphcHQgLXkgaW5zdGFsbCBtdHI="
+  install_nvidia_device_plugin = false
+  preemptible         = true
+  labels = {
+    label-key0 = "label-value0"
+    label-key1 = "label-value1"
+    label-key2 = "label-value2"
+  }
+  taints {
+    key = "test-key-0"
+    value = "test-value-0"
+    effect = "NoSchedule"
+  }
+  taints {
+    key = "test-key-1"
+    value = "test-value-1"
+    effect = "NoExecute"
+  }
+  taints {
+    key = "test-key-2"
+    value = "test-value-2"
+    effect = "PreferNoSchedule"
   }
 }`, projectName, clusterName, kubeVersion, maintenanceWindowStart)
 }

--- a/selectel/resource_selectel_mks_nodegroup_v1_test.go
+++ b/selectel/resource_selectel_mks_nodegroup_v1_test.go
@@ -47,6 +47,7 @@ func TestAccMKSNodegroupV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "autoscale_max_nodes", "3"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "user_data", "IyEvYmluL2Jhc2ggLXYKYXB0IC15IHVwZGF0ZQphcHQgLXkgaW5zdGFsbCBtdHI="),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "install_nvidia_device_plugin", "false"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "preemptible", "false"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key0", "label-value0"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key1", "label-value1"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key2", "label-value2"),
@@ -78,6 +79,7 @@ func TestAccMKSNodegroupV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "autoscale_max_nodes", "4"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "user_data", "IyEvYmluL2Jhc2ggLXYKYXB0IC15IHVwZGF0ZQphcHQgLXkgaW5zdGFsbCBtdHI="),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "install_nvidia_device_plugin", "false"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "preemptible", "false"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key3", "label-value3"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key4", "label-value4"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.#", "3"),
@@ -107,6 +109,7 @@ func TestAccMKSNodegroupV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "autoscale_max_nodes", "4"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "user_data", "IyEvYmluL2Jhc2ggLXYKYXB0IC15IHVwZGF0ZQphcHQgLXkgaW5zdGFsbCBtdHI="),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "install_nvidia_device_plugin", "false"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "preemptible", "false"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key3", "label-value3"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key4", "label-value4"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.#", "3"),
@@ -136,6 +139,7 @@ func TestAccMKSNodegroupV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "autoscale_max_nodes", "4"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "user_data", "IyEvYmluL2Jhc2ggLXYKYXB0IC15IHVwZGF0ZQphcHQgLXkgaW5zdGFsbCBtdHI="),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "install_nvidia_device_plugin", "false"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "preemptible", "false"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key3", "label-value3"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "labels.label-key4", "label-value4"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.#", "3"),
@@ -221,6 +225,7 @@ resource "selectel_mks_nodegroup_v1" "nodegroup_tf_acc_test_1" {
   autoscale_max_nodes = 3
   user_data           = "IyEvYmluL2Jhc2ggLXYKYXB0IC15IHVwZGF0ZQphcHQgLXkgaW5zdGFsbCBtdHI="
   install_nvidia_device_plugin = false
+  preemptible         = false
   labels = {
     label-key0 = "label-value0"
     label-key1 = "label-value1"
@@ -273,6 +278,7 @@ resource "selectel_mks_nodegroup_v1" "nodegroup_tf_acc_test_1" {
   autoscale_max_nodes = 4
   user_data           = "IyEvYmluL2Jhc2ggLXYKYXB0IC15IHVwZGF0ZQphcHQgLXkgaW5zdGFsbCBtdHI="
   install_nvidia_device_plugin = false
+  preemptible         = false
   labels = {
     label-key3 = "label-value3"
     label-key4 = "label-value4"
@@ -323,6 +329,7 @@ resource "selectel_mks_nodegroup_v1" "nodegroup_tf_acc_test_1" {
   autoscale_max_nodes = 4
   user_data           = "IyEvYmluL2Jhc2ggLXYKYXB0IC15IHVwZGF0ZQphcHQgLXkgaW5zdGFsbCBtdHI="
   install_nvidia_device_plugin = false
+  preemptible        = false
   labels = {
     label-key3 = "label-value3"
     label-key4 = "label-value4"
@@ -371,6 +378,7 @@ resource "selectel_mks_nodegroup_v1" "nodegroup_tf_acc_test_1" {
   autoscale_max_nodes = 4
   user_data           = "IyEvYmluL2Jhc2ggLXYKYXB0IC15IHVwZGF0ZQphcHQgLXkgaW5zdGFsbCBtdHI="
   install_nvidia_device_plugin = false
+  preemptible         = false
   labels = {
     label-key3 = "label-value3"
     label-key4 = "label-value4"

--- a/website/docs/r/mks_nodegroup_v1.html.markdown
+++ b/website/docs/r/mks_nodegroup_v1.html.markdown
@@ -25,6 +25,7 @@ resource "selectel_mks_nodegroup_v1" "nodegroup_1" {
   volume_type       = "fast.ru-7a"
 
   install_nvidia_device_plugin = false
+  preemptible       = false
 
   labels            = {
     "label-key0": "label-value0",
@@ -65,6 +66,8 @@ resource "selectel_mks_nodegroup_v1" "nodegroup_1" {
 Boolean flag: 
   * `true` — for flavors with GPU enables installation of the NVIDIA Device Plugin and GPU drivers. 
   * `false` — for flavors without GPU and flavors with GPU disables installation of the NVIDIA Device Plugin and GPU drivers. Learn more about [manual installation of GPU drivers](https://docs.selectel.ru/en/cloud/managed-kubernetes/node-groups/install-gpu-drivers/).
+
+* `preemptible` - (Optional)  Enables or disables the use of preemptible nodes for the node group. Boolean flag, the default value is false. Learn more about [Preemptible node groups](https://docs.selectel.ru/en/cloud/managed-kubernetes/node-groups/preemptible-node-groups/).
 
 * `cpus` - (Optional) Number of vCPUs for each node. Can be skipped only when `flavor_id` is set. Changing this creates a new node group. Learn more about [Configurations](https://docs.selectel.ru/en/cloud/managed-kubernetes/node-groups/configurations/).
 

--- a/website/docs/r/mks_nodegroup_v1.html.markdown
+++ b/website/docs/r/mks_nodegroup_v1.html.markdown
@@ -25,7 +25,7 @@ resource "selectel_mks_nodegroup_v1" "nodegroup_1" {
   volume_type       = "fast.ru-7a"
 
   install_nvidia_device_plugin = false
-  preemptible       = false
+  preemptible                  = false
 
   labels            = {
     "label-key0": "label-value0",
@@ -67,7 +67,7 @@ Boolean flag:
   * `true` — for flavors with GPU enables installation of the NVIDIA Device Plugin and GPU drivers. 
   * `false` — for flavors without GPU and flavors with GPU disables installation of the NVIDIA Device Plugin and GPU drivers. Learn more about [manual installation of GPU drivers](https://docs.selectel.ru/en/cloud/managed-kubernetes/node-groups/install-gpu-drivers/).
 
-* `preemptible` - (Optional)  Enables or disables the use of preemptible nodes for the node group. Boolean flag, the default value is false. Learn more about [Preemptible node groups](https://docs.selectel.ru/en/cloud/managed-kubernetes/node-groups/preemptible-node-groups/).
+* `preemptible` - (Optional) Enables or disables the use of preemptible nodes for the node group. Boolean flag, the default value is false. Learn more about [Preemptible node groups](https://docs.selectel.ru/en/cloud/managed-kubernetes/node-groups/preemptible-node-groups/).
 
 * `cpus` - (Optional) Number of vCPUs for each node. Can be skipped only when `flavor_id` is set. Changing this creates a new node group. Learn more about [Configurations](https://docs.selectel.ru/en/cloud/managed-kubernetes/node-groups/configurations/).
 


### PR DESCRIPTION
- Add `preemptible` argument for `selectel_mks_nodegroup_v1`
- Add `preemptible` option to docs
- Update `mks-go` version to v0.17.0
- Update tests