### PR TITLE
Add support status for nodegroups MKS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/selectel/domains-go v1.0.2
 	github.com/selectel/go-selvpcclient/v4 v4.0.0
 	github.com/selectel/iam-go v0.4.1
-	github.com/selectel/mks-go v0.18.0
+	github.com/selectel/mks-go v0.19.0
 	github.com/selectel/secretsmanager-go v0.2.1
 	github.com/stretchr/testify v1.8.4
 )

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ github.com/selectel/iam-go v0.4.1 h1:grncCGkPVCM6nwqSTk+q15M5ZO6S/Pe0AIbbmKtm6gU
 github.com/selectel/iam-go v0.4.1/go.mod h1:OIAkW7MZK97YUm+uvUgYbgDhkI9SdzTCxwd4yZoOR1o=
 github.com/selectel/mks-go v0.18.0 h1:RBoke/rnLtmgGxi6/U16YSF2Y9yE3W0GsqugGXGP/C8=
 github.com/selectel/mks-go v0.18.0/go.mod h1:VxtV3dzwgOEzZc+9VMQb9DvxfSlej2ZQ8jnT8kqIGgU=
+github.com/selectel/mks-go v0.19.0 h1:IIYML78aCzJnr+JYaF5IY0WEb2A2XaBtoS2WpOhbVtc=
+github.com/selectel/mks-go v0.19.0/go.mod h1:VxtV3dzwgOEzZc+9VMQb9DvxfSlej2ZQ8jnT8kqIGgU=
 github.com/selectel/secretsmanager-go v0.2.1 h1:OSBrA/07lm/Ecpwg59IJHFAoUHZR29oyfwUgTpr/dos=
 github.com/selectel/secretsmanager-go v0.2.1/go.mod h1:DUPexhiJWLTyZEvse7grJWdcA8p8TEI93gNu1dDu7Yg=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/go.sum
+++ b/go.sum
@@ -172,8 +172,6 @@ github.com/selectel/go-selvpcclient/v4 v4.0.0 h1:5HorF8n6u/4BUh2+cJEysmXhMOB9epG
 github.com/selectel/go-selvpcclient/v4 v4.0.0/go.mod h1:eFhL1KUW159KOJVeGO7k/Uxl0TYd/sBkWXjuF5WxmYk=
 github.com/selectel/iam-go v0.4.1 h1:grncCGkPVCM6nwqSTk+q15M5ZO6S/Pe0AIbbmKtm6gU=
 github.com/selectel/iam-go v0.4.1/go.mod h1:OIAkW7MZK97YUm+uvUgYbgDhkI9SdzTCxwd4yZoOR1o=
-github.com/selectel/mks-go v0.18.0 h1:RBoke/rnLtmgGxi6/U16YSF2Y9yE3W0GsqugGXGP/C8=
-github.com/selectel/mks-go v0.18.0/go.mod h1:VxtV3dzwgOEzZc+9VMQb9DvxfSlej2ZQ8jnT8kqIGgU=
 github.com/selectel/mks-go v0.19.0 h1:IIYML78aCzJnr+JYaF5IY0WEb2A2XaBtoS2WpOhbVtc=
 github.com/selectel/mks-go v0.19.0/go.mod h1:VxtV3dzwgOEzZc+9VMQb9DvxfSlej2ZQ8jnT8kqIGgU=
 github.com/selectel/secretsmanager-go v0.2.1 h1:OSBrA/07lm/Ecpwg59IJHFAoUHZR29oyfwUgTpr/dos=

--- a/selectel/mks.go
+++ b/selectel/mks.go
@@ -71,7 +71,7 @@ func waitForMKSNodegroupV1ActiveState(
 		string(nodegroup.StatusActive),
 	}
 
-	stateConfNodegroup := &resource.StateChangeConf{
+	stateConf := &resource.StateChangeConf{
 		Pending:    pending,
 		Target:     target,
 		Refresh:    mksNodegroupV1StateRefreshFunc(ctx, client, clusterID, nodegroupID),
@@ -80,7 +80,7 @@ func waitForMKSNodegroupV1ActiveState(
 		MinTimeout: 3 * time.Second,
 	}
 
-	_, err := stateConfNodegroup.WaitForStateContext(ctx)
+	_, err := stateConf.WaitForStateContext(ctx)
 	if err != nil {
 		return fmt.Errorf(
 			"error waiting for the nodegroup %s to become 'ACTIVE': %s",

--- a/selectel/mks.go
+++ b/selectel/mks.go
@@ -58,7 +58,7 @@ func waitForMKSClusterV1ActiveState(
 func waitForMKSNodegroupV1ActiveState(
 	ctx context.Context, client *v1.ServiceClient, clusterID string, nodegroupID string, timeout time.Duration,
 ) error {
-	pendingNodegroup := []string{
+	pending := []string{
 		string(nodegroup.StatusPendingCreate),
 		string(nodegroup.StatusPendingUpdate),
 		string(nodegroup.StatusPendingDelete),
@@ -67,13 +67,13 @@ func waitForMKSNodegroupV1ActiveState(
 		string(nodegroup.StatusPendingNodeReinstall),
 	}
 
-	targetNodegroup := []string{
+	target := []string{
 		string(nodegroup.StatusActive),
 	}
 
 	stateConfNodegroup := &resource.StateChangeConf{
-		Pending:    pendingNodegroup,
-		Target:     targetNodegroup,
+		Pending:    pending,
+		Target:     target,
 		Refresh:    mksNodegroupV1StateRefreshFunc(ctx, client, clusterID, nodegroupID),
 		Timeout:    timeout,
 		Delay:      10 * time.Second,

--- a/selectel/resource_selectel_mks_nodegroup_v1.go
+++ b/selectel/resource_selectel_mks_nodegroup_v1.go
@@ -464,9 +464,9 @@ func resourceMKSNodegroupV1Update(ctx context.Context, d *schema.ResourceData, m
 			return diag.FromErr(errUpdatingObject(objectNodegroup, d.Id(), err))
 		}
 
-		log.Printf("[DEBUG] waiting for cluster %s to become 'ACTIVE'", clusterID)
+		log.Printf("[DEBUG] waiting for nodegroup %s to become 'ACTIVE'", nodegroupID)
 		timeout := d.Timeout(schema.TimeoutUpdate)
-		err = waitForMKSClusterV1ActiveState(ctx, mksClient, clusterID, timeout)
+		err = waitForMKSNodegroupV1ActiveState(ctx, mksClient, clusterID, nodegroupID, timeout)
 		if err != nil {
 			return diag.FromErr(errUpdatingObject(objectNodegroup, d.Id(), err))
 		}

--- a/selectel/resource_selectel_mks_nodegroup_v1.go
+++ b/selectel/resource_selectel_mks_nodegroup_v1.go
@@ -41,6 +41,10 @@ func resourceMKSNodegroupV1() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"region": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/selectel/resource_selectel_mks_nodegroup_v1.go
+++ b/selectel/resource_selectel_mks_nodegroup_v1.go
@@ -365,6 +365,7 @@ func resourceMKSNodegroupV1Read(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	d.Set("cluster_id", mksNodegroup.ClusterID)
+	d.Set("status", mksNodegroup.Status)
 	d.Set("flavor_id", mksNodegroup.FlavorID)
 	d.Set("volume_gb", mksNodegroup.VolumeGB)
 	d.Set("volume_type", mksNodegroup.VolumeType)
@@ -500,9 +501,9 @@ func resourceMKSNodegroupV1Update(ctx context.Context, d *schema.ResourceData, m
 			return diag.FromErr(errUpdatingObject(objectNodegroup, d.Id(), err))
 		}
 
-		log.Printf("[DEBUG] waiting for cluster %s to become 'ACTIVE'", clusterID)
+		log.Printf("[DEBUG] waiting for nodegroup %s to become 'ACTIVE'", nodegroupID)
 		timeout := d.Timeout(schema.TimeoutUpdate)
-		err = waitForMKSClusterV1ActiveState(ctx, mksClient, clusterID, timeout)
+		err = waitForMKSNodegroupV1ActiveState(ctx, mksClient, clusterID, nodegroupID, timeout)
 		if err != nil {
 			return diag.FromErr(errUpdatingObject(objectNodegroup, d.Id(), err))
 		}

--- a/selectel/resource_selectel_mks_nodegroup_v1_test.go
+++ b/selectel/resource_selectel_mks_nodegroup_v1_test.go
@@ -62,6 +62,7 @@ func TestAccMKSNodegroupV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.2.value", "test-value-2"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.2.effect", "PreferNoSchedule"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "nodegroup_type", "STANDARD"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "status", "ACTIVE"),
 				),
 			},
 			{
@@ -93,6 +94,7 @@ func TestAccMKSNodegroupV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.2.value", "test-value-3"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.2.effect", "NoSchedule"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "nodegroup_type", "STANDARD"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "status", "ACTIVE"),
 				),
 			},
 			{
@@ -123,6 +125,7 @@ func TestAccMKSNodegroupV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.2.value", "test-value-3"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.2.effect", "NoSchedule"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "nodegroup_type", "STANDARD"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "status", "ACTIVE"),
 				),
 			},
 			{
@@ -153,6 +156,7 @@ func TestAccMKSNodegroupV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.2.value", "test-value-3"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.2.effect", "NoSchedule"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "nodegroup_type", "STANDARD"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "status", "ACTIVE"),
 				),
 			},
 			{
@@ -187,6 +191,7 @@ func TestAccMKSNodegroupV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.2.value", "test-value-2"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "taints.2.effect", "PreferNoSchedule"),
 					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "nodegroup_type", "STANDARD"),
+					resource.TestCheckResourceAttr("selectel_mks_nodegroup_v1.nodegroup_tf_acc_test_1", "status", "ACTIVE"),
 				),
 			},
 		},

--- a/website/docs/r/mks_nodegroup_v1.html.markdown
+++ b/website/docs/r/mks_nodegroup_v1.html.markdown
@@ -103,6 +103,8 @@ Boolean flag:
 
 * `nodegroup_type` - Type of the node group. Available values are `STANDARD` and `GPU`.
 
+* status - Node group status.
+
 ## Import
 
 You can import a node group:


### PR DESCRIPTION
* Updated the `mks-go` dependency from version `v0.18.0` to `v0.19.0`
* Added the `waitForMKSNodegroupV1ActiveState` function to wait for a nodegroup to reach the 'ACTIVE' state
* Modified the `resourceMKSNodegroupV1Read` function to set the `status` field of the nodegroup
* Updated the `resourceMKSNodegroupV1Update` to wait nodegroup status
* Updated tests