### PR TITLE
Fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ FEATURES:
 IMPROVEMENTS:
 
 * Update documentation for dbaas datastores ([#346](https://github.com/selectel/terraform-provider-selectel/pull/346))
+
 ## 6.8.0 (October 6, 2025)
 
 FEATURES:
@@ -101,6 +102,7 @@ BUG FIXES:
 * Fixed wrong behavior causing cluster creation failed due to conflict of values `zonal` and `enable_patch_version_auto_upgrade` ([#326](https://github.com/selectel/terraform-provider-selectel/pull/326))
 
 BREAKING CHANGES:
+
 * Due to API changes, older versions of the provider will incorrectly display node group resizing as instant, even though the operation is still in progress. The latest version correctly reflects the actual state of the resize process.
 
 ## 6.1.1 (January 28, 2025)


### PR DESCRIPTION
1. Fixed broken links and added some missed closing parentheses
2. Normalized blank line spacing. There were different amounts of blank lines between paragraphs / headings.
Brought them to a single consistent style.
3. Normalized month name formatting. There was mixed usage: some full month names and some abbreviated. Especially because “May” tricked contributors into thinking abbreviations like "Oct" were preferred. Now all month names use one consistent format — full month names.