### PR TITLE
Add CA certificates to OIDC params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 6.5.0 (June 5, 2025)
+
+FEATURES:
+
+* Add `ca_certs` to `oidc` in Managed Kubernetes ([#337](https://github.com/selectel/terraform-provider-selectel/pull/337))
+
+BUG FIXES:
+ 
+* Fix updating `oidc` in Managed Kubernetes: cluster state does not change when it is not necessary ([#337](https://github.com/selectel/terraform-provider-selectel/pull/337))
+
+IMPROVEMENTS:
+ 
+* Bump `mks-go` to v0.20.0 ([#337](https://github.com/selectel/terraform-provider-selectel/pull/337))
+* Bump `golang.org/x/net` to v0.38.0 ([#337](https://github.com/selectel/terraform-provider-selectel/pull/337))
+
 ## 6.4.1 (May 6, 2025)
 
 BUG FIXES:

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/vmihailenco/tagparser v0.1.1 // indirect
 	github.com/zclconf/go-cty v1.12.1 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
-	golang.org/x/net v0.37.0 // indirect
+	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/selectel/domains-go v1.0.2
 	github.com/selectel/go-selvpcclient/v4 v4.1.0
 	github.com/selectel/iam-go v0.4.1
-	github.com/selectel/mks-go v0.19.0
+	github.com/selectel/mks-go v0.20.0
 	github.com/selectel/secretsmanager-go v0.2.1
 	github.com/stretchr/testify v1.8.4
 )

--- a/go.sum
+++ b/go.sum
@@ -228,8 +228,8 @@ golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210326060303-6b1517762897/go.mod h1:uSPa2vr4CLtc/ILN5odXGNXS6mhrKVzTaCXzk9m6W3k=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.37.0 h1:1zLorHbz+LYj7MQlSf1+2tPIIgibq2eL5xkrGk6f+2c=
-golang.org/x/net v0.37.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
+golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/go.sum
+++ b/go.sum
@@ -172,8 +172,8 @@ github.com/selectel/go-selvpcclient/v4 v4.1.0 h1:22lBp+rzg9g2MP4iiGhpVAcCt0kMv7I
 github.com/selectel/go-selvpcclient/v4 v4.1.0/go.mod h1:eFhL1KUW159KOJVeGO7k/Uxl0TYd/sBkWXjuF5WxmYk=
 github.com/selectel/iam-go v0.4.1 h1:grncCGkPVCM6nwqSTk+q15M5ZO6S/Pe0AIbbmKtm6gU=
 github.com/selectel/iam-go v0.4.1/go.mod h1:OIAkW7MZK97YUm+uvUgYbgDhkI9SdzTCxwd4yZoOR1o=
-github.com/selectel/mks-go v0.19.0 h1:IIYML78aCzJnr+JYaF5IY0WEb2A2XaBtoS2WpOhbVtc=
-github.com/selectel/mks-go v0.19.0/go.mod h1:VxtV3dzwgOEzZc+9VMQb9DvxfSlej2ZQ8jnT8kqIGgU=
+github.com/selectel/mks-go v0.20.0 h1:4GCekG3qkBfl7HADlVcjpIAHJDZFjclY8rLFhuEHqHI=
+github.com/selectel/mks-go v0.20.0/go.mod h1:VxtV3dzwgOEzZc+9VMQb9DvxfSlej2ZQ8jnT8kqIGgU=
 github.com/selectel/secretsmanager-go v0.2.1 h1:OSBrA/07lm/Ecpwg59IJHFAoUHZR29oyfwUgTpr/dos=
 github.com/selectel/secretsmanager-go v0.2.1/go.mod h1:DUPexhiJWLTyZEvse7grJWdcA8p8TEI93gNu1dDu7Yg=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/selectel/mks.go
+++ b/selectel/mks.go
@@ -563,6 +563,7 @@ func flattenMKSClusterV1OIDC(view *cluster.View) []interface{} {
 		"client_id":      view.KubernetesOptions.OIDC.ClientID,
 		"username_claim": view.KubernetesOptions.OIDC.UsernameClaim,
 		"groups_claim":   view.KubernetesOptions.OIDC.GroupsClaim,
+		"ca_certs":       view.KubernetesOptions.OIDC.CACerts,
 	}}
 }
 
@@ -599,22 +600,27 @@ func expandMKSNodegroupV1Labels(labels map[string]interface{}) map[string]string
 	return result
 }
 
-func expandAndValidateMKSClusterV1OIDC(d *schema.ResourceData) (cluster.OIDC, error) {
+func expandMKSClusterV1OIDC(d *schema.ResourceData) cluster.OIDC {
 	nestedResource := d.Get("oidc").([]any)
 	if len(nestedResource) == 0 {
-		return cluster.OIDC{}, nil
+		return cluster.OIDC{}
 	}
 
 	// Resource always comes with only first element because of validation
 	resourceMap := nestedResource[0].(map[string]interface{})
-	oidc := cluster.OIDC{
+	return cluster.OIDC{
 		Enabled:       resourceMap["enabled"].(bool),
 		ProviderName:  resourceMap["provider_name"].(string),
 		IssuerURL:     resourceMap["issuer_url"].(string),
 		ClientID:      resourceMap["client_id"].(string),
 		UsernameClaim: resourceMap["username_claim"].(string),
 		GroupsClaim:   resourceMap["groups_claim"].(string),
+		CACerts:       resourceMap["ca_certs"].(string),
 	}
+}
+
+func expandAndValidateMKSClusterV1OIDC(d *schema.ResourceData) (cluster.OIDC, error) {
+	oidc := expandMKSClusterV1OIDC(d)
 
 	if oidc.Enabled {
 		for _, s := range []string{oidc.ProviderName, oidc.IssuerURL, oidc.ClientID} {

--- a/selectel/mks.go
+++ b/selectel/mks.go
@@ -608,6 +608,7 @@ func expandMKSClusterV1OIDC(d *schema.ResourceData) cluster.OIDC {
 
 	// Resource always comes with only first element because of validation
 	resourceMap := nestedResource[0].(map[string]interface{})
+
 	return cluster.OIDC{
 		Enabled:       resourceMap["enabled"].(bool),
 		ProviderName:  resourceMap["provider_name"].(string),

--- a/selectel/resource_selectel_mks_cluster_v1.go
+++ b/selectel/resource_selectel_mks_cluster_v1.go
@@ -157,6 +157,7 @@ func resourceMKSClusterV1() *schema.Resource {
 				ForceNew: false,
 				MaxItems: 1,
 				MinItems: 1,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enabled": {
@@ -165,32 +166,44 @@ func resourceMKSClusterV1() *schema.Resource {
 						},
 						"provider_name": {
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
 						},
 						"issuer_url": {
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
 						},
 						"client_id": {
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
 						},
 						"username_claim": {
 							Type:     schema.TypeString,
 							Optional: true,
 							Default:  "",
-							DiffSuppressFunc: func(_, oldVersion, newVersion string, _ *schema.ResourceData) bool {
+							DiffSuppressFunc: func(_, oldVersion, newVersion string, d *schema.ResourceData) bool {
+								oidc := expandMKSClusterV1OIDC(d)
+
 								// Ignore diff on default value from API.
-								return oldVersion == "sub" && newVersion == ""
+								return oldVersion == "sub" && newVersion == "" && oidc.Enabled
 							},
 						},
 						"groups_claim": {
 							Type:     schema.TypeString,
 							Optional: true,
 							Default:  "",
-							DiffSuppressFunc: func(_, oldVersion, newVersion string, _ *schema.ResourceData) bool {
+							DiffSuppressFunc: func(_, oldVersion, newVersion string, d *schema.ResourceData) bool {
+								oidc := expandMKSClusterV1OIDC(d)
+
 								// Ignore diff on default value from API.
-								return oldVersion == "groups" && newVersion == ""
+								return oldVersion == "groups" && newVersion == "" && oidc.Enabled
+							},
+						},
+						"ca_certs": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "",
+							DiffSuppressFunc: func(_, oldVersion, newVersion string, _ *schema.ResourceData) bool {
+								return strings.TrimSpace(oldVersion) == strings.TrimSpace(newVersion)
 							},
 						},
 					},

--- a/selectel/resource_selectel_mks_cluster_v1_test.go
+++ b/selectel/resource_selectel_mks_cluster_v1_test.go
@@ -63,6 +63,7 @@ func TestAccMKSClusterV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "oidc.0.client_id", ""),
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "oidc.0.username_claim", ""),
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "oidc.0.groups_claim", ""),
+					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "oidc.0.ca_certs", ""),
 				),
 			},
 			{
@@ -85,6 +86,7 @@ func TestAccMKSClusterV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "oidc.0.client_id", "test"),
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "oidc.0.username_claim", "email"),
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "oidc.0.groups_claim", "groups"),
+					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "oidc.0.ca_certs", "ca_certs"),
 				),
 			},
 		},
@@ -128,6 +130,7 @@ func TestAccMKSClusterV1Zonal(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "oidc.0.client_id", "test"),
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "oidc.0.username_claim", "email"),
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "oidc.0.groups_claim", "groups"),
+					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "oidc.0.ca_certs", "ca_certs"),
 				),
 			},
 		},
@@ -171,6 +174,7 @@ func TestAccMKSClusterV1PrivateKubeAPI(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "oidc.0.client_id", ""),
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "oidc.0.username_claim", ""),
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "oidc.0.groups_claim", ""),
+					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "oidc.0.ca_certs", ""),
 				),
 			},
 		},
@@ -343,6 +347,7 @@ func testAccMKSClusterV1Zonal(projectName, clusterName, kubeVersion, maintenance
 	 issuer_url     = "https://keycloak.example.com/realms/kubernetes"
 	 username_claim = "email"
 	 groups_claim   = "groups"
+	 ca_certs       = "ca_certs"
    }
  }`, projectName, clusterName, kubeVersion, maintenanceWindowStart)
 }

--- a/website/docs/r/mks_cluster_v1.html.markdown
+++ b/website/docs/r/mks_cluster_v1.html.markdown
@@ -106,7 +106,7 @@ resource "selectel_mks_cluster_v1" "basic_cluster" {
 
   * `groups_claim` - JWT claim to use as the user's group. The default value is `groups`.
 
-  * `ca_certs` - Certificate in PEM format for the CA that signed your identity provider's web certificate. Required when using self-signed certificates.
+  * `ca_certs` - Certificate in PEM format for the CA that signed your identity provider's web certificate. Required when using self-signed certificates. *Learn more about [Access to the cluster through an OIDC provider](https://docs.selectel.ru/en/cloud/managed-kubernetes/clusters/access-to-cluster-with-oidc-provider/).*
 
 ## Attributes Reference
 

--- a/website/docs/r/mks_cluster_v1.html.markdown
+++ b/website/docs/r/mks_cluster_v1.html.markdown
@@ -106,7 +106,7 @@ resource "selectel_mks_cluster_v1" "basic_cluster" {
 
   * `groups_claim` - (Optional) JWT claim to use as the user's group. The default value is `groups`.
 
-  * `ca_certs` - (Optional) Certificate in PEM format for the CA that signed your identity provider's web certificate. Optional if the certificate is issued by the public CA that Ubuntu by default considers trustworthy. *Learn more about [Access to the cluster through an OIDC provider](https://docs.selectel.ru/en/cloud/managed-kubernetes/clusters/access-to-cluster-with-oidc-provider/).*
+  * `ca_certs` - (Optional) Certificate in PEM format for the CA that signed your identity provider's web certificate. Optional if the certificate is issued by the public CA that Ubuntu by default considers trustworthy. Learn more about [Access to the cluster through an OIDC provider](https://docs.selectel.ru/en/cloud/managed-kubernetes/clusters/access-to-cluster-with-oidc-provider/).
 
 ## Attributes Reference
 

--- a/website/docs/r/mks_cluster_v1.html.markdown
+++ b/website/docs/r/mks_cluster_v1.html.markdown
@@ -102,11 +102,11 @@ resource "selectel_mks_cluster_v1" "basic_cluster" {
 
   * `client_id` - (Required) Service identifier issued by the OIDC provider and used in authentication requests to the resources.
 
-  * `username_claim` - JWT claim to use as the username. The default value is `sub`. The content of the claim must be a unique identifier of the end user.
+  * `username_claim` - (Optional) JWT claim to use as the username. The default value is `sub`. The content of the claim must be a unique identifier of the end user.
 
-  * `groups_claim` - JWT claim to use as the user's group. The default value is `groups`.
+  * `groups_claim` - (Optional) JWT claim to use as the user's group. The default value is `groups`.
 
-  * `ca_certs` - Certificate in PEM format for the CA that signed your identity provider's web certificate. Required when using self-signed certificates. *Learn more about [Access to the cluster through an OIDC provider](https://docs.selectel.ru/en/cloud/managed-kubernetes/clusters/access-to-cluster-with-oidc-provider/).*
+  * `ca_certs` - (Optional) Certificate in PEM format for the CA that signed your identity provider's web certificate. Optional if the certificate is issued by the public CA that Ubuntu by default considers trustworthy. *Learn more about [Access to the cluster through an OIDC provider](https://docs.selectel.ru/en/cloud/managed-kubernetes/clusters/access-to-cluster-with-oidc-provider/).*
 
 ## Attributes Reference
 

--- a/website/docs/r/mks_cluster_v1.html.markdown
+++ b/website/docs/r/mks_cluster_v1.html.markdown
@@ -106,6 +106,8 @@ resource "selectel_mks_cluster_v1" "basic_cluster" {
 
   * `groups_claim` - JWT claim to use as the user's group. The default value is `groups`.
 
+  * `ca_certs` - Certificate in PEM format for the CA that signed your identity provider's web certificate. Required when using self-signed certificates.
+
 ## Attributes Reference
 
 * `maintenance_window_end` - Time in UTC when maintenance in the cluster ends. The format is `hh:mm:ss`. Learn more about the [Maintenance window](https://docs.selectel.ru/en/cloud/managed-kubernetes/clusters/set-up-maintenance-window/).


### PR DESCRIPTION
- Add `ca_certs` to `oidc`
- Fix updating `oidc`: cluster state does not change when it is not necessary
- Add oidc ca_certs to docs
- Update mks-go version to v0.20.0
- bump golang.org/x/net to v0.38.0