### PR TITLE
Rewrite description of the status MKS nodegroup

### DIFF
--- a/website/docs/r/mks_nodegroup_v1.html.markdown
+++ b/website/docs/r/mks_nodegroup_v1.html.markdown
@@ -103,7 +103,7 @@ Boolean flag:
 
 * `nodegroup_type` - Type of the node group. Available values are `STANDARD` and `GPU`.
 
-* status - Node group status.
+* `status` - Status of the node group.
 
 ## Import
 


### PR DESCRIPTION
Changes:
- Corrected the formatting of the `status` field description to use backticks for consistency with other field descriptions.
