### PR TITLE
feat!: add support for private subnets for dedicated servers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/selectel/cloudbackup-go v1.0.1-0.20251028081814-eed36cddb45b
 	github.com/selectel/craas-go v0.4.2
 	github.com/selectel/dbaas-go v0.18.0
-	github.com/selectel/dedicated-go v1.0.0
+	github.com/selectel/dedicated-go/v2 v2.0.0
 	github.com/selectel/domains-go v1.0.2
 	github.com/selectel/globalrouter-go v1.2.0
 	github.com/selectel/go-selvpcclient/v4 v4.2.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/selectel/cloudbackup-go v1.0.1-0.20251028081814-eed36cddb45b
 	github.com/selectel/craas-go v0.4.2
 	github.com/selectel/dbaas-go v0.18.0
-	github.com/selectel/dedicated-go/v2 v2.0.0
+	github.com/selectel/dedicated-go/v2 v2.1.0
 	github.com/selectel/domains-go v1.0.2
 	github.com/selectel/globalrouter-go v1.2.0
 	github.com/selectel/go-selvpcclient/v4 v4.2.0

--- a/go.sum
+++ b/go.sum
@@ -196,6 +196,8 @@ github.com/selectel/dbaas-go v0.18.0 h1:IrnEt/6ETx6oKvV4est6RGei4AebrUPN/njczZfb
 github.com/selectel/dbaas-go v0.18.0/go.mod h1:KU+HEvlHGdq4hgHaKagz+JvCIAVya1N+ugZIaea0m4Y=
 github.com/selectel/dedicated-go/v2 v2.0.0 h1:xtPiNgyT6cKNJL5nZWgkwuZ7+ZFUefvH55UooWfHvI0=
 github.com/selectel/dedicated-go/v2 v2.0.0/go.mod h1:4x2656DDXxvQdEVGVO27/PcgydBuQwiqw2E7nFDbVVM=
+github.com/selectel/dedicated-go/v2 v2.1.0 h1:S0H80vYOUrgSPb1jlXzuaN8L+7XRCb1ZoPSip163r0I=
+github.com/selectel/dedicated-go/v2 v2.1.0/go.mod h1:4x2656DDXxvQdEVGVO27/PcgydBuQwiqw2E7nFDbVVM=
 github.com/selectel/domains-go v1.0.2 h1:Si6iGaMnTFJxwiJVI50DOdZnwcxc87kqaWrVQYW0a4U=
 github.com/selectel/domains-go v1.0.2/go.mod h1:SugRKfq4sTpnOHquslCpzda72wV8u0cMBHx0C0l+bzA=
 github.com/selectel/globalrouter-go v1.2.0 h1:hNwxN9YAEaGSsveZ35u1m3CqTWjKIyIfvibJID8aEl0=

--- a/go.sum
+++ b/go.sum
@@ -194,8 +194,8 @@ github.com/selectel/craas-go v0.4.2 h1:sfCpA9PygkBKeDOkuGgBAOemp6PSJOL58m47hkvtO
 github.com/selectel/craas-go v0.4.2/go.mod h1:9RAUn9PdMITP4I3GAade6v2hjB2j3lo3J2dDlG5SLYE=
 github.com/selectel/dbaas-go v0.18.0 h1:IrnEt/6ETx6oKvV4est6RGei4AebrUPN/njczZfbVL0=
 github.com/selectel/dbaas-go v0.18.0/go.mod h1:KU+HEvlHGdq4hgHaKagz+JvCIAVya1N+ugZIaea0m4Y=
-github.com/selectel/dedicated-go v1.0.0 h1:VXdEfAhkNOLWN5UDjI6UNofUUnZpENCtsfBnXhIcdcw=
-github.com/selectel/dedicated-go v1.0.0/go.mod h1:O4hAz+DaPm1nJoPplhZGqll0S9pwHYKSSNs3hE1/OjQ=
+github.com/selectel/dedicated-go/v2 v2.0.0 h1:xtPiNgyT6cKNJL5nZWgkwuZ7+ZFUefvH55UooWfHvI0=
+github.com/selectel/dedicated-go/v2 v2.0.0/go.mod h1:4x2656DDXxvQdEVGVO27/PcgydBuQwiqw2E7nFDbVVM=
 github.com/selectel/domains-go v1.0.2 h1:Si6iGaMnTFJxwiJVI50DOdZnwcxc87kqaWrVQYW0a4U=
 github.com/selectel/domains-go v1.0.2/go.mod h1:SugRKfq4sTpnOHquslCpzda72wV8u0cMBHx0C0l+bzA=
 github.com/selectel/globalrouter-go v1.2.0 h1:hNwxN9YAEaGSsveZ35u1m3CqTWjKIyIfvibJID8aEl0=

--- a/go.sum
+++ b/go.sum
@@ -194,8 +194,6 @@ github.com/selectel/craas-go v0.4.2 h1:sfCpA9PygkBKeDOkuGgBAOemp6PSJOL58m47hkvtO
 github.com/selectel/craas-go v0.4.2/go.mod h1:9RAUn9PdMITP4I3GAade6v2hjB2j3lo3J2dDlG5SLYE=
 github.com/selectel/dbaas-go v0.18.0 h1:IrnEt/6ETx6oKvV4est6RGei4AebrUPN/njczZfbVL0=
 github.com/selectel/dbaas-go v0.18.0/go.mod h1:KU+HEvlHGdq4hgHaKagz+JvCIAVya1N+ugZIaea0m4Y=
-github.com/selectel/dedicated-go/v2 v2.0.0 h1:xtPiNgyT6cKNJL5nZWgkwuZ7+ZFUefvH55UooWfHvI0=
-github.com/selectel/dedicated-go/v2 v2.0.0/go.mod h1:4x2656DDXxvQdEVGVO27/PcgydBuQwiqw2E7nFDbVVM=
 github.com/selectel/dedicated-go/v2 v2.1.0 h1:S0H80vYOUrgSPb1jlXzuaN8L+7XRCb1ZoPSip163r0I=
 github.com/selectel/dedicated-go/v2 v2.1.0/go.mod h1:4x2656DDXxvQdEVGVO27/PcgydBuQwiqw2E7nFDbVVM=
 github.com/selectel/domains-go v1.0.2 h1:Si6iGaMnTFJxwiJVI50DOdZnwcxc87kqaWrVQYW0a4U=

--- a/selectel/data_source_selectel_dedicated_configuration_v1.go
+++ b/selectel/data_source_selectel_dedicated_configuration_v1.go
@@ -46,7 +46,7 @@ func dataSourceDedicatedConfigurationV1() *schema.Resource {
 }
 
 func dataSourceDedicatedConfigurationV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	dsClient, diagErr := getDedicatedClient(d, meta)
+	dsClient, diagErr := getDedicatedClient(d, meta, true)
 	if diagErr != nil {
 		return diagErr
 	}

--- a/selectel/data_source_selectel_dedicated_configuration_v1.go
+++ b/selectel/data_source_selectel_dedicated_configuration_v1.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	v2 "github.com/selectel/dedicated-go/v2/pkg/v2"
 	"github.com/terraform-providers/terraform-provider-selectel/selectel/internal/reflect"
 )
 
@@ -58,14 +59,14 @@ func dataSourceDedicatedConfigurationV1Read(ctx context.Context, d *schema.Resou
 
 	log.Printf("[DEBUG] Getting server configurations")
 
-	serversList, _, err := dsClient.ServersRaw(ctx)
+	serversList, _, err := dsClient.Servers(ctx)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(
 			"error getting list of servers configurations (without chips): %w", err,
 		))
 	}
 
-	serverChipsList, _, err := dsClient.ServerChipsRaw(ctx)
+	serverChipsList, _, err := dsClient.ServerChips(ctx)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf(
 			"error getting list of servers configurations (with chips): %w", err))
@@ -82,8 +83,7 @@ func dataSourceDedicatedConfigurationV1Read(ctx context.Context, d *schema.Resou
 
 	ids := make([]string, 0, len(filteredServers))
 	for _, e := range filteredServers {
-		id, _ := e["uuid"].(string)
-		ids = append(ids, id)
+		ids = append(ids, e.ID)
 	}
 
 	slices.Sort(ids)
@@ -120,23 +120,23 @@ func expandDedicatedConfigurationsSearchFilter(d *schema.ResourceData) (*dedicat
 	return filter, nil
 }
 
-func filterDedicatedConfigurations(list []map[string]any, filter *dedicatedConfigurationsFilter) []map[string]any {
-	var filteredRaw []map[string]any
+func filterDedicatedConfigurations(list []v2.Server, filter *dedicatedConfigurationsFilter) []v2.Server {
+	var filtered []v2.Server
 	for _, entry := range list {
 		if reflect.IsSetContainsSubset(filter.deepFilter, entry) {
-			filteredRaw = append(filteredRaw, entry)
+			filtered = append(filtered, entry)
 		}
 	}
 
-	return filteredRaw
+	return filtered
 }
 
-func flattenDedicatedConfigurations(list []map[string]any) []interface{} {
+func flattenDedicatedConfigurations(list []v2.Server) []interface{} {
 	res := make([]interface{}, len(list))
 	for i, e := range list {
 		sMap := make(map[string]interface{})
-		sMap["id"] = e["uuid"]
-		sMap["name"] = e["name"]
+		sMap["id"] = e.ID
+		sMap["name"] = e.Name
 
 		res[i] = sMap
 	}

--- a/selectel/data_source_selectel_dedicated_configuration_v1_test.go
+++ b/selectel/data_source_selectel_dedicated_configuration_v1_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	v2 "github.com/selectel/dedicated-go/v2/pkg/v2"
 	"github.com/selectel/go-selvpcclient/v4/selvpcclient/resell/v2/projects"
 )
 
@@ -47,16 +48,15 @@ func testAccDedicatedConfigurationV1Exists(
 
 		dsClient := newTestDedicatedAPIClient(rs, testAccProvider)
 
-		serversFromAPI, _, err := dsClient.ServersRaw(ctx)
+		serversFromAPI, _, err := dsClient.Servers(ctx)
 		if err != nil {
 			return err
 		}
 
-		var srvFromAPI map[string]interface{}
+		var srvFromAPI *v2.Server
 		for _, srv := range serversFromAPI {
-			name, _ := srv["name"].(string)
-			if name == serverName {
-				srvFromAPI = srv
+			if srv.Name == serverName {
+				srvFromAPI = &srv
 			}
 		}
 

--- a/selectel/data_source_selectel_dedicated_location_v1.go
+++ b/selectel/data_source_selectel_dedicated_location_v1.go
@@ -61,7 +61,7 @@ func dataSourceDedicatedLocationV1() *schema.Resource {
 }
 
 func dataSourceDedicatedLocationV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	dsClient, diagErr := getDedicatedClient(d, meta)
+	dsClient, diagErr := getDedicatedClient(d, meta, true)
 	if diagErr != nil {
 		return diagErr
 	}
@@ -128,6 +128,9 @@ func expandDedicatedLocationsSearchFilter(d *schema.ResourceData) dedicatedLocat
 func filterDedicatedLocations(list dedicated.Locations, filter dedicatedLocationsFilter) dedicated.Locations {
 	var filtered dedicated.Locations
 	for _, entry := range list {
+		if entry.Visibility == "admin_only" {
+			continue // filter by visibility admin_only
+		}
 		if filter.name == "" || entry.Name == filter.name {
 			filtered = append(filtered, entry)
 		}

--- a/selectel/data_source_selectel_dedicated_location_v1.go
+++ b/selectel/data_source_selectel_dedicated_location_v1.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	dedicated "github.com/selectel/dedicated-go/pkg/v2"
+	dedicated "github.com/selectel/dedicated-go/v2/pkg/v2"
 )
 
 func dataSourceDedicatedLocationV1() *schema.Resource {

--- a/selectel/data_source_selectel_dedicated_location_v1.go
+++ b/selectel/data_source_selectel_dedicated_location_v1.go
@@ -128,8 +128,8 @@ func expandDedicatedLocationsSearchFilter(d *schema.ResourceData) dedicatedLocat
 func filterDedicatedLocations(list dedicated.Locations, filter dedicatedLocationsFilter) dedicated.Locations {
 	var filtered dedicated.Locations
 	for _, entry := range list {
-		if entry.Visibility == "admin_only" {
-			continue // filter by visibility admin_only
+		if entry.Visibility == "only_in_admin" {
+			continue // filter by visibility only_in_admin
 		}
 		if filter.name == "" || entry.Name == filter.name {
 			filtered = append(filtered, entry)

--- a/selectel/data_source_selectel_dedicated_os_v1.go
+++ b/selectel/data_source_selectel_dedicated_os_v1.go
@@ -104,7 +104,7 @@ func dataSourceDedicatedOSV1() *schema.Resource {
 }
 
 func dataSourceDedicatedOSV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	dsClient, diagErr := getDedicatedClient(d, meta)
+	dsClient, diagErr := getDedicatedClient(d, meta, true)
 	if diagErr != nil {
 		return diagErr
 	}

--- a/selectel/data_source_selectel_dedicated_os_v1.go
+++ b/selectel/data_source_selectel_dedicated_os_v1.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	dedicated "github.com/selectel/dedicated-go/pkg/v2"
+	dedicated "github.com/selectel/dedicated-go/v2/pkg/v2"
 )
 
 func dataSourceDedicatedOSV1() *schema.Resource {

--- a/selectel/data_source_selectel_dedicated_private_subnet_v1.go
+++ b/selectel/data_source_selectel_dedicated_private_subnet_v1.go
@@ -6,10 +6,9 @@ import (
 	"slices"
 	"strconv"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	dedicated "github.com/selectel/dedicated-go/v2/pkg/v2"
 )
 

--- a/selectel/data_source_selectel_dedicated_private_subnet_v1.go
+++ b/selectel/data_source_selectel_dedicated_private_subnet_v1.go
@@ -17,8 +17,9 @@ func dataSourceDedicatedPrivateSubnetV1() *schema.Resource {
 		ReadContext: dataSourceDedicatedPrivateSubnetV1Read,
 		Schema: map[string]*schema.Schema{
 			"project_id": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.IsUUID,
 			},
 			"filter": {
 				Type:     schema.TypeSet,
@@ -27,8 +28,9 @@ func dataSourceDedicatedPrivateSubnetV1() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"location_id": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.IsUUID,
 						},
 						"ip": {
 							Type:         schema.TypeString,

--- a/selectel/data_source_selectel_dedicated_private_subnet_v1.go
+++ b/selectel/data_source_selectel_dedicated_private_subnet_v1.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	dedicated "github.com/selectel/dedicated-go/pkg/v2"
 )
 
-func dataSourceDedicatedPublicSubnetV1() *schema.Resource {
+func dataSourceDedicatedPrivateSubnetV1() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceDedicatedPublicSubnetV1Read,
+		ReadContext: dataSourceDedicatedPrivateSubnetV1Read,
 		Schema: map[string]*schema.Schema{
 			"project_id": {
 				Type:     schema.TypeString,
@@ -24,6 +25,10 @@ func dataSourceDedicatedPublicSubnetV1() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"location_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 						"ip": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -32,7 +37,7 @@ func dataSourceDedicatedPublicSubnetV1() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-						"location_id": {
+						"vlan": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
@@ -49,7 +54,7 @@ func dataSourceDedicatedPublicSubnetV1() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"network_id": {
+						"vlan": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
@@ -57,24 +62,12 @@ func dataSourceDedicatedPublicSubnetV1() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"broadcast": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"gateway": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"reserved_vrrp_ips": {
+						"reserved_ip": {
 							Type:     schema.TypeList,
 							Computed: true,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 							},
-						},
-						"ip": {
-							Type:     schema.TypeString,
-							Computed: true,
 						},
 					},
 				},
@@ -83,25 +76,39 @@ func dataSourceDedicatedPublicSubnetV1() *schema.Resource {
 	}
 }
 
-func dataSourceDedicatedPublicSubnetV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceDedicatedPrivateSubnetV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dsClient, diagErr := getDedicatedClient(d, meta, true)
 	if diagErr != nil {
 		return diagErr
 	}
 
-	filter := expandDedicatedPublicSubnetsSearchFilter(d)
+	filter := expandDedicatedPrivateSubnetsSearchFilter(d)
 
-	subnets, _, err := dsClient.NetworkSubnets(ctx, filter.locationID)
+	var allSubnets dedicated.Subnets
+
+	nets, _, err := dsClient.Networks(ctx, filter.locationID, dedicated.NetworkTypeLocal, filter.vlan)
 	if err != nil {
-		return diag.FromErr(errGettingObjects(objectSubnet, err))
+		return diag.FromErr(errGettingObjects(objectNetwork, err))
 	}
 
-	filteredSubnets, err := filterDedicatedPublicSubnets(subnets, filter)
+	// Get subnets for all networks in the location
+	for _, network := range nets {
+		localSubnets, _, err := dsClient.NetworkLocalSubnets(ctx, network.UUID)
+		if err != nil {
+			continue // Continue with other networks if one fails
+		}
+		allSubnets = append(allSubnets, localSubnets...)
+	}
+
+	filteredSubnets, err := filterDedicatedPrivateSubnets(allSubnets, filter)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error filtering subnets: %w", err))
 	}
 
-	subnetsFlatten := flattenDedicatedPublicSubnets(filteredSubnets, filter)
+	subnetsFlatten, err := flattenDedicatedPrivateSubnets(ctx, filteredSubnets, dsClient)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	if err := d.Set("subnets", subnetsFlatten); err != nil {
 		return diag.FromErr(err)
 	}
@@ -123,14 +130,15 @@ func dataSourceDedicatedPublicSubnetV1Read(ctx context.Context, d *schema.Resour
 	return nil
 }
 
-type dedicatedPublicSubnetsSearchFilter struct {
+type dedicatedPrivateSubnetsSearchFilter struct {
+	locationID string
 	ip         string
 	subnet     string
-	locationID string
+	vlan       string
 }
 
-func expandDedicatedPublicSubnetsSearchFilter(d *schema.ResourceData) dedicatedPublicSubnetsSearchFilter {
-	filter := dedicatedPublicSubnetsSearchFilter{}
+func expandDedicatedPrivateSubnetsSearchFilter(d *schema.ResourceData) dedicatedPrivateSubnetsSearchFilter {
+	filter := dedicatedPrivateSubnetsSearchFilter{}
 
 	filterSet, ok := d.Get("filter").(*schema.Set)
 	if !ok {
@@ -141,7 +149,12 @@ func expandDedicatedPublicSubnetsSearchFilter(d *schema.ResourceData) dedicatedP
 		return filter
 	}
 
-	resourceFilterMap := filterSet.List()[0].(map[string]interface{})
+	resourceFilterMap := filterSet.List()[0].(map[string]any)
+
+	locationID, ok := resourceFilterMap["location_id"]
+	if ok {
+		filter.locationID = locationID.(string)
+	}
 
 	ip, ok := resourceFilterMap["ip"]
 	if ok {
@@ -153,15 +166,15 @@ func expandDedicatedPublicSubnetsSearchFilter(d *schema.ResourceData) dedicatedP
 		filter.subnet = subnet.(string)
 	}
 
-	locationID, ok := resourceFilterMap["location_id"]
+	vlan, ok := resourceFilterMap["vlan"]
 	if ok {
-		filter.locationID = locationID.(string)
+		filter.vlan = vlan.(string)
 	}
 
 	return filter
 }
 
-func filterDedicatedPublicSubnets(subnets dedicated.Subnets, filter dedicatedPublicSubnetsSearchFilter) (dedicated.Subnets, error) {
+func filterDedicatedPrivateSubnets(subnets dedicated.Subnets, filter dedicatedPrivateSubnetsSearchFilter) (dedicated.Subnets, error) {
 	var filteredSubnets dedicated.Subnets
 	for _, subnet := range subnets {
 		isIPIncluded := false
@@ -173,8 +186,7 @@ func filterDedicatedPublicSubnets(subnets dedicated.Subnets, filter dedicatedPub
 			}
 		}
 
-		if (filter.subnet == "" || filter.subnet == subnet.Subnet) &&
-			(filter.ip == "" || isIPIncluded) {
+		if (filter.subnet == "" || filter.subnet == subnet.Subnet) && (filter.ip == "" || isIPIncluded) {
 			filteredSubnets = append(filteredSubnets, subnet)
 
 			continue
@@ -184,23 +196,30 @@ func filterDedicatedPublicSubnets(subnets dedicated.Subnets, filter dedicatedPub
 	return filteredSubnets, nil
 }
 
-func flattenDedicatedPublicSubnets(subnets dedicated.Subnets, filter dedicatedPublicSubnetsSearchFilter) []interface{} {
-	subnetsList := make([]interface{}, len(subnets))
-	for i, subnet := range subnets {
-		subnetMap := make(map[string]interface{})
-		subnetMap["id"] = subnet.UUID
-		subnetMap["network_id"] = subnet.NetworkUUID
-		subnetMap["subnet"] = subnet.Subnet
-		subnetMap["broadcast"] = subnet.Broadcast.String()
-		subnetMap["gateway"] = subnet.Gateway.String()
-		subnetMap["reserved_vrrp_ips"] = subnet.ReservedVRRPIPAsStrings()
+func flattenDedicatedPrivateSubnets(ctx context.Context, subnets dedicated.Subnets, dsClient *dedicated.ServiceClient) ([]map[string]any, error) {
+	subnetsList := make([]map[string]any, 0, len(subnets))
 
-		if filter.ip != "" {
-			subnetMap["ip"] = filter.ip
+	for _, subnet := range subnets {
+		subnetMap := make(map[string]any)
+
+		subnetMap["id"] = subnet.UUID
+		subnetMap["vlan"] = strconv.Itoa(subnet.Network)
+		subnetMap["subnet"] = subnet.Subnet
+
+		reservedIPs, _, err := dsClient.NetworkSubnetLocalReservedIPs(ctx, subnet.UUID)
+		if err != nil {
+			return nil, err
 		}
 
-		subnetsList[i] = subnetMap
+		var ips []string
+		for _, reservedIP := range reservedIPs {
+			ips = append(ips, reservedIP.IP.String())
+		}
+
+		subnetMap["reserved_ip"] = ips
+
+		subnetsList = append(subnetsList, subnetMap)
 	}
 
-	return subnetsList
+	return subnetsList, nil
 }

--- a/selectel/data_source_selectel_dedicated_private_subnet_v1.go
+++ b/selectel/data_source_selectel_dedicated_private_subnet_v1.go
@@ -42,7 +42,7 @@ func dataSourceDedicatedPrivateSubnetV1() *schema.Resource {
 							ValidateFunc: validation.IsCIDR,
 						},
 						"vlan": {
-							Type:         schema.TypeString,
+							Type:         schema.TypeInt,
 							Optional:     true,
 							ValidateFunc: validation.IntBetween(1, 3499),
 						},
@@ -91,7 +91,7 @@ func dataSourceDedicatedPrivateSubnetV1Read(ctx context.Context, d *schema.Resou
 
 	var allSubnets dedicated.Subnets
 
-	nets, _, err := dsClient.Networks(ctx, filter.locationID, dedicated.NetworkTypeLocal, filter.vlan)
+	nets, _, err := dsClient.Networks(ctx, filter.locationID, dedicated.NetworkTypeLocal, strconv.Itoa(filter.vlan))
 	if err != nil {
 		return diag.FromErr(errGettingObjects(objectNetwork, err))
 	}
@@ -141,7 +141,7 @@ type dedicatedPrivateSubnetsSearchFilter struct {
 	locationID string
 	ip         string
 	subnet     string
-	vlan       string
+	vlan       int
 }
 
 func expandDedicatedPrivateSubnetsSearchFilter(d *schema.ResourceData) dedicatedPrivateSubnetsSearchFilter {
@@ -175,7 +175,7 @@ func expandDedicatedPrivateSubnetsSearchFilter(d *schema.ResourceData) dedicated
 
 	vlan, ok := resourceFilterMap["vlan"]
 	if ok {
-		filter.vlan = vlan.(string)
+		filter.vlan = vlan.(int)
 	}
 
 	return filter

--- a/selectel/data_source_selectel_dedicated_private_subnet_v1.go
+++ b/selectel/data_source_selectel_dedicated_private_subnet_v1.go
@@ -6,6 +6,8 @@ import (
 	"slices"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	dedicated "github.com/selectel/dedicated-go/v2/pkg/v2"
@@ -30,16 +32,19 @@ func dataSourceDedicatedPrivateSubnetV1() *schema.Resource {
 							Optional: true,
 						},
 						"ip": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.IsIPv4Range,
 						},
 						"subnet": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.IsCIDR,
 						},
 						"vlan": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(1, 3499),
 						},
 					},
 				},
@@ -62,7 +67,7 @@ func dataSourceDedicatedPrivateSubnetV1() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"reserved_ip": {
+						"reserved_ips": {
 							Type:     schema.TypeList,
 							Computed: true,
 							Elem: &schema.Schema{
@@ -95,7 +100,7 @@ func dataSourceDedicatedPrivateSubnetV1Read(ctx context.Context, d *schema.Resou
 	for _, network := range nets {
 		localSubnets, _, err := dsClient.NetworkLocalSubnets(ctx, network.UUID)
 		if err != nil {
-			continue // Continue with other networks if one fails
+			return diag.FromErr(fmt.Errorf("error getting local subnets for network %s: %w", network.UUID, err))
 		}
 		allSubnets = append(allSubnets, localSubnets...)
 	}
@@ -109,7 +114,9 @@ func dataSourceDedicatedPrivateSubnetV1Read(ctx context.Context, d *schema.Resou
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("subnets", subnetsFlatten); err != nil {
+
+	err = d.Set("subnets", subnetsFlatten)
+	if err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -188,15 +195,15 @@ func filterDedicatedPrivateSubnets(subnets dedicated.Subnets, filter dedicatedPr
 
 		if (filter.subnet == "" || filter.subnet == subnet.Subnet) && (filter.ip == "" || isIPIncluded) {
 			filteredSubnets = append(filteredSubnets, subnet)
-
-			continue
 		}
 	}
 
 	return filteredSubnets, nil
 }
 
-func flattenDedicatedPrivateSubnets(ctx context.Context, subnets dedicated.Subnets, dsClient *dedicated.ServiceClient) ([]map[string]any, error) {
+func flattenDedicatedPrivateSubnets(
+	ctx context.Context, subnets dedicated.Subnets, dsClient *dedicated.ServiceClient,
+) ([]map[string]any, error) {
 	subnetsList := make([]map[string]any, 0, len(subnets))
 
 	for _, subnet := range subnets {
@@ -216,7 +223,7 @@ func flattenDedicatedPrivateSubnets(ctx context.Context, subnets dedicated.Subne
 			ips = append(ips, reservedIP.IP.String())
 		}
 
-		subnetMap["reserved_ip"] = ips
+		subnetMap["reserved_ips"] = ips
 
 		subnetsList = append(subnetsList, subnetMap)
 	}

--- a/selectel/data_source_selectel_dedicated_private_subnet_v1.go
+++ b/selectel/data_source_selectel_dedicated_private_subnet_v1.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	dedicated "github.com/selectel/dedicated-go/pkg/v2"
+	dedicated "github.com/selectel/dedicated-go/v2/pkg/v2"
 )
 
 func dataSourceDedicatedPrivateSubnetV1() *schema.Resource {

--- a/selectel/data_source_selectel_dedicated_private_subnet_v1.go
+++ b/selectel/data_source_selectel_dedicated_private_subnet_v1.go
@@ -17,9 +17,8 @@ func dataSourceDedicatedPrivateSubnetV1() *schema.Resource {
 		ReadContext: dataSourceDedicatedPrivateSubnetV1Read,
 		Schema: map[string]*schema.Schema{
 			"project_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.IsUUID,
+				Type:     schema.TypeString,
+				Required: true,
 			},
 			"filter": {
 				Type:     schema.TypeSet,

--- a/selectel/data_source_selectel_dedicated_private_subnet_v1.go
+++ b/selectel/data_source_selectel_dedicated_private_subnet_v1.go
@@ -42,9 +42,8 @@ func dataSourceDedicatedPrivateSubnetV1() *schema.Resource {
 							ValidateFunc: validation.IsCIDR,
 						},
 						"vlan": {
-							Type:         schema.TypeInt,
-							Optional:     true,
-							ValidateFunc: validation.IntBetween(1, 3499),
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 					},
 				},
@@ -91,7 +90,7 @@ func dataSourceDedicatedPrivateSubnetV1Read(ctx context.Context, d *schema.Resou
 
 	var allSubnets dedicated.Subnets
 
-	nets, _, err := dsClient.Networks(ctx, filter.locationID, dedicated.NetworkTypeLocal, strconv.Itoa(filter.vlan))
+	nets, _, err := dsClient.Networks(ctx, filter.locationID, dedicated.NetworkTypeLocal, filter.vlan)
 	if err != nil {
 		return diag.FromErr(errGettingObjects(objectNetwork, err))
 	}
@@ -141,7 +140,7 @@ type dedicatedPrivateSubnetsSearchFilter struct {
 	locationID string
 	ip         string
 	subnet     string
-	vlan       int
+	vlan       string
 }
 
 func expandDedicatedPrivateSubnetsSearchFilter(d *schema.ResourceData) dedicatedPrivateSubnetsSearchFilter {
@@ -175,7 +174,7 @@ func expandDedicatedPrivateSubnetsSearchFilter(d *schema.ResourceData) dedicated
 
 	vlan, ok := resourceFilterMap["vlan"]
 	if ok {
-		filter.vlan = vlan.(int)
+		filter.vlan = vlan.(string)
 	}
 
 	return filter

--- a/selectel/data_source_selectel_dedicated_private_subnet_v1_test.go
+++ b/selectel/data_source_selectel_dedicated_private_subnet_v1_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	dedicated "github.com/selectel/dedicated-go/pkg/v2"
+	dedicated "github.com/selectel/dedicated-go/v2/pkg/v2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/selectel/data_source_selectel_dedicated_private_subnet_v1_test.go
+++ b/selectel/data_source_selectel_dedicated_private_subnet_v1_test.go
@@ -1,0 +1,303 @@
+package selectel
+
+import (
+	"fmt"
+	"github.com/selectel/go-selvpcclient/v4/selvpcclient/resell/v2/projects"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	dedicated "github.com/selectel/dedicated-go/pkg/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAccDedicatedPrivateSubnetV1DataSource(t *testing.T) {
+	var (
+		project      projects.Project
+		projectName  = acctest.RandomWithPrefix("tf-acc")
+		locationName = "SPB-5"
+		vlan         = "2989"
+		subnet       = "10.10.10.0/24"
+		ip           = "10.10.10.10"
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccSelectelPreCheckWithAuth(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDedicatedPrivateSubnetV1DataSourceBasic(projectName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVPCV2ProjectExists("selectel_vpc_project_v2.project_tf_acc_test_1", &project),
+					resource.TestCheckResourceAttrSet("data.selectel_dedicated_private_subnet_v1.subnet_ds", "subnets.#"),
+					resource.TestCheckResourceAttrSet("data.selectel_dedicated_private_subnet_v1.subnet_ds", "subnets.0.id"),
+					resource.TestCheckResourceAttrSet("data.selectel_dedicated_private_subnet_v1.subnet_ds", "subnets.0.subnet"),
+					resource.TestCheckResourceAttrSet("data.selectel_dedicated_private_subnet_v1.subnet_ds", "subnets.0.vlan"),
+					resource.TestCheckResourceAttrSet("data.selectel_dedicated_private_subnet_v1.subnet_ds", "subnets.0.reserved_ip.#"),
+				),
+			},
+			{
+				Config:   testAccDedicatedPrivateSubnetV1DataSourceBasic(projectName),
+				PlanOnly: true,
+			},
+			{
+				Config: testAccDedicatedPrivateSubnetV1DataSourceWithLocationFilter(projectName, locationName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDedicatedLocationV1Exists("data.selectel_dedicated_location_v1.location_tf_acc_test_1", locationName),
+					resource.TestCheckResourceAttr("data.selectel_dedicated_private_subnet_v1.subnet_ds", "subnets.#", "1"),
+				),
+			},
+			{
+				Config: testAccDedicatedPrivateSubnetV1DataSourceWithVLANFilter(projectName, vlan),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.selectel_dedicated_private_subnet_v1.subnet_ds", "subnets.#", "1"),
+					resource.TestCheckResourceAttr(
+						"data.selectel_dedicated_private_subnet_v1.subnet_ds",
+						"subnets.0.vlan",
+						vlan,
+					),
+				),
+			},
+			{
+				Config: testAccDedicatedPrivateSubnetV1DataSourceWithSubnetFilter(projectName, subnet),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.selectel_dedicated_private_subnet_v1.subnet_ds", "subnets.#", "1"),
+					resource.TestCheckResourceAttr(
+						"data.selectel_dedicated_private_subnet_v1.subnet_ds",
+						"subnets.0.subnet",
+						subnet,
+					),
+				),
+			},
+			{
+				Config: testAccDedicatedPrivateSubnetV1DataSourceWithIPFilter(projectName, ip),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.selectel_dedicated_private_subnet_v1.subnet_ds", "subnets.#", "1"),
+					resource.TestCheckResourceAttr(
+						"data.selectel_dedicated_private_subnet_v1.subnet_ds",
+						"subnets.0.subnet",
+						subnet,
+					),
+				),
+			},
+			{
+				Config: testAccDedicatedPrivateSubnetV1DataSourceWithIPFilter(projectName, "1.1.1.1"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.selectel_dedicated_private_subnet_v1.subnet_ds", "subnets.#", "0"),
+				),
+			},
+			{
+				Config:      testAccDedicatedPrivateSubnetV1DataSourceWithVLANFilter(projectName, "wrong"),
+				ExpectError: regexp.MustCompile(`invalid parameters to filter on tag or vlan`),
+			},
+			{
+				Config:      testAccDedicatedPrivateSubnetV1DataSourceWithIPFilter(projectName, "wrong"),
+				ExpectError: regexp.MustCompile(`invalid`),
+			},
+		},
+	})
+}
+
+func Test_filterDedicatedPrivateSubnets(t *testing.T) {
+	unfilteredList := dedicated.Subnets{
+		{
+			UUID:   "1",
+			Subnet: "192.168.1.0/24",
+		},
+		{
+			UUID:   "2",
+			Subnet: "10.0.0.0/16",
+		},
+		{
+			UUID:   "3",
+			Subnet: "172.16.0.0/12",
+		},
+	}
+
+	type args struct {
+		subnets dedicated.Subnets
+		filter  dedicatedPrivateSubnetsSearchFilter
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    dedicated.Subnets
+		wantErr bool
+	}{
+		{
+			name: "EmptyFilter",
+			args: args{
+				subnets: unfilteredList,
+				filter:  dedicatedPrivateSubnetsSearchFilter{},
+			},
+			want: unfilteredList,
+		},
+		{
+			name: "IncludeSubnet",
+			args: args{
+				subnets: unfilteredList,
+				filter: dedicatedPrivateSubnetsSearchFilter{
+					subnet: unfilteredList[0].Subnet,
+				},
+			},
+			want: dedicated.Subnets{
+				unfilteredList[0],
+			},
+		},
+		{
+			name: "IncludeIP",
+			args: args{
+				subnets: unfilteredList,
+				filter: dedicatedPrivateSubnetsSearchFilter{
+					ip: "10.0.0.1",
+				},
+			},
+			want: dedicated.Subnets{
+				unfilteredList[1],
+			},
+		},
+		{
+			name: "IncludeIPAndSubnet",
+			args: args{
+				subnets: unfilteredList,
+				filter: dedicatedPrivateSubnetsSearchFilter{
+					ip:     "10.0.0.1",
+					subnet: unfilteredList[1].Subnet,
+				},
+			},
+			want: dedicated.Subnets{
+				unfilteredList[1],
+			},
+		},
+		{
+			name: "IncludeIPFrom172Range",
+			args: args{
+				subnets: unfilteredList,
+				filter: dedicatedPrivateSubnetsSearchFilter{
+					ip: "172.16.0.10",
+				},
+			},
+			want: dedicated.Subnets{
+				unfilteredList[2],
+			},
+		},
+		{
+			name: "NoMatches",
+			args: args{
+				subnets: unfilteredList,
+				filter: dedicatedPrivateSubnetsSearchFilter{
+					ip:     "10.0.0.1",
+					subnet: unfilteredList[0].Subnet,
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "NoMatches2",
+			args: args{
+				subnets: unfilteredList,
+				filter: dedicatedPrivateSubnetsSearchFilter{
+					ip:     "8.0.0.1",
+					subnet: "8.0.0.0/24",
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "InvalidIPErr",
+			args: args{
+				subnets: unfilteredList,
+				filter: dedicatedPrivateSubnetsSearchFilter{
+					ip: "invalid",
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := filterDedicatedPrivateSubnets(tt.args.subnets, tt.args.filter)
+			assert.Equal(t, tt.wantErr, err != nil)
+			assert.Equalf(t, tt.want, got, "filterDedicatedPrivateSubnets(%v, %v)", tt.args.subnets, tt.args.filter)
+		})
+	}
+}
+
+func testAccDedicatedPrivateSubnetV1DataSourceBasic(projectName string) string {
+	return fmt.Sprintf(`
+resource "selectel_vpc_project_v2" "project_tf_acc_test_1" {
+ name        = "%s"
+}
+
+data "selectel_dedicated_private_subnet_v1" "subnet_ds" {
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+}`, projectName)
+}
+
+func testAccDedicatedPrivateSubnetV1DataSourceWithLocationFilter(projectName, locationName string) string {
+	return fmt.Sprintf(`
+resource "selectel_vpc_project_v2" "project_tf_acc_test_1" {
+ name        = "%s"
+}
+
+data "selectel_dedicated_location_v1" "location_tf_acc_test_1" {
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  filter {
+    name = "%s"
+  }
+}
+
+data "selectel_dedicated_private_subnet_v1" "subnet_ds" {
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  
+  filter {
+    location_id = "${data.selectel_dedicated_location_v1.location_tf_acc_test_1.locations[0].id}"
+  }
+}`, projectName, locationName)
+}
+
+func testAccDedicatedPrivateSubnetV1DataSourceWithVLANFilter(projectName, vlan string) string {
+	return fmt.Sprintf(`
+resource "selectel_vpc_project_v2" "project_tf_acc_test_1" {
+ name        = "%s"
+}
+
+data "selectel_dedicated_private_subnet_v1" "subnet_ds" {
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  
+  filter {
+    vlan = "%s"
+  }
+}`, projectName, vlan)
+}
+
+func testAccDedicatedPrivateSubnetV1DataSourceWithSubnetFilter(projectName, subnet string) string {
+	return fmt.Sprintf(`
+resource "selectel_vpc_project_v2" "project_tf_acc_test_1" {
+ name        = "%s"
+}
+
+data "selectel_dedicated_private_subnet_v1" "subnet_ds" {
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  
+  filter {
+    subnet = "%s"
+  }
+}`, projectName, subnet)
+}
+
+func testAccDedicatedPrivateSubnetV1DataSourceWithIPFilter(projectName, ip string) string {
+	return fmt.Sprintf(`
+resource "selectel_vpc_project_v2" "project_tf_acc_test_1" {
+ name        = "%s"
+}
+
+data "selectel_dedicated_private_subnet_v1" "subnet_ds" {
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  
+  filter {
+    ip = "%s"
+  }
+}`, projectName, ip)
+}

--- a/selectel/data_source_selectel_dedicated_private_subnet_v1_test.go
+++ b/selectel/data_source_selectel_dedicated_private_subnet_v1_test.go
@@ -5,11 +5,10 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/selectel/go-selvpcclient/v4/selvpcclient/resell/v2/projects"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	dedicated "github.com/selectel/dedicated-go/v2/pkg/v2"
+	"github.com/selectel/go-selvpcclient/v4/selvpcclient/resell/v2/projects"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/selectel/data_source_selectel_dedicated_private_subnet_v1_test.go
+++ b/selectel/data_source_selectel_dedicated_private_subnet_v1_test.go
@@ -2,9 +2,10 @@ package selectel
 
 import (
 	"fmt"
-	"github.com/selectel/go-selvpcclient/v4/selvpcclient/resell/v2/projects"
 	"regexp"
 	"testing"
+
+	"github.com/selectel/go-selvpcclient/v4/selvpcclient/resell/v2/projects"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -34,7 +35,7 @@ func TestAccDedicatedPrivateSubnetV1DataSource(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.selectel_dedicated_private_subnet_v1.subnet_ds", "subnets.0.id"),
 					resource.TestCheckResourceAttrSet("data.selectel_dedicated_private_subnet_v1.subnet_ds", "subnets.0.subnet"),
 					resource.TestCheckResourceAttrSet("data.selectel_dedicated_private_subnet_v1.subnet_ds", "subnets.0.vlan"),
-					resource.TestCheckResourceAttrSet("data.selectel_dedicated_private_subnet_v1.subnet_ds", "subnets.0.reserved_ip.#"),
+					resource.TestCheckResourceAttrSet("data.selectel_dedicated_private_subnet_v1.subnet_ds", "subnets.0.reserved_ips.#"),
 				),
 			},
 			{

--- a/selectel/data_source_selectel_dedicated_public_subnet_v1.go
+++ b/selectel/data_source_selectel_dedicated_public_subnet_v1.go
@@ -102,7 +102,9 @@ func dataSourceDedicatedPublicSubnetV1Read(ctx context.Context, d *schema.Resour
 	}
 
 	subnetsFlatten := flattenDedicatedPublicSubnets(filteredSubnets, filter)
-	if err := d.Set("subnets", subnetsFlatten); err != nil {
+
+	err = d.Set("subnets", subnetsFlatten)
+	if err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/selectel/data_source_selectel_dedicated_public_subnet_v1.go
+++ b/selectel/data_source_selectel_dedicated_public_subnet_v1.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	dedicated "github.com/selectel/dedicated-go/pkg/v2"
+	dedicated "github.com/selectel/dedicated-go/v2/pkg/v2"
 )
 
 func dataSourceDedicatedPublicSubnetV1() *schema.Resource {

--- a/selectel/data_source_selectel_dedicated_public_subnet_v1_test.go
+++ b/selectel/data_source_selectel_dedicated_public_subnet_v1_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	dedicated "github.com/selectel/dedicated-go/pkg/v2"
+	dedicated "github.com/selectel/dedicated-go/v2/pkg/v2"
 	"github.com/selectel/go-selvpcclient/v4/selvpcclient/resell/v2/projects"
 	"github.com/stretchr/testify/assert"
 )

--- a/selectel/dedicated.go
+++ b/selectel/dedicated.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	dedicated "github.com/selectel/dedicated-go/pkg/v2"
+	dedicated "github.com/selectel/dedicated-go/v2/pkg/v2"
 	"github.com/selectel/go-selvpcclient/v4/selvpcclient"
 	"github.com/selectel/go-selvpcclient/v4/selvpcclient/resell/v2/servers"
 	"github.com/terraform-providers/terraform-provider-selectel/selectel/internal/hashcode"

--- a/selectel/dedicated.go
+++ b/selectel/dedicated.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	dedicated "github.com/selectel/dedicated-go/pkg/v2"
+	"github.com/selectel/go-selvpcclient/v4/selvpcclient"
 	"github.com/selectel/go-selvpcclient/v4/selvpcclient/resell/v2/servers"
 	"github.com/terraform-providers/terraform-provider-selectel/selectel/internal/hashcode"
 )
@@ -39,13 +40,25 @@ func hashServers(v interface{}) int {
 	return hashcode.String(fmt.Sprintf("%s-", m["id"].(string)))
 }
 
-func getDedicatedClient(d *schema.ResourceData, meta interface{}) (*dedicated.ServiceClient, diag.Diagnostics) {
+func getDedicatedClient(d *schema.ResourceData, meta interface{}, withProjectScope bool) (*dedicated.ServiceClient, diag.Diagnostics) {
 	config := meta.(*Config)
-	projectID := d.Get(dedicatedServerSchemaKeyProjectID).(string)
 
-	selvpcClient, err := config.GetSelVPCClientWithProjectScope(projectID)
-	if err != nil {
-		return nil, diag.FromErr(fmt.Errorf("can't get project-scope selvpc client for dedicated servers api: %w", err))
+	var (
+		selvpcClient *selvpcclient.Client
+		err          error
+	)
+
+	if withProjectScope {
+		projectID := d.Get(dedicatedServerSchemaKeyProjectID).(string)
+		selvpcClient, err = config.GetSelVPCClientWithProjectScope(projectID)
+		if err != nil {
+			return nil, diag.FromErr(fmt.Errorf("can't get project-scope selvpc client for dedicated servers api: %w", err))
+		}
+	} else {
+		selvpcClient, err = config.GetSelVPCClient()
+		if err != nil {
+			return nil, diag.FromErr(fmt.Errorf("can't get selvpc client for dedicated servers api: %w", err))
+		}
 	}
 
 	url := "https://api.selectel.ru/servers/v2"
@@ -499,7 +512,7 @@ func resourceDedicatedServerV1GetFreePublicIPs(
 		)
 	}
 
-	nets, _, err := cl.Networks(ctx, locationID, dedicated.NetworkTypeInet)
+	nets, _, err := cl.Networks(ctx, locationID, dedicated.NetworkTypeInet, "")
 	if err != nil {
 		return nil, fmt.Errorf(
 			"failed to get %s networks for %s %s: %w", dedicated.NetworkTypeInet, objectLocation, locationID, err,
@@ -518,7 +531,7 @@ func resourceDedicatedServerV1GetFreePublicIPs(
 		)
 	}
 
-	reservedIPs, _, err := cl.NetworkReservedIPs(ctx, locationID)
+	reservedIPs, _, err := cl.NetworkReservedIPs(ctx, locationID, "")
 	if err != nil {
 		return nil, fmt.Errorf(
 			"failed to get reserved ips for %s %s: %w", objectLocation, locationID, err,
@@ -533,53 +546,6 @@ func resourceDedicatedServerV1GetFreePublicIPs(
 	}
 
 	return freeIP, nil
-}
-
-func resourceDedicatedServerV1GetFreePrivateIPs(
-	ctx context.Context, cl *dedicated.ServiceClient, locationID, subnetStr string,
-) (ip net.IP, subnetID string, err error) {
-	nets, _, err := cl.Networks(ctx, locationID, dedicated.NetworkTypeLocal)
-	if err != nil {
-		return nil, "", fmt.Errorf(
-			"failed to get %s networks for %s %s: %w", dedicated.NetworkTypeInet, objectLocation, locationID, err,
-		)
-	}
-
-	if len(nets) != 1 {
-		return nil, "", fmt.Errorf(
-			"expected exactly one local network for %s %s, got %d", objectLocation, locationID, len(nets),
-		)
-	}
-
-	subnets, _, err := cl.NetworkLocalSubnets(ctx, nets[0].UUID)
-	if err != nil {
-		return nil, "", fmt.Errorf(
-			"failed to get subnets for %s %s: %w", objectLocation, locationID, err,
-		)
-	}
-
-	subnet := subnets.FindBySubnet(subnetStr)
-	if subnet == nil {
-		return nil, "", fmt.Errorf(
-			"can't find subnet %s for %s %s and network %s", subnetStr, objectLocation, locationID, nets[0].UUID,
-		)
-	}
-
-	reservedIPs, _, err := cl.NetworkSubnetLocalReservedIPs(ctx, subnet.UUID)
-	if err != nil {
-		return nil, "", fmt.Errorf(
-			"failed to get reserved ips for %s %s: %w", objectLocation, locationID, err,
-		)
-	}
-
-	freeIP, err := subnet.GetFreeIP(reservedIPs, true)
-	if err != nil {
-		return nil, "", fmt.Errorf(
-			"failed to compute free ips for %s %s: %w", objectLocation, locationID, err,
-		)
-	}
-
-	return freeIP, subnet.UUID, nil
 }
 
 var defaultHostNames = [52]string{

--- a/selectel/dedicated_test.go
+++ b/selectel/dedicated_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	dedicated "github.com/selectel/dedicated-go/pkg/v2"
+	dedicated "github.com/selectel/dedicated-go/v2/pkg/v2"
 	"github.com/selectel/go-selvpcclient/v4/selvpcclient/resell/v2/servers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/selectel/internal/reflect/map.go
+++ b/selectel/internal/reflect/map.go
@@ -10,7 +10,6 @@ func IsSetContainsSubset(subset map[string]interface{}, set any) bool {
 }
 
 func match(subset map[string]interface{}, val reflect.Value) bool {
-	// разыменовываем указатели
 	if val.Kind() == reflect.Ptr {
 		val = val.Elem()
 	}
@@ -47,7 +46,6 @@ func match(subset map[string]interface{}, val reflect.Value) bool {
 
 func matchValue(subsetValue any, setValue any) bool {
 	switch subsetValueTyped := subsetValue.(type) {
-
 	case map[string]interface{}:
 		return IsSetContainsSubset(subsetValueTyped, setValue)
 
@@ -56,6 +54,7 @@ func matchValue(subsetValue any, setValue any) bool {
 		if !ok {
 			return false
 		}
+
 		return isArrayContainsSubarray(subsetValueTyped, setSlice)
 
 	default:

--- a/selectel/internal/reflect/map.go
+++ b/selectel/internal/reflect/map.go
@@ -1,38 +1,81 @@
 package reflect
 
-import "reflect"
+import (
+	"reflect"
+	"strings"
+)
 
-func IsSetContainsSubset(subset, set map[string]interface{}) bool {
+func IsSetContainsSubset(subset map[string]interface{}, set any) bool {
+	return match(subset, reflect.ValueOf(set))
+}
+
+func match(subset map[string]interface{}, val reflect.Value) bool {
+	// разыменовываем указатели
+	if val.Kind() == reflect.Ptr {
+		val = val.Elem()
+	}
+
 	for k, subsetValue := range subset {
-		setValue, ok := set[k]
-		if !ok {
-			return false
-		}
+		var fieldValue reflect.Value
 
-		switch subsetValueTyped := subsetValue.(type) {
-		case map[string]interface{}:
-			setValueTyped, ok := setValue.(map[string]interface{})
-			if !ok || !IsSetContainsSubset(subsetValueTyped, setValueTyped) {
+		switch val.Kind() {
+		case reflect.Map:
+			fieldValue = val.MapIndex(reflect.ValueOf(k))
+			if !fieldValue.IsValid() {
 				return false
 			}
 
-		case []interface{}:
-			setValueTyped, ok := setValue.([]interface{})
-			if !ok {
-				return false
-			}
-			if !isArrayContainsSubarray(subsetValueTyped, setValueTyped) {
+		case reflect.Struct:
+			fieldValue = val.FieldByNameFunc(func(name string) bool {
+				return strings.EqualFold(name, k)
+			})
+			if !fieldValue.IsValid() {
 				return false
 			}
 
 		default:
-			if !reflect.DeepEqual(subsetValue, setValue) {
-				return false
-			}
+			return false
+		}
+
+		if !matchValue(subsetValue, fieldValue.Interface()) {
+			return false
 		}
 	}
 
 	return true
+}
+
+func matchValue(subsetValue any, setValue any) bool {
+	switch subsetValueTyped := subsetValue.(type) {
+
+	case map[string]interface{}:
+		return IsSetContainsSubset(subsetValueTyped, setValue)
+
+	case []interface{}:
+		setSlice, ok := toSlice(setValue)
+		if !ok {
+			return false
+		}
+		return isArrayContainsSubarray(subsetValueTyped, setSlice)
+
+	default:
+		return reflect.DeepEqual(subsetValue, setValue)
+	}
+}
+
+func toSlice(v any) ([]interface{}, bool) {
+	val := reflect.ValueOf(v)
+
+	if val.Kind() != reflect.Slice && val.Kind() != reflect.Array {
+		return nil, false
+	}
+
+	var result []interface{}
+	for i := 0; i < val.Len(); i++ {
+		result = append(result, val.Index(i).Interface())
+	}
+
+	return result, true
 }
 
 func isArrayContainsSubarray(subarray, array []interface{}) bool {

--- a/selectel/internal/reflect/map.go
+++ b/selectel/internal/reflect/map.go
@@ -32,6 +32,33 @@ func match(subset map[string]interface{}, val reflect.Value) bool {
 				return false
 			}
 
+		case reflect.Invalid,
+			reflect.Bool,
+			reflect.Int,
+			reflect.Int8,
+			reflect.Int16,
+			reflect.Int32,
+			reflect.Int64,
+			reflect.Uint,
+			reflect.Uint8,
+			reflect.Uint16,
+			reflect.Uint32,
+			reflect.Uint64,
+			reflect.Uintptr,
+			reflect.Float32,
+			reflect.Float64,
+			reflect.Complex64,
+			reflect.Complex128,
+			reflect.Array,
+			reflect.Chan,
+			reflect.Func,
+			reflect.Interface,
+			reflect.Pointer,
+			reflect.Slice,
+			reflect.String,
+			reflect.UnsafePointer:
+			return false
+
 		default:
 			return false
 		}

--- a/selectel/networking.go
+++ b/selectel/networking.go
@@ -2,6 +2,7 @@ package selectel
 
 import (
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 
@@ -51,4 +52,46 @@ func subnetsMapsFromStructs(subnetsStructs []subnets.Subnet) []map[string]interf
 	}
 
 	return associatedSubnets
+}
+
+// validatePrivateSubnet checks if the provided CIDR belongs to private IP ranges:
+// 10.0.0.0/8, 172.16.0.0/12, or 192.168.0.0/16.
+func validatePrivateSubnet(cidr string) error {
+	_, network, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return fmt.Errorf("invalid CIDR format: %s", err)
+	}
+
+	// Define private IP ranges
+	privateRanges := []struct {
+		Name string
+		Net  *net.IPNet
+	}{
+		{
+			Name: "10.0.0.0/8",
+			Net:  &net.IPNet{IP: net.ParseIP("10.0.0.0"), Mask: net.CIDRMask(8, 32)},
+		},
+		{
+			Name: "172.16.0.0/12",
+			Net:  &net.IPNet{IP: net.ParseIP("172.16.0.0"), Mask: net.CIDRMask(12, 32)},
+		},
+		{
+			Name: "192.168.0.0/16",
+			Net:  &net.IPNet{IP: net.ParseIP("192.168.0.0"), Mask: net.CIDRMask(16, 32)},
+		},
+	}
+
+	// Check if the network is within any of the private ranges
+	for _, privateRange := range privateRanges {
+		if privateRange.Net.Contains(network.IP) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("subnet %s does not belong to private IP ranges: 10.0.0.0/8, 172.16.0.0/12, or 192.168.0.0/16", cidr)
+}
+
+// IsPrivateSubnet validates if the provided CIDR belongs to private IP ranges.
+func IsPrivateSubnet(cidr string) bool {
+	return validatePrivateSubnet(cidr) == nil
 }

--- a/selectel/networking.go
+++ b/selectel/networking.go
@@ -3,6 +3,7 @@ package selectel
 import (
 	"fmt"
 	"net"
+	"net/netip"
 	"strconv"
 	"strings"
 
@@ -62,36 +63,14 @@ func validatePrivateSubnet(cidr string) error {
 		return fmt.Errorf("invalid CIDR format: %s", err)
 	}
 
-	// Define private IP ranges
-	privateRanges := []struct {
-		Name string
-		Net  *net.IPNet
-	}{
-		{
-			Name: "10.0.0.0/8",
-			Net:  &net.IPNet{IP: net.ParseIP("10.0.0.0"), Mask: net.CIDRMask(8, 32)},
-		},
-		{
-			Name: "172.16.0.0/12",
-			Net:  &net.IPNet{IP: net.ParseIP("172.16.0.0"), Mask: net.CIDRMask(12, 32)},
-		},
-		{
-			Name: "192.168.0.0/16",
-			Net:  &net.IPNet{IP: net.ParseIP("192.168.0.0"), Mask: net.CIDRMask(16, 32)},
-		},
+	ipAddr, ok := netip.AddrFromSlice(network.IP)
+	if !ok {
+		return fmt.Errorf("invalid IP address: %s", network.IP)
 	}
 
-	// Check if the network is within any of the private ranges
-	for _, privateRange := range privateRanges {
-		if privateRange.Net.Contains(network.IP) {
-			return nil
-		}
+	if ipAddr.IsPrivate() {
+		return nil
 	}
 
 	return fmt.Errorf("subnet %s does not belong to private IP ranges: 10.0.0.0/8, 172.16.0.0/12, or 192.168.0.0/16", cidr)
-}
-
-// IsPrivateSubnet validates if the provided CIDR belongs to private IP ranges.
-func IsPrivateSubnet(cidr string) bool {
-	return validatePrivateSubnet(cidr) == nil
 }

--- a/selectel/networking_test.go
+++ b/selectel/networking_test.go
@@ -87,3 +87,79 @@ func TestSubnetsMapsFromStructs(t *testing.T) {
 
 	assert.ElementsMatch(t, expectedSubnetsMaps, actualSubnetsMaps)
 }
+
+func TestValidatePrivateSubnet(t *testing.T) {
+	type testCase struct {
+		cidr          string
+		expectedError bool
+	}
+	testCases := []testCase{
+		// Valid private subnets
+		{"10.0.0.0/8", false},
+		{"10.100.123.0/24", false},
+		{"10.255.255.255/32", false},
+		{"172.16.0.0/12", false},
+		{"172.20.100.0/24", false},
+		{"172.31.255.255/32", false},
+		{"192.168.0.0/16", false},
+		{"192.168.100.0/24", false},
+		{"192.168.255.255/32", false},
+
+		// Invalid private subnets (public addresses)
+		{"8.8.8.8/32", true},
+		{"1.1.1.1/32", true},
+		{"11.0.0.0/8", true},
+		{"172.32.0.0/12", true},
+		{"192.169.0.0/16", true},
+		{"172.15.0.0/12", true},
+
+		// Invalid CIDR formats
+		{"invalid-cidr", true},
+		{"10.0.0.0", true},
+		{"10.0.0.0/", true},
+		{"/8", true},
+		{"", true},
+	}
+
+	for _, tc := range testCases {
+		err := validatePrivateSubnet(tc.cidr)
+		if tc.expectedError {
+			assert.Error(t, err, "Expected error for CIDR: %s", tc.cidr)
+		} else {
+			assert.NoError(t, err, "Unexpected error for CIDR: %s", tc.cidr)
+		}
+	}
+}
+
+func TestIsPrivateSubnet(t *testing.T) {
+	testCases := map[string]bool{
+		// Should return true (valid private subnets)
+		"10.0.0.0/8":         true,
+		"10.100.123.0/24":    true,
+		"10.255.255.255/32":  true,
+		"172.16.0.0/12":      true,
+		"172.20.100.0/24":    true,
+		"172.31.255.255/32":  true,
+		"192.168.0.0/16":     true,
+		"192.168.100.0/24":   true,
+		"192.168.255.255/32": true,
+
+		// Should return false (public addresses or invalid formats)
+		"8.8.8.8/32":     false,
+		"1.1.1.1/32":     false,
+		"11.0.0.0/8":     false,
+		"172.32.0.0/12":  false,
+		"192.169.0.0/16": false,
+		"172.15.0.0/12":  false,
+		"invalid-cidr":   false,
+		"10.0.0.0":       false,
+		"10.0.0.0/":      false,
+		"/8":             false,
+		"":               false,
+	}
+
+	for cidr, expected := range testCases {
+		result := IsPrivateSubnet(cidr)
+		assert.Equal(t, expected, result, "IsPrivateSubnet returned wrong value for CIDR: %s", cidr)
+	}
+}

--- a/selectel/networking_test.go
+++ b/selectel/networking_test.go
@@ -130,36 +130,3 @@ func TestValidatePrivateSubnet(t *testing.T) {
 		}
 	}
 }
-
-func TestIsPrivateSubnet(t *testing.T) {
-	testCases := map[string]bool{
-		// Should return true (valid private subnets)
-		"10.0.0.0/8":         true,
-		"10.100.123.0/24":    true,
-		"10.255.255.255/32":  true,
-		"172.16.0.0/12":      true,
-		"172.20.100.0/24":    true,
-		"172.31.255.255/32":  true,
-		"192.168.0.0/16":     true,
-		"192.168.100.0/24":   true,
-		"192.168.255.255/32": true,
-
-		// Should return false (public addresses or invalid formats)
-		"8.8.8.8/32":     false,
-		"1.1.1.1/32":     false,
-		"11.0.0.0/8":     false,
-		"172.32.0.0/12":  false,
-		"192.169.0.0/16": false,
-		"172.15.0.0/12":  false,
-		"invalid-cidr":   false,
-		"10.0.0.0":       false,
-		"10.0.0.0/":      false,
-		"/8":             false,
-		"":               false,
-	}
-
-	for cidr, expected := range testCases {
-		result := IsPrivateSubnet(cidr)
-		assert.Equal(t, expected, result, "IsPrivateSubnet returned wrong value for CIDR: %s", cidr)
-	}
-}

--- a/selectel/provider.go
+++ b/selectel/provider.go
@@ -55,7 +55,7 @@ const (
 	objectDedicatedServer              = "dedicated-server"
 	objectOS                           = "os"
 	objectLocation                     = "location"
-	objectNetwork                      = "network"
+	objectNetwork                      = "dedicated-network"
 	objectCloudBackupPlan              = "cloud-backup-plan"
 	objectCloudBackupCheckpoint        = "cloud-backup-checkpoint"
 	objectGlobalRouterZone             = "global-router-zone"

--- a/selectel/provider.go
+++ b/selectel/provider.go
@@ -55,6 +55,7 @@ const (
 	objectDedicatedServer              = "dedicated-server"
 	objectOS                           = "os"
 	objectLocation                     = "location"
+	objectNetwork                      = "network"
 	objectCloudBackupPlan              = "cloud-backup-plan"
 	objectCloudBackupCheckpoint        = "cloud-backup-checkpoint"
 	objectGlobalRouterZone             = "global-router-zone"
@@ -144,6 +145,7 @@ func Provider(providerVersion string) *schema.Provider {
 			"selectel_dedicated_os_v1":                  dataSourceDedicatedOSV1(),
 			"selectel_dedicated_location_v1":            dataSourceDedicatedLocationV1(),
 			"selectel_dedicated_public_subnet_v1":       dataSourceDedicatedPublicSubnetV1(),
+			"selectel_dedicated_private_subnet_v1":      dataSourceDedicatedPrivateSubnetV1(),
 			"selectel_cloudbackup_plan_v2":              dataSourceCloudBackupPlanV2(),
 			"selectel_cloudbackup_checkpoint_v2":        dataSourceCloudBackupCheckpointV2(),
 			"selectel_global_router_service_v1":         dataSourceGlobalRouterServiceV1(),
@@ -203,6 +205,7 @@ func Provider(providerVersion string) *schema.Provider {
 			"selectel_global_router_static_route_v1":                resourceGlobalRouterStaticRouteV1(),
 			"selectel_private_dns_service_v1":                       resourcePrivateDNSServiceV1(),
 			"selectel_private_dns_zone_v1":                          resourcePrivateDNSZoneV1(),
+			"selectel_dedicated_private_subnet_v1":                  resourceDedicatedPrivateSubnetV1(),
 		},
 	}
 

--- a/selectel/provider_test.go
+++ b/selectel/provider_test.go
@@ -73,6 +73,18 @@ func testAccSelectelPreCheckWithProjectID(t *testing.T) {
 	}
 }
 
+func testAccSelectelPreCheckWithAuth(t *testing.T) {
+	testAccSelectelPreCheck(t)
+
+	if v := os.Getenv("OS_AUTH_URL"); v == "" {
+		t.Fatal("OS_AUTH_URL must be set for acceptance tests")
+	}
+
+	if v := os.Getenv("OS_REGION_NAME"); v == "" {
+		t.Fatal("OS_REGION_NAME must be set for acceptance tests")
+	}
+}
+
 func testAccCheckSelectelImportEnv(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]

--- a/selectel/resource_selectel_dedicated_private_subnet_v1.go
+++ b/selectel/resource_selectel_dedicated_private_subnet_v1.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	dedicated "github.com/selectel/dedicated-go/v2/pkg/v2"
@@ -29,22 +31,25 @@ func resourceDedicatedPrivateSubnetV1() *schema.Resource {
 				Description: "ID of the created private subnet",
 			},
 			"location_id": {
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				Description: "Location ID where the private subnet will be created",
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				Description:  "Location ID where the private subnet will be created",
+				ValidateFunc: validation.IsUUID,
 			},
 			"vlan": {
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				Description: "VLAN TAG for the private subnet",
+				Type:         schema.TypeInt,
+				Required:     true,
+				ForceNew:     true,
+				Description:  "VLAN TAG for the private subnet",
+				ValidateFunc: validation.IntBetween(1, 3499),
 			},
 			"subnet": {
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				Description: "CIDR notation for the private subnet (e.g., 192.168.1.0/24)",
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				Description:  "CIDR notation for the private subnet (e.g., 192.168.1.0/24)",
+				ValidateFunc: validation.IsCIDR,
 			},
 		},
 	}
@@ -57,7 +62,7 @@ func resourceDedicatedPrivateSubnetV1Create(ctx context.Context, d *schema.Resou
 	}
 
 	locationID := d.Get("location_id").(string)
-	vlan := d.Get("vlan").(string)
+	vlan := d.Get("vlan").(int)
 	subnetCIDR := d.Get("subnet").(string)
 
 	// Validate private subnet
@@ -66,7 +71,7 @@ func resourceDedicatedPrivateSubnetV1Create(ctx context.Context, d *schema.Resou
 		return diag.FromErr(err)
 	}
 
-	networks, _, err := client.Networks(ctx, locationID, dedicated.NetworkTypeLocal, vlan)
+	networks, _, err := client.Networks(ctx, locationID, dedicated.NetworkTypeLocal, strconv.Itoa(vlan))
 	if err != nil {
 		return diag.Errorf("failed to get networks for location %s: %s", locationID, err)
 	}

--- a/selectel/resource_selectel_dedicated_private_subnet_v1.go
+++ b/selectel/resource_selectel_dedicated_private_subnet_v1.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	dedicated "github.com/selectel/dedicated-go/pkg/v2"
+	dedicated "github.com/selectel/dedicated-go/v2/pkg/v2"
 )
 
 func resourceDedicatedPrivateSubnetV1() *schema.Resource {

--- a/selectel/resource_selectel_dedicated_private_subnet_v1.go
+++ b/selectel/resource_selectel_dedicated_private_subnet_v1.go
@@ -1,0 +1,123 @@
+package selectel
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	dedicated "github.com/selectel/dedicated-go/pkg/v2"
+)
+
+func resourceDedicatedPrivateSubnetV1() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDedicatedPrivateSubnetV1Create,
+		ReadContext:   resourceDedicatedPrivateSubnetV1Read,
+		DeleteContext: resourceDedicatedPrivateSubnetV1Delete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "ID of the created private subnet",
+			},
+			"location_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Location ID where the private subnet will be created",
+			},
+			"vlan": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "VLAN TAG for the private subnet",
+			},
+			"subnet": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "CIDR notation for the private subnet (e.g., 192.168.1.0/24)",
+			},
+		},
+	}
+}
+
+func resourceDedicatedPrivateSubnetV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	client, diagErr := getDedicatedClient(d, meta, false)
+	if diagErr != nil {
+		return diagErr
+	}
+
+	locationID := d.Get("location_id").(string)
+	vlan := d.Get("vlan").(string)
+	subnetCIDR := d.Get("subnet").(string)
+
+	// Validate private subnet
+	err := validatePrivateSubnet(subnetCIDR)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	networks, _, err := client.Networks(ctx, locationID, dedicated.NetworkTypeLocal, vlan)
+	if err != nil {
+		return diag.Errorf("failed to get networks for location %s: %s", locationID, err)
+	}
+	if len(networks) == 0 {
+		return diag.Errorf("vlan %s not found in location %s", vlan, locationID)
+	}
+
+	localSubnet, _, err := client.CreateNetworkLocalSubnet(ctx, networks[0].UUID, subnetCIDR)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	_ = d.Set("vlan", strconv.Itoa(localSubnet.Network))
+	_ = d.Set("location_id", localSubnet.LocationUUID)
+	_ = d.Set("subnet", localSubnet.Subnet)
+	d.SetId(localSubnet.UUID)
+
+	return nil
+}
+
+func resourceDedicatedPrivateSubnetV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	client, diagErr := getDedicatedClient(d, meta, false)
+	if diagErr != nil {
+		return diagErr
+	}
+
+	localSubnet, _, err := client.GetNetworkLocalSubnet(ctx, d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	_ = d.Set("vlan", strconv.Itoa(localSubnet.Network))
+	_ = d.Set("location_id", localSubnet.LocationUUID)
+	_ = d.Set("subnet", localSubnet.Subnet)
+	d.SetId(localSubnet.UUID)
+
+	return nil
+}
+
+func resourceDedicatedPrivateSubnetV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	client, diagErr := getDedicatedClient(d, meta, false)
+	if diagErr != nil {
+		return diagErr
+	}
+
+	_, err := client.DeleteNetworkLocalSubnet(ctx, d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId("")
+
+	return nil
+}

--- a/selectel/resource_selectel_dedicated_private_subnet_v1.go
+++ b/selectel/resource_selectel_dedicated_private_subnet_v1.go
@@ -37,11 +37,10 @@ func resourceDedicatedPrivateSubnetV1() *schema.Resource {
 				ValidateFunc: validation.IsUUID,
 			},
 			"vlan": {
-				Type:         schema.TypeInt,
-				Required:     true,
-				ForceNew:     true,
-				Description:  "VLAN TAG for the private subnet",
-				ValidateFunc: validation.IntBetween(1, 3499),
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "VLAN TAG for the private subnet",
 			},
 			"subnet": {
 				Type:         schema.TypeString,
@@ -61,7 +60,7 @@ func resourceDedicatedPrivateSubnetV1Create(ctx context.Context, d *schema.Resou
 	}
 
 	locationID := d.Get("location_id").(string)
-	vlan := d.Get("vlan").(int)
+	vlan := d.Get("vlan").(string)
 	subnetCIDR := d.Get("subnet").(string)
 
 	// Validate private subnet
@@ -70,12 +69,12 @@ func resourceDedicatedPrivateSubnetV1Create(ctx context.Context, d *schema.Resou
 		return diag.FromErr(err)
 	}
 
-	networks, _, err := client.Networks(ctx, locationID, dedicated.NetworkTypeLocal, strconv.Itoa(vlan))
+	networks, _, err := client.Networks(ctx, locationID, dedicated.NetworkTypeLocal, vlan)
 	if err != nil {
 		return diag.Errorf("failed to get networks for location %s: %s", locationID, err)
 	}
 	if len(networks) == 0 {
-		return diag.Errorf("vlan %d not found in location %s", vlan, locationID)
+		return diag.Errorf("vlan %s not found in location %s", vlan, locationID)
 	}
 
 	localSubnet, _, err := client.CreateNetworkLocalSubnet(ctx, networks[0].UUID, subnetCIDR)

--- a/selectel/resource_selectel_dedicated_private_subnet_v1.go
+++ b/selectel/resource_selectel_dedicated_private_subnet_v1.go
@@ -5,10 +5,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	dedicated "github.com/selectel/dedicated-go/v2/pkg/v2"
 )
 
@@ -76,7 +75,7 @@ func resourceDedicatedPrivateSubnetV1Create(ctx context.Context, d *schema.Resou
 		return diag.Errorf("failed to get networks for location %s: %s", locationID, err)
 	}
 	if len(networks) == 0 {
-		return diag.Errorf("vlan %s not found in location %s", vlan, locationID)
+		return diag.Errorf("vlan %d not found in location %s", vlan, locationID)
 	}
 
 	localSubnet, _, err := client.CreateNetworkLocalSubnet(ctx, networks[0].UUID, subnetCIDR)

--- a/selectel/resource_selectel_dedicated_private_subnet_v1_test.go
+++ b/selectel/resource_selectel_dedicated_private_subnet_v1_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/selectel/go-selvpcclient/v4/selvpcclient/resell/v2/projects"

--- a/selectel/resource_selectel_dedicated_private_subnet_v1_test.go
+++ b/selectel/resource_selectel_dedicated_private_subnet_v1_test.go
@@ -2,9 +2,10 @@ package selectel
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"regexp"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"

--- a/selectel/resource_selectel_dedicated_private_subnet_v1_test.go
+++ b/selectel/resource_selectel_dedicated_private_subnet_v1_test.go
@@ -1,0 +1,132 @@
+package selectel
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/selectel/go-selvpcclient/v4/selvpcclient/resell/v2/projects"
+)
+
+func TestAccDedicatedPrivateSubnetV1Basic(t *testing.T) {
+	var (
+		project      projects.Project
+		subnetID     string
+		projectName  = acctest.RandomWithPrefix("tf-acc")
+		locationName = "SPB-5"
+		vlan         = "2989"
+		subnet       = "10.10.10.0/24"
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccSelectelPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDedicatedPrivateSubnetV1Basic(projectName, locationName, vlan, subnet),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVPCV2ProjectExists("selectel_vpc_project_v2.project_tf_acc_test_1", &project),
+					testAccCheckDedicatedPrivateSubnetV1Exists("selectel_dedicated_private_subnet_v1.subnet_tf_acc_test_1", &subnetID),
+					resource.TestCheckResourceAttrSet("selectel_dedicated_private_subnet_v1.subnet_tf_acc_test_1", "location_id"),
+					resource.TestCheckResourceAttrSet("selectel_dedicated_private_subnet_v1.subnet_tf_acc_test_1", "vlan"),
+					resource.TestCheckResourceAttrSet("selectel_dedicated_private_subnet_v1.subnet_tf_acc_test_1", "subnet"),
+					resource.TestCheckResourceAttrSet("selectel_dedicated_private_subnet_v1.subnet_tf_acc_test_1", "id"),
+				),
+			},
+			{
+				Config:   testAccDedicatedPrivateSubnetV1Basic(projectName, locationName, vlan, subnet),
+				PlanOnly: true,
+			},
+			{
+				Config:      testAccDedicatedPrivateSubnetV1InvalidCIDR(projectName, locationName, vlan),
+				ExpectError: regexp.MustCompile("invalid CIDR format"),
+			},
+			{
+				Config:      testAccDedicatedPrivateSubnetV1InvalidVLAN(projectName, locationName, subnet),
+				ExpectError: regexp.MustCompile(`invalid parameters to filter on tag or vlan`),
+			},
+		},
+	})
+}
+
+func testAccCheckDedicatedPrivateSubnetV1Exists(n string, subnetID *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		*subnetID = rs.Primary.ID
+
+		return nil
+	}
+}
+
+func testAccDedicatedPrivateSubnetV1Basic(projectName, location, vlan, subnet string) string {
+	return fmt.Sprintf(`
+resource "selectel_vpc_project_v2" "project_tf_acc_test_1" {
+  name = "%s"
+}
+
+data "selectel_dedicated_location_v1" "location_tf_acc_test_1" {
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  filter {
+    name = "%s"
+  }
+}
+
+resource "selectel_dedicated_private_subnet_v1" "subnet_tf_acc_test_1" {
+  location_id  = "${data.selectel_dedicated_location_v1.location_tf_acc_test_1.locations[0].id}"
+  vlan         = "%s"
+  subnet       = "%s"
+}`, projectName, location, vlan, subnet)
+}
+
+func testAccDedicatedPrivateSubnetV1InvalidCIDR(projectName, location, vlan string) string {
+	return fmt.Sprintf(`
+resource "selectel_vpc_project_v2" "project_tf_acc_test_1" {
+  name = "%s"
+}
+
+data "selectel_dedicated_location_v1" "location_tf_acc_test_1" {
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  filter {
+    name = "%s"
+  }
+}
+
+resource "selectel_dedicated_private_subnet_v1" "subnet_tf_acc_test_1" {
+  location_id  = "${data.selectel_dedicated_location_v1.location_tf_acc_test_1.locations[0].id}"
+  vlan         = "%s"
+  subnet       = "192.168.100.0/255"
+}
+`, projectName, location, vlan)
+}
+
+func testAccDedicatedPrivateSubnetV1InvalidVLAN(projectName, location, subnet string) string {
+	return fmt.Sprintf(`
+resource "selectel_vpc_project_v2" "project_tf_acc_test_1" {
+  name = "%s"
+}
+
+data "selectel_dedicated_location_v1" "location_tf_acc_test_1" {
+  project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  filter {
+    name = "%s"
+  }
+}
+
+resource "selectel_dedicated_private_subnet_v1" "subnet_tf_acc_test_1" {
+  location_id  = "${data.selectel_dedicated_location_v1.location_tf_acc_test_1.locations[0].id}"
+  vlan         = "65000"
+  subnet       = "%s"
+}
+`, projectName, location, subnet)
+}

--- a/selectel/resource_selectel_dedicated_server_v1.go
+++ b/selectel/resource_selectel_dedicated_server_v1.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	dedicated "github.com/selectel/dedicated-go/pkg/v2"
+	dedicated "github.com/selectel/dedicated-go/v2/pkg/v2"
 	waiters "github.com/terraform-providers/terraform-provider-selectel/selectel/waiters/dedicated"
 )
 

--- a/selectel/resource_selectel_dedicated_server_v1.go
+++ b/selectel/resource_selectel_dedicated_server_v1.go
@@ -624,7 +624,31 @@ func resourceDedicatedServerV1Update(ctx context.Context, d *schema.ResourceData
 		osID            = d.Get(dedicatedServerSchemaKeyOSID).(string)
 		sshKeyName, _   = d.Get(dedicatedServerSchemaKeyOSSSHKeyName).(string)
 		password, _     = d.Get(dedicatedServerSchemaKeyOSPassword).(string)
+
+		privateSubnetIP, _                     = d.Get(dedicatedServerSchemaKeyPrivateSubnetIP).(string)
+		oldPrivateSubnetID, newPrivateSubnetID = d.GetChange(dedicatedServerSchemaKeyPrivateSubnetID)
 	)
+
+	if oldPrivateSubnetID.(string) == "" && newPrivateSubnetID.(string) != "" {
+		_, _, err := dsClient.AddIPInNetworkLocalSubnet(ctx, newPrivateSubnetID.(string), d.Id(), privateSubnetIP)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	// If only private_subnet_id changed, no need to reinstall OS
+	onlyPrivateSubnetChanged := d.HasChange(dedicatedServerSchemaKeyPrivateSubnetID) &&
+		!d.HasChange(dedicatedServerSchemaKeyOSID) &&
+		!d.HasChange(dedicatedServerSchemaKeyOSHostName) &&
+		!d.HasChange(dedicatedServerSchemaKeyOSSSHKey) &&
+		!d.HasChange(dedicatedServerSchemaKeyOSSSHKeyName) &&
+		!d.HasChange(dedicatedServerSchemaKeyOSPassword) &&
+		!d.HasChange(dedicatedServerSchemaKeyOSPartitionsConfig) &&
+		!d.HasChange(dedicatedServerSchemaKeyOSUserData)
+
+	if onlyPrivateSubnetChanged {
+		return nil
+	}
 
 	data, err := resourceDedicatedServerV1UpdateLoadData(ctx, dsClient, d, locationID, osID, configurationID, sshKeyName)
 	if err != nil {
@@ -751,7 +775,9 @@ func resourceDedicatedServerV1UpdateValidatePreconditions(
 	)
 
 	switch {
-	case !(d.HasChange(dedicatedServerSchemaKeyOSID) || (forceUpdateAdditionalParams && isAdditionalParamsChanged)): //nolint:staticcheck
+	case !d.HasChange(dedicatedServerSchemaKeyOSID) &&
+		(!forceUpdateAdditionalParams || !isAdditionalParamsChanged) &&
+		!d.HasChange(dedicatedServerSchemaKeyPrivateSubnetID):
 		return fmt.Errorf("can't update cause os configuration has not changed")
 
 	case d.HasChange(dedicatedServerSchemaKeyProjectID):

--- a/selectel/resource_selectel_dedicated_server_v1.go
+++ b/selectel/resource_selectel_dedicated_server_v1.go
@@ -160,9 +160,43 @@ func resourceDedicatedServerV1Create(ctx context.Context, d *schema.ResourceData
 
 	_ = d.Set(dedicatedServerSchemaPublicIP, reservedIP.publicIP)
 	_ = d.Set(dedicatedServerSchemaPrivateIP, reservedIP.privateIP)
-	_ = d.Set(dedicatedServerSchemaPrivateVlan, reservedIP.privateVLAN)
+
+	rd, _, err := dsClient.ResourceDetails(ctx, d.Id())
+	if err != nil {
+		return diag.FromErr(errGettingObject(objectDedicatedServer, d.Id(), err))
+	}
+
+	privateVlan, err := resourceDedicatedServerGetPrivateVlan(ctx, dsClient, rd.HWUUID, rd.LocationUUID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if privateVlan != nil {
+		_ = d.Set(dedicatedServerSchemaPrivateVlan, *privateVlan)
+	}
 
 	return nil
+}
+
+func resourceDedicatedServerGetPrivateVlan(
+	ctx context.Context, dsClient *dedicated.ServiceClient,
+	hwID, locationID string,
+) (*int, error) {
+	localType := dedicated.NetworkTypeLocal
+
+	ports, _, err := dsClient.GetHardwarePortsList(ctx, hwID, &localType)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, port := range ports {
+		for _, network := range port.Network {
+			if network.LocationUUID == locationID {
+				return &network.Vlan, nil
+			}
+		}
+	}
+
+	return nil, nil
 }
 
 type serversDedicatedServerV1CreateData struct {
@@ -179,9 +213,8 @@ type serversDedicatedServerV1CreateData struct {
 }
 
 type reservedIP struct {
-	publicIP    string
-	privateIP   string
-	privateVLAN string
+	publicIP  string
+	privateIP string
 }
 
 func resourceDedicatedServerGetReservedIPs(
@@ -203,7 +236,6 @@ func resourceDedicatedServerGetReservedIPs(
 	}
 	if len(reservedPrivateIPs) > 0 {
 		result.privateIP = reservedPrivateIPs[0].IP.String()
-		result.privateVLAN = reservedPrivateIPs[0].Network
 	}
 
 	return result, nil
@@ -523,7 +555,14 @@ func resourceDedicatedServerV1Read(ctx context.Context, d *schema.ResourceData, 
 
 	_ = d.Set(dedicatedServerSchemaPublicIP, reservedIP.publicIP)
 	_ = d.Set(dedicatedServerSchemaPrivateIP, reservedIP.privateIP)
-	_ = d.Set(dedicatedServerSchemaPrivateVlan, reservedIP.privateVLAN)
+
+	privateVlan, err := resourceDedicatedServerGetPrivateVlan(ctx, dsClient, rd.HWUUID, rd.LocationUUID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if privateVlan != nil {
+		_ = d.Set(dedicatedServerSchemaPrivateVlan, *privateVlan)
+	}
 
 	return nil
 }

--- a/selectel/resource_selectel_dedicated_server_v1.go
+++ b/selectel/resource_selectel_dedicated_server_v1.go
@@ -33,7 +33,7 @@ func resourceDedicatedServerV1() *schema.Resource {
 }
 
 func resourceDedicatedServerV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	dsClient, diagErr := getDedicatedClient(d, meta)
+	dsClient, diagErr := getDedicatedClient(d, meta, true)
 	if diagErr != nil {
 		return diagErr
 	}
@@ -55,12 +55,21 @@ func resourceDedicatedServerV1Create(ctx context.Context, d *schema.ResourceData
 
 		publicSubnetID, _ = d.Get(dedicatedServerSchemaKeyPublicSubnetID).(string)
 		publicSubnetIP, _ = d.Get(dedicatedServerSchemaKeyPublicSubnetIP).(string)
-		privateSubnet, _  = d.Get(dedicatedServerSchemaKeyPrivateSubnet).(string)
+
+		privateSubnetID, _ = d.Get(dedicatedServerSchemaKeyPrivateSubnetID).(string)
+		privateSubnetIP, _ = d.Get(dedicatedServerSchemaKeyPrivateSubnetIP).(string)
+
+		addPrivateVlan, _ = d.Get(dedicatedServerSchemaAddPrivateVlan).(bool)
 	)
 
+	// Validate that private_subnet_ip cannot be used without private_subnet_id
+	if privateSubnetIP != "" && privateSubnetID == "" {
+		return diag.FromErr(errors.New("private_subnet_ip cannot be used without private_subnet_id"))
+	}
+
 	data, err := resourceDedicatedServerV1CreateLoadData(
-		ctx, dsClient, locationID, osID, configurationID, publicSubnetID, publicSubnetIP, privateSubnet,
-		sshKeyName, pricePlanName, partitionsConfigFromSchema,
+		ctx, dsClient, locationID, osID, configurationID, publicSubnetID, publicSubnetIP,
+		privateSubnetID, privateSubnetIP, sshKeyName, pricePlanName, partitionsConfigFromSchema,
 	)
 	if err != nil {
 		return diag.FromErr(err)
@@ -79,7 +88,7 @@ func resourceDedicatedServerV1Create(ctx context.Context, d *schema.ResourceData
 
 	err = resourceDedicatedServerV1CreateValidatePreconditions(
 		ctx, dsClient, data, locationID, data.pricePlan.UUID, configurationID, osID, userData != "",
-		sshKeyPK != "" || data.sshKeyByName != nil, password != "", privateSubnet != "",
+		sshKeyPK != "" || data.sshKeyByName != nil, password != "", privateSubnetID != "",
 	)
 	if err != nil {
 		return diag.FromErr(err)
@@ -91,24 +100,25 @@ func resourceDedicatedServerV1Create(ctx context.Context, d *schema.ResourceData
 		hostName = resourceDedicatedServerV1GenerateHostNameIfNotPresented(d)
 
 		req = &dedicated.ServerBillingPostPayload{
-			ServiceUUID:      configurationID,
-			PricePlanUUID:    data.pricePlan.UUID,
-			PayCurrency:      data.billingPayCurrency,
-			LocationUUID:     locationID,
-			Quantity:         1,
-			IPList:           data.ipsPublic,
-			LocalIPList:      data.ipsPrivate,
-			LocalSubnetUUID:  data.localSubnetUUID,
-			ProjectUUID:      d.Get(dedicatedServerSchemaKeyProjectID).(string),
-			PartitionsConfig: data.partitions,
-			OSVersion:        data.os.VersionValue,
-			OSTemplate:       data.os.OSValue,
-			OSArch:           data.os.Arch,
-			UserSSHKey:       sshKeyPK,
-			UserHostname:     hostName,
-			UserDesc:         hostName,
-			Password:         password,
-			UserData:         userData,
+			ServiceUUID:          configurationID,
+			PricePlanUUID:        data.pricePlan.UUID,
+			PayCurrency:          data.billingPayCurrency,
+			LocationUUID:         locationID,
+			Quantity:             1,
+			IPList:               data.ipsPublic,
+			LocalIPList:          data.ipsPrivate,
+			LocalSubnetUUID:      data.localSubnetUUID,
+			ProjectUUID:          d.Get(dedicatedServerSchemaKeyProjectID).(string),
+			PartitionsConfig:     data.partitions,
+			OSVersion:            data.os.VersionValue,
+			OSTemplate:           data.os.OSValue,
+			OSArch:               data.os.Arch,
+			UserSSHKey:           sshKeyPK,
+			UserHostname:         hostName,
+			UserDesc:             hostName,
+			Password:             password,
+			UserData:             userData,
+			LocalNetworkRequired: addPrivateVlan,
 		}
 	)
 
@@ -143,6 +153,15 @@ func resourceDedicatedServerV1Create(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(errCreatingObject(objectDedicatedServer, err))
 	}
 
+	reservedIP, err := resourceDedicatedServerGetReservedIPs(ctx, dsClient, d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	_ = d.Set(dedicatedServerSchemaPublicIP, reservedIP.publicIP)
+	_ = d.Set(dedicatedServerSchemaPrivateIP, reservedIP.privateIP)
+	_ = d.Set(dedicatedServerSchemaPrivateVlan, reservedIP.privateVLAN)
+
 	return nil
 }
 
@@ -159,9 +178,40 @@ type serversDedicatedServerV1CreateData struct {
 	pricePlan          *dedicated.PricePlan
 }
 
+type reservedIP struct {
+	publicIP    string
+	privateIP   string
+	privateVLAN string
+}
+
+func resourceDedicatedServerGetReservedIPs(
+	ctx context.Context, dsClient *dedicated.ServiceClient, resourceID string,
+) (*reservedIP, error) {
+	result := &reservedIP{}
+
+	reservedPublicIPs, _, err := dsClient.NetworkReservedIPs(ctx, "", resourceID)
+	if err != nil {
+		return nil, fmt.Errorf("error getting reserved public IPs: %w", err)
+	}
+	if len(reservedPublicIPs) > 0 {
+		result.publicIP = reservedPublicIPs[0].IP.String()
+	}
+
+	reservedPrivateIPs, _, err := dsClient.NetworkReservedLocalIPs(ctx, resourceID)
+	if err != nil {
+		return nil, fmt.Errorf("error getting reserved private IPs: %w", err)
+	}
+	if len(reservedPrivateIPs) > 0 {
+		result.privateIP = reservedPrivateIPs[0].IP.String()
+		result.privateVLAN = reservedPrivateIPs[0].Network
+	}
+
+	return result, nil
+}
+
 func resourceDedicatedServerV1CreateLoadData(
 	ctx context.Context, dsClient *dedicated.ServiceClient,
-	locationID, osID, configurationID, publicSubnetID, publicSubnetIP, privateSubnet, sshKeyName, pricePlanName string,
+	locationID, osID, configurationID, publicSubnetID, publicSubnetIP, privateSubnetID, privateSubnetIP, sshKeyName, pricePlanName string,
 	partitionsConfigFromSchema *PartitionsConfig,
 ) (*serversDedicatedServerV1CreateData, error) {
 	operatingSystems, _, err := dsClient.OperatingSystems(ctx, &dedicated.OperatingSystemsQuery{
@@ -220,20 +270,15 @@ func resourceDedicatedServerV1CreateLoadData(
 		publicIPs = append(publicIPs, publicIP)
 	}
 
-	var (
-		privateIPs      []net.IP
-		localSubnetUUID string
-	)
-	if privateSubnet != "" {
-		// also validating the sufficiency of free addresses
-		var privateIP net.IP
+	var privateIPs []net.IP
 
-		privateIP, localSubnetUUID, err = resourceDedicatedServerV1GetFreePrivateIPs(ctx, dsClient, locationID, privateSubnet)
-		if err != nil {
-			return nil, err
+	if privateSubnetIP != "" {
+		ip := net.ParseIP(privateSubnetIP)
+		if ip == nil {
+			return nil, fmt.Errorf("failed to parse private IP %q", privateSubnetIP)
 		}
 
-		privateIPs = append(privateIPs, privateIP)
+		privateIPs = append(privateIPs, ip)
 	}
 
 	var sshKey *dedicated.SSHKey
@@ -281,7 +326,7 @@ func resourceDedicatedServerV1CreateLoadData(
 		partitions:         partitionsConfig,
 		ipsPublic:          publicIPs,
 		ipsPrivate:         privateIPs,
-		localSubnetUUID:    localSubnetUUID,
+		localSubnetUUID:    privateSubnetID,
 		sshKeyByName:       sshKey,
 		billing:            billing,
 		billingPayCurrency: billingPayCurrency,
@@ -393,7 +438,7 @@ func resourceDedicatedServerV1CreateValidatePreconditions(
 }
 
 func resourceDedicatedServerV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	dsClient, diagErr := getDedicatedClient(d, meta)
+	dsClient, diagErr := getDedicatedClient(d, meta, true)
 	if diagErr != nil {
 		return diagErr
 	}
@@ -471,11 +516,20 @@ func resourceDedicatedServerV1Read(ctx context.Context, d *schema.ResourceData, 
 
 	_ = d.Set("os_id", os.UUID)
 
+	reservedIP, err := resourceDedicatedServerGetReservedIPs(ctx, dsClient, d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	_ = d.Set(dedicatedServerSchemaPublicIP, reservedIP.publicIP)
+	_ = d.Set(dedicatedServerSchemaPrivateIP, reservedIP.privateIP)
+	_ = d.Set(dedicatedServerSchemaPrivateVlan, reservedIP.privateVLAN)
+
 	return nil
 }
 
 func resourceDedicatedServerV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	dsClient, diagErr := getDedicatedClient(d, meta)
+	dsClient, diagErr := getDedicatedClient(d, meta, true)
 	if diagErr != nil {
 		return diagErr
 	}
@@ -501,7 +555,7 @@ func resourceDedicatedServerV1Delete(ctx context.Context, d *schema.ResourceData
 func resourceDedicatedServerV1UpdateWithStateRollback(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	d.Partial(true)
 
-	dsClient, diagErr := getDedicatedClient(d, meta)
+	dsClient, diagErr := getDedicatedClient(d, meta, true)
 	if diagErr != nil {
 		return diagErr
 	}

--- a/selectel/resource_selectel_dedicated_server_v1.go
+++ b/selectel/resource_selectel_dedicated_server_v1.go
@@ -683,7 +683,7 @@ func resourceDedicatedServerV1Update(ctx context.Context, d *schema.ResourceData
 			UserHostname:     hostName,
 			Password:         password,
 			PartitionsConfig: data.partitions,
-			UserData:         userData,
+			UserData:         &userData,
 		}
 	)
 

--- a/selectel/resource_selectel_dedicated_server_v1_test.go
+++ b/selectel/resource_selectel_dedicated_server_v1_test.go
@@ -3,7 +3,6 @@ package selectel
 import (
 	"context"
 	"fmt"
-	"github.com/selectel/go-selvpcclient/v4/selvpcclient/resell/v2/projects"
 	"net/http"
 	"strings"
 	"testing"
@@ -12,7 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	dedicated "github.com/selectel/dedicated-go/pkg/v2"
+	dedicated "github.com/selectel/dedicated-go/v2/pkg/v2"
+	"github.com/selectel/go-selvpcclient/v4/selvpcclient/resell/v2/projects"
 	"github.com/stretchr/testify/assert"
 	"github.com/terraform-providers/terraform-provider-selectel/selectel/internal/httptest"
 )

--- a/selectel/resource_selectel_dedicated_server_v1_test.go
+++ b/selectel/resource_selectel_dedicated_server_v1_test.go
@@ -3,6 +3,7 @@ package selectel
 import (
 	"context"
 	"fmt"
+	"github.com/selectel/go-selvpcclient/v4/selvpcclient/resell/v2/projects"
 	"net/http"
 	"strings"
 	"testing"
@@ -12,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	dedicated "github.com/selectel/dedicated-go/pkg/v2"
-	"github.com/selectel/go-selvpcclient/v4/selvpcclient/resell/v2/projects"
 	"github.com/stretchr/testify/assert"
 	"github.com/terraform-providers/terraform-provider-selectel/selectel/internal/httptest"
 )
@@ -25,13 +25,18 @@ func TestAccDedicatedServerV1Basic(t *testing.T) {
 
 		osName                        = "Ubuntu"
 		osVersion, updatedOSVersion   = "2404", "2204"
-		locationName                  = "MSK-2"
-		cfgName                       = "CL25-NVMe"
+		locationName                  = "SPB-5"
+		cfgName                       = "EL10-SSD"
 		pricePlanName                 = "1 day"
 		osHostName, updatedOSHostName = "hostname", "hostname1"
 		osPassword, updatedOSPassword = "Passw0rd!", "Passw0rd!1"
 		userData, updatedUserData     = "#!/bin/bash", "#!/bin/sh"
-		sshKey                        = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCOIWeVNMRC7Y9jeBoG5GP3irOf/u5EbuHYixuZEmtHDtmtlnmzdcBEnpPY5OlFhjSySlUC1clCIShMXgWBfdnvk7Dbp5hgCP3Lh9pS/b8e3kxstIiGF9d7IX04DfVTOF424LlMAFbHNsrmX+uU3lizO20DljFIJNML0OdUO7eKg0XOK1OWVQlSzvZbFj39oYTSqCtoI92czQf4DdJ+0IF1/ZNewE6xPohfnZp5cl82UjYs8vxmcaiifVf7kUyQe/ilv/fZYpt59KCJBJDrTU/ko9hNxCVXrCOw7pPOQayoQ2Vir3M1AnhDMunoxFBocndgffNXVQYtA/3TXLVB7feb"
+		sshKey                        = `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCOIWeVNMRC7Y9jeBoG5GP3irOf/u5EbuHYixuZEmtHDtmtlnmzdcBEnpPY5OlFhjSySlUC1clCIShMXgWBfdnvk7Dbp5hgCP3Lh9pS/b8e3kxstIiGF9d7IX04DfVTOF424LlMAFbHNsrmX+uU3lizO20DljFIJNML0OdUO7eKg0XOK1OWVQlSzvZbFj39oYTSqCtoI92czQf4DdJ+0IF1/ZNewE6xPohfnZp5cl82UjYs8vxmcaiifVf7kUyQe/ilv/fZYpt59KCJBJDrTU/ko9hNxCVXrCOw7pPOQayoQ2Vir3M1AnhDMunoxFBocndgffNXVQYtA/3TXLVB7feb`
+
+		privateSubnetID string
+		privateSubnet   = "192.168.100.0/24"
+		privateIP       = "192.168.100.1"
+		vlan            = "2989"
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -85,6 +90,15 @@ func TestAccDedicatedServerV1Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_dedicated_server_v1.server_tf_acc_test_1", "os_password", updatedOSPassword),
 				),
 			},
+			{
+				Config: testAccDedicatedServerV1WithPrivateSubnet(projectName, osName, osVersion, locationName, cfgName, pricePlanName, vlan, privateSubnet, privateIP),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDedicatedPrivateSubnetV1Exists("selectel_dedicated_private_subnet_v1.subnet_tf_acc_test_1", &privateSubnetID),
+					resource.TestCheckResourceAttr("selectel_dedicated_server_v1.server_tf_acc_test_1", "private_vlan", vlan),
+					resource.TestCheckResourceAttrSet("selectel_dedicated_server_v1.server_tf_acc_test_1", "public_ip"),
+					resource.TestCheckResourceAttr("selectel_dedicated_server_v1.server_tf_acc_test_1", "private_ip", privateIP),
+				),
+			},
 		},
 	})
 }
@@ -124,7 +138,7 @@ data "selectel_dedicated_os_v1" "os_tf_acc_test_1" {
 
  filter {
    name             = "%s"
-   version          = "%s"
+   version_value    = "%s"
  }
 }
 
@@ -188,6 +202,55 @@ resource "selectel_dedicated_server_v1" "server_tf_acc_test_1" {
  }
 }
 `, projectName, osName, osVersion, locationName, cfgName, pricePlanName, osHostName, sshKey, osPassword, userData)
+}
+
+func testAccDedicatedServerV1WithPrivateSubnet(
+	projectName, osName, osVersion, locationName, cfgName, pricePlanName, vlan, subnet, privateIP string,
+) string {
+	return fmt.Sprintf(`
+resource "selectel_vpc_project_v2" "project_tf_acc_test_1" {
+ name        = "%s"
+}
+
+data "selectel_dedicated_os_v1" "os_tf_acc_test_1" {
+ project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+
+ filter {
+   name             = "%s"
+   version_value    = "%s"
+ }
+}
+
+data "selectel_dedicated_location_v1" "location_tf_acc_test_1" {
+ project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+ filter {
+   name = "%s"
+ }
+}
+
+data "selectel_dedicated_configuration_v1" "server_configuration_tf_acc_test_1" {
+ project_id     = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+ deep_filter = "{\"name\": \"%s\"}"
+}
+
+resource "selectel_dedicated_private_subnet_v1" "subnet_tf_acc_test_1" {
+ location_id = "${data.selectel_dedicated_location_v1.location_tf_acc_test_1.locations[0].id}"
+ vlan        = "%s"
+ subnet      = "%s"
+}
+
+resource "selectel_dedicated_server_v1" "server_tf_acc_test_1" {
+ project_id = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+
+ configuration_id = "${data.selectel_dedicated_configuration_v1.server_configuration_tf_acc_test_1.configurations.0.id}"
+ location_id      = "${data.selectel_dedicated_location_v1.location_tf_acc_test_1.locations[0].id}"
+ os_id            = "${data.selectel_dedicated_os_v1.os_tf_acc_test_1.os.0.id}"
+ price_plan_name  = "%s"
+
+ private_subnet_id = "${selectel_dedicated_private_subnet_v1.subnet_tf_acc_test_1.id}"
+ private_subnet_ip = "%s"
+}
+`, projectName, osName, osVersion, locationName, cfgName, vlan, subnet, pricePlanName, privateIP)
 }
 
 func Test_resourceDedicatedServerV1CreateValidatePreconditions(t *testing.T) {

--- a/selectel/schema_selectel_dedicated_server_v1.go
+++ b/selectel/schema_selectel_dedicated_server_v1.go
@@ -192,7 +192,7 @@ func resourceDedicatedServerV1Schema() map[string]*schema.Schema {
 			Computed: true,
 		},
 		dedicatedServerSchemaPrivateVlan: {
-			Type:     schema.TypeString,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
 	}

--- a/selectel/schema_selectel_dedicated_server_v1.go
+++ b/selectel/schema_selectel_dedicated_server_v1.go
@@ -1,6 +1,8 @@
 package selectel
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -12,6 +14,7 @@ const (
 	dedicatedServerSchemaKeyPricePlanName            = "price_plan_name"
 	dedicatedServerSchemaKeyPublicSubnetID           = "public_subnet_id"
 	dedicatedServerSchemaKeyPublicSubnetIP           = "public_subnet_ip"
+	dedicatedServerSchemaKeyPrivateSubnet            = "private_subnet"
 	dedicatedServerSchemaKeyPrivateSubnetID          = "private_subnet_id"
 	dedicatedServerSchemaKeyPrivateSubnetIP          = "private_subnet_ip"
 	dedicatedServerSchemaKeyOSUserData               = "user_data"
@@ -145,15 +148,20 @@ func resourceDedicatedServerV1Schema() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Optional: true,
 		},
+		dedicatedServerSchemaKeyPrivateSubnet: {
+			Type:          schema.TypeString,
+			Optional:      true,
+			Deprecated:    fmt.Sprintf("Use `%s` instead.", dedicatedServerSchemaKeyPrivateSubnetID),
+			ConflictsWith: []string{dedicatedServerSchemaKeyPrivateSubnetID},
+		},
 		dedicatedServerSchemaKeyPrivateSubnetID: {
-			Type:     schema.TypeString,
-			Optional: true,
-			ForceNew: true,
+			Type:          schema.TypeString,
+			Optional:      true,
+			ConflictsWith: []string{dedicatedServerSchemaKeyPrivateSubnet},
 		},
 		dedicatedServerSchemaKeyPrivateSubnetIP: {
 			Type:     schema.TypeString,
 			Optional: true,
-			ForceNew: true,
 		},
 		dedicatedServerSchemaAddPrivateVlan: {
 			Type:     schema.TypeBool,

--- a/selectel/schema_selectel_dedicated_server_v1.go
+++ b/selectel/schema_selectel_dedicated_server_v1.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 const (
@@ -158,10 +159,12 @@ func resourceDedicatedServerV1Schema() map[string]*schema.Schema {
 			Type:          schema.TypeString,
 			Optional:      true,
 			ConflictsWith: []string{dedicatedServerSchemaKeyPrivateSubnet},
+			ValidateFunc:  validation.IsUUID,
 		},
 		dedicatedServerSchemaKeyPrivateSubnetIP: {
-			Type:     schema.TypeString,
-			Optional: true,
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.IsIPv4Address,
 		},
 		dedicatedServerSchemaAddPrivateVlan: {
 			Type:     schema.TypeBool,

--- a/selectel/schema_selectel_dedicated_server_v1.go
+++ b/selectel/schema_selectel_dedicated_server_v1.go
@@ -160,11 +160,13 @@ func resourceDedicatedServerV1Schema() map[string]*schema.Schema {
 			Optional:      true,
 			ConflictsWith: []string{dedicatedServerSchemaKeyPrivateSubnet},
 			ValidateFunc:  validation.IsUUID,
+			RequiredWith:  []string{dedicatedServerSchemaKeyPrivateSubnetIP},
 		},
 		dedicatedServerSchemaKeyPrivateSubnetIP: {
 			Type:         schema.TypeString,
 			Optional:     true,
 			ValidateFunc: validation.IsIPv4Address,
+			RequiredWith: []string{dedicatedServerSchemaKeyPrivateSubnetID},
 		},
 		dedicatedServerSchemaAddPrivateVlan: {
 			Type:     schema.TypeBool,

--- a/selectel/schema_selectel_dedicated_server_v1.go
+++ b/selectel/schema_selectel_dedicated_server_v1.go
@@ -12,7 +12,8 @@ const (
 	dedicatedServerSchemaKeyPricePlanName            = "price_plan_name"
 	dedicatedServerSchemaKeyPublicSubnetID           = "public_subnet_id"
 	dedicatedServerSchemaKeyPublicSubnetIP           = "public_subnet_ip"
-	dedicatedServerSchemaKeyPrivateSubnet            = "private_subnet"
+	dedicatedServerSchemaKeyPrivateSubnetID          = "private_subnet_id"
+	dedicatedServerSchemaKeyPrivateSubnetIP          = "private_subnet_ip"
 	dedicatedServerSchemaKeyOSUserData               = "user_data"
 	dedicatedServerSchemaKeyOSHostName               = "os_host_name"
 	dedicatedServerSchemaKeyOSSSHKey                 = "ssh_key"
@@ -30,6 +31,10 @@ const (
 	dedicatedServerSchemaKeyFSType                   = "fs_type"
 	dedicatedServerSchemaKeyOSPassword               = "os_password"
 	dedicatedServerSchemaForceUpdateAdditionalParams = "force_update_additional_params"
+	dedicatedServerSchemaPublicIP                    = "public_ip"
+	dedicatedServerSchemaPrivateIP                   = "private_ip"
+	dedicatedServerSchemaAddPrivateVlan              = "add_private_vlan"
+	dedicatedServerSchemaPrivateVlan                 = "private_vlan"
 )
 
 func resourceDedicatedServerV1Schema() map[string]*schema.Schema {
@@ -140,9 +145,20 @@ func resourceDedicatedServerV1Schema() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Optional: true,
 		},
-		dedicatedServerSchemaKeyPrivateSubnet: {
+		dedicatedServerSchemaKeyPrivateSubnetID: {
 			Type:     schema.TypeString,
 			Optional: true,
+			ForceNew: true,
+		},
+		dedicatedServerSchemaKeyPrivateSubnetIP: {
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+		},
+		dedicatedServerSchemaAddPrivateVlan: {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
 		},
 
 		// optional misc
@@ -153,6 +169,20 @@ func resourceDedicatedServerV1Schema() map[string]*schema.Schema {
 		dedicatedServerSchemaForceUpdateAdditionalParams: {
 			Type:     schema.TypeBool,
 			Optional: true,
+		},
+
+		// computed attributes
+		dedicatedServerSchemaPublicIP: {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		dedicatedServerSchemaPrivateIP: {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		dedicatedServerSchemaPrivateVlan: {
+			Type:     schema.TypeString,
+			Computed: true,
 		},
 	}
 }

--- a/selectel/waiters/dedicated/boot.go
+++ b/selectel/waiters/dedicated/boot.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	dedicated "github.com/selectel/dedicated-go/pkg/v2"
+	dedicated "github.com/selectel/dedicated-go/v2/pkg/v2"
 )
 
 func WaitForServersServerInstallNewOSV1ActiveState(

--- a/selectel/waiters/dedicated/server.go
+++ b/selectel/waiters/dedicated/server.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	dedicated "github.com/selectel/dedicated-go/pkg/v2"
+	dedicated "github.com/selectel/dedicated-go/v2/pkg/v2"
 )
 
 func WaitForServersServerV1ActiveState(

--- a/website/docs/d/dedicated_location_v1.html.markdown
+++ b/website/docs/d/dedicated_location_v1.html.markdown
@@ -31,7 +31,7 @@ data "selectel_dedicated_location_v1" "server_location" {
 
 ## Attributes Reference
 
-* `locations` - List of the available locations:
+* `locations` - List of the available locations (excluding locations with `visibility = "admin_only"`):
 
   * `id` - Unique identifier of the location.
 

--- a/website/docs/d/dedicated_location_v1.html.markdown
+++ b/website/docs/d/dedicated_location_v1.html.markdown
@@ -31,7 +31,7 @@ data "selectel_dedicated_location_v1" "server_location" {
 
 ## Attributes Reference
 
-* `locations` - List of the available locations (excluding locations with `visibility = "admin_only"`):
+* `locations` - List of the available locations:
 
   * `id` - Unique identifier of the location.
 

--- a/website/docs/d/dedicated_private_subnet_v1.html.markdown
+++ b/website/docs/d/dedicated_private_subnet_v1.html.markdown
@@ -42,7 +42,7 @@ data "selectel_dedicated_private_subnet_v1" "subnet_ds" {
   * `id` - Unique identifier of the subnet (UUID).
   * `subnet` - Subnet CIDR (e.g., "192.168.100.0/24").
   * `vlan` - VLAN ID (tag in API).
-  * `reserved_ip` - List of reserved IP addresses in the subnet.
+  * `reserved_ips` - List of reserved IP addresses in the subnet.
 
 where:
 

--- a/website/docs/d/dedicated_private_subnet_v1.html.markdown
+++ b/website/docs/d/dedicated_private_subnet_v1.html.markdown
@@ -1,0 +1,69 @@
+---
+layout: "selectel"
+page_title: "Selectel: selectel_dedicated_private_subnet_v1"
+sidebar_current: "docs-selectel-data-source-dedicated-private-subnet-v1"
+description: |-
+  Retrieves information about dedicated private subnets.
+---
+
+# selectel\_dedicated\_private\_subnet\_v1
+
+Retrieves information about dedicated private subnets.
+
+## Example usage
+
+```hcl
+data "selectel_dedicated_private_subnet_v1" "subnet_ds" {
+  project_id = selectel_vpc_project_v2.project_1.id
+
+  filter {
+    location_id = "73bc417f-bc6b-45c1-8e06-ea9d5cce061c"
+    vlan        = "100"
+    subnet      = "192.168.100.0/24"
+  }
+}
+```
+
+## Argument Reference
+
+* `project_id` - (Required) Unique identifier of the associated project. Retrieved from the [selectel_vpc_project_v2](https://registry.terraform.io/providers/selectel/selectel/latest/docs/resources/vpc_project_v2) resource.
+
+* `filter` - (Optional) Filter for searching subnets.
+  * `location_id` - (Optional) Location ID to filter subnets by location.
+  * `subnet` - (Optional) Subnet CIDR to filter (e.g., "192.168.100.0/24").
+  * `vlan` - (Optional) VLAN ID to filter subnets by VLAN tag.
+  * `ip` - (Optional) IP address to check if it's included in the subnet.
+
+## Attributes Reference
+
+* `id` - Unique identifier of the data source (checksum of subnet IDs).
+
+* `subnets` - List of matching subnets, each containing:
+  * `id` - Unique identifier of the subnet (UUID).
+  * `subnet` - Subnet CIDR (e.g., "192.168.100.0/24").
+  * `vlan` - VLAN ID (tag in API).
+  * `reserved_ip` - List of reserved IP addresses in the subnet.
+
+## Import
+
+You can import a subnet data source:
+
+```shell
+export OS_DOMAIN_NAME=<account_id>
+export OS_USERNAME=<username>
+export OS_PASSWORD=<password>
+export INFRA_PROJECT_ID=<selectel_project_id>
+terraform import selectel_dedicated_private_subnet_v1.subnet_ds <subnet_id>
+```
+
+where:
+
+* `<account_id>` — Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/).
+
+* `<username>` — Name of the service user.
+
+* `<password>` — Password of the service user.
+
+* `<selectel_project_id>` — Unique identifier of the associated project.
+
+* `<subnet_id>` — Unique identifier of the subnet.

--- a/website/docs/d/dedicated_private_subnet_v1.html.markdown
+++ b/website/docs/d/dedicated_private_subnet_v1.html.markdown
@@ -44,18 +44,6 @@ data "selectel_dedicated_private_subnet_v1" "subnet_ds" {
   * `vlan` - VLAN ID (tag in API).
   * `reserved_ip` - List of reserved IP addresses in the subnet.
 
-## Import
-
-You can import a subnet data source:
-
-```shell
-export OS_DOMAIN_NAME=<account_id>
-export OS_USERNAME=<username>
-export OS_PASSWORD=<password>
-export INFRA_PROJECT_ID=<selectel_project_id>
-terraform import selectel_dedicated_private_subnet_v1.subnet_ds <subnet_id>
-```
-
 where:
 
 * `<account_id>` — Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/).

--- a/website/docs/r/dedicated_private_subnet_v1.html.markdown
+++ b/website/docs/r/dedicated_private_subnet_v1.html.markdown
@@ -1,0 +1,61 @@
+---
+layout: "selectel"
+page_title: "Selectel: selectel_dedicated_private_subnet_v1"
+sidebar_current: "docs-selectel-resource-dedicated-private-subnet-v1"
+description: |-
+  Creates and manages a private subnet in Selectel Dedicated Servers.
+---
+
+# selectel\_dedicated\_private\_subnet\_v1
+
+Creates and manages a private subnet in Selectel Dedicated Servers.
+
+## Example usage
+
+```hcl
+resource "selectel_dedicated_private_subnet_v1" "subnet_1" {
+  location_id = "73bc417f-bc6b-45c1-8e06-ea9d5cce061c"
+  vlan        = "100"
+  subnet      = "192.168.100.0/24"
+}
+```
+
+## Argument Reference
+
+* `location_id` - (Required) Unique identifier of the location where the private subnet will be created. Retrieved from the [dedicated_location_v1](https://registry.terraform.io/providers/selectel/selectel/latest/docs/dedicated_location_v1) data source.
+
+* `vlan` - (Required) VLAN ID for the private subnet. Must be a unique VLAN within the location.
+
+* `subnet` - (Required) CIDR block for the private subnet. Must be within private IP ranges: 10.0.0.0/8, 172.16.0.0/12, or 192.168.0.0/16.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Unique identifier of the private subnet.
+* `vlan` - VLAN ID of the private subnet.
+* `subnet` - CIDR block of the private subnet.
+
+## Import
+
+You can import a private subnet:
+
+```shell
+export OS_DOMAIN_NAME=<account_id>
+export OS_USERNAME=<username>
+export OS_PASSWORD=<password>
+export INFRA_PROJECT_ID=<selectel_project_id>
+terraform import selectel_dedicated_private_subnet_v1.subnet_1 <subnet_id>
+```
+
+where:
+
+* `<account_id>` — Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/). Learn more about [Registration](https://docs.selectel.ru/en/control-panel-actions/account/registration/).
+
+* `<username>` — Name of the service user. To get the name, in the [Control panel](https://my.selectel.ru/iam/users_management/users?type=service), go to **Identity & Access Management** ⟶ **User management** ⟶ the **Service users** tab ⟶ copy the name of the required user. Learn more about [Service users](https://docs.selectel.ru/en/control-panel-actions/users-and-roles/user-types-and-roles/).
+
+* `<password>` — Password of the service user.
+
+* `<selectel_project_id>` — Unique identifier of the associated project. To get the ID, in the [Control panel](https://my.selectel.ru/servers), go to **Servers and colocation** ⟶ project name ⟶ copy the ID of the required project. Learn more about [Projects](https://docs.selectel.ru/en/control-panel-actions/projects/about-projects/).
+
+* `<subnet_id>` — Unique identifier of the private subnet.

--- a/website/docs/r/dedicated_server_v1.html.markdown
+++ b/website/docs/r/dedicated_server_v1.html.markdown
@@ -24,6 +24,8 @@ resource "selectel_dedicated_server_v1" "server_1" {
   os_host_name     = "Turing"
   public_subnet_id = data.selectel_dedicated_public_subnet_v1.subnets.subnets[0].id
   # public_subnet_ip = data.selectel_dedicated_public_subnet_v1.subnets.subnets[0].ip
+  private_subnet_id = var.private_subnet_id  # Optional: Private subnet ID
+  private_subnet_ip = "192.168.100.10"       # Optional: Specific private IP
   ssh_key_name     = "deploy-ed25519"
   os_password      = "Passw0rd!"
   user_data        = file("init-script-dir/init.sh")
@@ -105,6 +107,14 @@ resource "selectel_dedicated_server_v1" "server_1" {
 
 * `public_subnet_ip` - (Optional) Public IP to use. Can be set instead of `public_subnet_id`.
 
+* `private_subnet_id` - (Optional) ID of the private subnet to connect the server to. Changing this forces the server to be recreated.
+
+* `private_subnet_ip` - (Optional) Specific private IP address to assign to the server within the private subnet. Used in conjunction with `private_subnet_id`.
+
+* `add_private_vlan` - (Optional) If set to `true`, creates a private VLAN for the server during creation. Defaults to `false`.
+
+* `private_vlan` - (Computed) The VLAN ID of the private subnet assigned to the server. Returned when a private VLAN is configured or created for the server.
+
 * `os_host_name` - (Optional) Hostname for the server.
 
 * `force_update_additional_params` - (Optional) Enable or disable update for additional os params (os_password, user_data, ssh_key, ssh_key_name, partitions_config, os_host_name) without changing os_id. NOTE: installing new os will delete all data on the server.
@@ -114,6 +124,9 @@ resource "selectel_dedicated_server_v1" "server_1" {
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - Unique identifier of the server.
+* `public_ip` - Public IP address of the server.
+* `private_ip` - Private IP address of the server.
+* `private_vlan` - The VLAN ID of the private subnet assigned to the server. Returned when a private VLAN is configured or created for the server.
 
 ## Import
 


### PR DESCRIPTION
1. Добавлены атрибуты с IP-адресами созданного сервера для ресурса
dedicated_server_v1.
2. Добавлен аргумент для ресурса dedicated_server_v1 для возможности создания
сервера сразу с приватным vlan.
3. Добавлен атрибут для ресурса dedicated_server_v1, отражающий наличие
приватного VLAN на сервере.
4. Добавлен источник данных для работы с приватными подсетями.
5. Добавлены параметры для подключения приватной подсети к серверу для
ресурса dedicated_server_v1.
6. Добавлен ресурс для приватных подсетей.
7. Убраны из списка вывода data source dedicated_location_v1 локации, у которых
visibility = “admin_only”.

https://github.com/selectel/dedicated-go/pull/2

Jira Issue: **COOPERATION-97008**