### PR TITLE
chore: upgrade golang to 1.26 and add go-fix to CI

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.26"
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.26"
 
       - name: Import GPG key
         id: import_gpg

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.26"
       - run: make test
 
   golangci-lint:
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.26"
       - uses: golangci/golangci-lint-action@v7
         with:
           version: v2.1.6
@@ -33,6 +33,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.26"
       - run: go mod tidy -v
       - run: git diff --exit-code

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -25,7 +25,7 @@ jobs:
           go-version: "1.26"
       - uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.1.6
+          version: v2.11.3
 
   tidy:
     runs-on: ubuntu-24.04

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -36,3 +36,13 @@ jobs:
           go-version: "1.26"
       - run: go mod tidy -v
       - run: git diff --exit-code
+
+  gofix:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+      - run: go fix ./...
+      - run: git diff --exit-code

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This provider plugin is maintained by:
 ## Requirements
 
 * [Terraform](https://www.terraform.io/downloads.html) 1.x
-* [Go](https://golang.org/doc/install) 1.24 (to build the provider plugin)
+* [Go](https://golang.org/doc/install) 1.26 (to build the provider plugin)
 
 ## Building The Provider
 
@@ -43,7 +43,7 @@ You can find examples in this repository: [selectel/terraform-examples](https://
 
 ## Developing the Provider
 
-If you wish to work on the provider, you'll first need [Go](https://golang.org) installed on your machine (version 1.24+ is _required_).
+If you wish to work on the provider, you'll first need [Go](https://golang.org) installed on your machine (version 1.26+ is _required_).
 
 To compile the provider, run `make build`. This will build the provider and put the provider binary in the current directory.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/terraform-providers/terraform-provider-selectel
 
-go 1.24.0
+go 1.26
 
 require (
 	github.com/hashicorp/go-retryablehttp v0.7.7

--- a/selectel/backups.go
+++ b/selectel/backups.go
@@ -8,7 +8,7 @@ import (
 	cloudbackup "github.com/selectel/cloudbackup-go/pkg/v2"
 )
 
-func getScheduledBackupClient(d *schema.ResourceData, meta interface{}) (*cloudbackup.ServiceClient, diag.Diagnostics) {
+func getScheduledBackupClient(d *schema.ResourceData, meta any) (*cloudbackup.ServiceClient, diag.Diagnostics) {
 	config := meta.(*Config)
 	projectID := d.Get("project_id").(string)
 	region := d.Get("region").(string)

--- a/selectel/craas.go
+++ b/selectel/craas.go
@@ -54,7 +54,7 @@ func waitForCRaaSRegistryV1StableState(
 func craasRegistryV1StateRefreshFunc(
 	ctx context.Context, client *clientv1.ServiceClient, registryID string,
 ) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		r, _, err := registry.Get(ctx, client, registryID)
 		if err != nil {
 			return nil, "", err
@@ -64,7 +64,7 @@ func craasRegistryV1StateRefreshFunc(
 	}
 }
 
-func getCRaaSClient(d *schema.ResourceData, meta interface{}) (*clientv1.ServiceClient, diag.Diagnostics) {
+func getCRaaSClient(d *schema.ResourceData, meta any) (*clientv1.ServiceClient, diag.Diagnostics) {
 	config := meta.(*Config)
 	selvpcClient, err := config.GetSelVPCClientWithProjectScope(d.Get("project_id").(string))
 	if err != nil {
@@ -81,7 +81,7 @@ func getCRaaSClient(d *schema.ResourceData, meta interface{}) (*clientv1.Service
 	return craasClient, nil
 }
 
-func getCRaaSClientV2(d *schema.ResourceData, meta interface{}) (*clientv2.ServiceClient, diag.Diagnostics) {
+func getCRaaSClientV2(d *schema.ResourceData, meta any) (*clientv2.ServiceClient, diag.Diagnostics) {
 	config := meta.(*Config)
 	selvpcClient, err := config.GetSelVPCClientWithProjectScope(d.Get("project_id").(string))
 	if err != nil {

--- a/selectel/data_source_selectel_cloudbackup_checkpoint_v2.go
+++ b/selectel/data_source_selectel_cloudbackup_checkpoint_v2.go
@@ -140,7 +140,7 @@ func dataSourceCloudBackupCheckpointV2() *schema.Resource {
 	}
 }
 
-func dataSourceCloudBackupCheckpointV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceCloudBackupCheckpointV2Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	filter := expandCloudBlockStorageBackupCheckpointsSearchFilter(d)
 
 	log.Printf("[DEBUG] Getting %s '%#v'", objectCloudBackupCheckpoint, filter)
@@ -173,7 +173,7 @@ func dataSourceCloudBackupCheckpointV2Read(ctx context.Context, d *schema.Resour
 }
 
 func dataSourceCloudBackupCheckpointV2LoadCheckpoints(
-	ctx context.Context, d *schema.ResourceData, meta interface{}, filter cloudBackupCheckpointsFilter,
+	ctx context.Context, d *schema.ResourceData, meta any, filter cloudBackupCheckpointsFilter,
 ) ([]*cloudbackup.Checkpoint, diag.Diagnostics) {
 	client, diagErr := getScheduledBackupClient(d, meta)
 	if diagErr != nil {
@@ -226,7 +226,7 @@ func expandCloudBlockStorageBackupCheckpointsSearchFilter(d *schema.ResourceData
 		return filter
 	}
 
-	resourceFilterMap := filterSet.List()[0].(map[string]interface{})
+	resourceFilterMap := filterSet.List()[0].(map[string]any)
 
 	planName, ok := resourceFilterMap["plan_name"]
 	if ok {
@@ -241,18 +241,18 @@ func expandCloudBlockStorageBackupCheckpointsSearchFilter(d *schema.ResourceData
 	return filter
 }
 
-func flattenCloudBlockStorageBackupCheckpoints(list []*cloudbackup.Checkpoint) []interface{} {
-	checkpoints := make([]interface{}, len(list))
+func flattenCloudBlockStorageBackupCheckpoints(list []*cloudbackup.Checkpoint) []any {
+	checkpoints := make([]any, len(list))
 	for i, e := range list {
-		sMap := make(map[string]interface{})
+		sMap := make(map[string]any)
 		sMap["id"] = e.ID
 		sMap["plan_id"] = e.PlanID
 		sMap["created_at"] = e.CreatedAt
 		sMap["status"] = e.Status
 
-		items := make([]interface{}, len(e.CheckpointItems))
+		items := make([]any, len(e.CheckpointItems))
 		for j, item := range e.CheckpointItems {
-			itemMap := make(map[string]interface{})
+			itemMap := make(map[string]any)
 			itemMap["id"] = item.ID
 			itemMap["backup_id"] = item.BackupID
 			itemMap["chain_id"] = item.ChainID
@@ -262,8 +262,8 @@ func flattenCloudBlockStorageBackupCheckpoints(list []*cloudbackup.Checkpoint) [
 			itemMap["is_incremental"] = item.IsIncremental
 			itemMap["status"] = item.Status
 
-			resource := make([]interface{}, 1)
-			resourceMap := make(map[string]interface{})
+			resource := make([]any, 1)
+			resourceMap := make(map[string]any)
 			resourceMap["id"] = item.Resource.ID
 			resourceMap["name"] = item.Resource.Name
 			resourceMap["type"] = item.Resource.Type
@@ -277,8 +277,8 @@ func flattenCloudBlockStorageBackupCheckpoints(list []*cloudbackup.Checkpoint) [
 		checkpoints[i] = sMap
 	}
 
-	return []interface{}{
-		map[string]interface{}{
+	return []any{
+		map[string]any{
 			"list":  checkpoints,
 			"total": len(checkpoints),
 		},

--- a/selectel/data_source_selectel_cloudbackup_plan_v2.go
+++ b/selectel/data_source_selectel_cloudbackup_plan_v2.go
@@ -120,7 +120,7 @@ func dataSourceCloudBackupPlanV2() *schema.Resource {
 	}
 }
 
-func dataSourceCloudBackupPlanV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceCloudBackupPlanV2Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	filter := expandCloudBackupPlansSearchFilter(d)
 
 	log.Printf("[DEBUG] Getting %s '%#v'", objectCloudBackupPlan, filter)
@@ -155,7 +155,7 @@ func dataSourceCloudBackupPlanV2Read(ctx context.Context, d *schema.ResourceData
 }
 
 func dataSourceCloudBackupPlanV2LoadPlans(
-	ctx context.Context, d *schema.ResourceData, meta interface{}, filter cloudBackupPlansFilter,
+	ctx context.Context, d *schema.ResourceData, meta any, filter cloudBackupPlansFilter,
 ) ([]*cloudbackup.Plan, diag.Diagnostics) {
 	client, diagErr := getScheduledBackupClient(d, meta)
 	if diagErr != nil {
@@ -209,7 +209,7 @@ func expandCloudBackupPlansSearchFilter(d *schema.ResourceData) cloudBackupPlans
 		return filter
 	}
 
-	resourceFilterMap := filterSet.List()[0].(map[string]interface{})
+	resourceFilterMap := filterSet.List()[0].(map[string]any)
 
 	name, ok := resourceFilterMap["name"]
 	if ok {
@@ -242,19 +242,19 @@ func filterCloudBackupPlans(list []*cloudbackup.Plan, filter cloudBackupPlansFil
 	return filtered
 }
 
-func flattenCloudBackupPlans(list []*cloudbackup.Plan, total int) []interface{} {
-	plans := make([]interface{}, len(list))
+func flattenCloudBackupPlans(list []*cloudbackup.Plan, total int) []any {
+	plans := make([]any, len(list))
 	for i, e := range list {
-		sMap := make(map[string]interface{})
+		sMap := make(map[string]any)
 		sMap["backup_mode"] = e.BackupMode
 		sMap["created_at"] = e.CreatedAt
 		sMap["id"] = e.ID
 		sMap["full_backups_amount"] = e.FullBackupsAmount
 		sMap["name"] = e.Name
 
-		resources := make([]interface{}, len(e.Resources))
+		resources := make([]any, len(e.Resources))
 		for j, r := range e.Resources {
-			rMap := make(map[string]interface{})
+			rMap := make(map[string]any)
 			rMap["id"] = r.ID
 			rMap["name"] = r.Name
 			rMap["type"] = r.Type
@@ -269,8 +269,8 @@ func flattenCloudBackupPlans(list []*cloudbackup.Plan, total int) []interface{} 
 		plans[i] = sMap
 	}
 
-	return []interface{}{
-		map[string]interface{}{
+	return []any{
+		map[string]any{
 			"list":  plans,
 			"total": total,
 		},

--- a/selectel/data_source_selectel_dbaas_available_extension_v1.go
+++ b/selectel/data_source_selectel_dbaas_available_extension_v1.go
@@ -70,7 +70,7 @@ func dataSourceDBaaSAvailableExtensionV1() *schema.Resource {
 	}
 }
 
-func dataSourceDBaaSAvailableExtensionV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceDBaaSAvailableExtensionV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -112,7 +112,7 @@ func expandAvailableExtensionSearchFilter(filterSet *schema.Set) (availableExten
 		return filter, nil
 	}
 
-	resourceFilterMap := filterSet.List()[0].(map[string]interface{})
+	resourceFilterMap := filterSet.List()[0].(map[string]any)
 
 	name, ok := resourceFilterMap["name"]
 	if ok {
@@ -137,10 +137,10 @@ func filterAvailableExtensionByName(availableExtensions []dbaas.AvailableExtensi
 	return filteredAvailableExtensions
 }
 
-func flattenAvailableExtensions(availableExtensions []dbaas.AvailableExtension) []interface{} {
-	availableExtensionsList := make([]interface{}, len(availableExtensions))
+func flattenAvailableExtensions(availableExtensions []dbaas.AvailableExtension) []any {
+	availableExtensionsList := make([]any, len(availableExtensions))
 	for i, availableExtension := range availableExtensions {
-		availableExtensionsMap := make(map[string]interface{})
+		availableExtensionsMap := make(map[string]any)
 		availableExtensionsMap["id"] = availableExtension.ID
 		availableExtensionsMap["name"] = availableExtension.Name
 		availableExtensionsMap["datastore_type_ids"] = availableExtension.DatastoreTypeIDs

--- a/selectel/data_source_selectel_dbaas_configuration_parameter_v1.go
+++ b/selectel/data_source_selectel_dbaas_configuration_parameter_v1.go
@@ -107,7 +107,7 @@ func dataSourceDBaaSConfigurationParameterV1() *schema.Resource {
 	}
 }
 
-func dataSourceDBaaSConfigurationParameterV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceDBaaSConfigurationParameterV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -150,7 +150,7 @@ func expandConfigurationParameterSearchFilter(filterSet *schema.Set) (configurat
 		return filter, nil
 	}
 
-	resourceFilterMap := filterSet.List()[0].(map[string]interface{})
+	resourceFilterMap := filterSet.List()[0].(map[string]any)
 
 	datastoreTypeID, ok := resourceFilterMap["datastore_type_id"]
 	if ok {
@@ -195,7 +195,7 @@ func filterConfigurationParametersByName(configurationParameters []dbaas.Configu
 	return filteredConfigurationParameters
 }
 
-func convertListParametersTypes(parameters []interface{}) []string {
+func convertListParametersTypes(parameters []any) []string {
 	parameterList := make([]string, len(parameters))
 	for i, value := range parameters {
 		parameterList[i] = convertFieldToStringByType(value)
@@ -204,10 +204,10 @@ func convertListParametersTypes(parameters []interface{}) []string {
 	return parameterList
 }
 
-func flattenDBaaSConfigurationParameters(configurationParameters []dbaas.ConfigurationParameter) []interface{} {
-	configurationParametersList := make([]interface{}, len(configurationParameters))
+func flattenDBaaSConfigurationParameters(configurationParameters []dbaas.ConfigurationParameter) []any {
+	configurationParametersList := make([]any, len(configurationParameters))
 	for i, param := range configurationParameters {
-		configurationParametersMap := make(map[string]interface{})
+		configurationParametersMap := make(map[string]any)
 		configurationParametersMap["id"] = param.ID
 		configurationParametersMap["datastore_type_id"] = param.DatastoreTypeID
 		configurationParametersMap["name"] = param.Name

--- a/selectel/data_source_selectel_dbaas_datastore_type_v1.go
+++ b/selectel/data_source_selectel_dbaas_datastore_type_v1.go
@@ -65,7 +65,7 @@ func dataSourceDBaaSDatastoreTypeV1() *schema.Resource {
 	}
 }
 
-func dataSourceDBaaSDatastoreTypeV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceDBaaSDatastoreTypeV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -108,7 +108,7 @@ func expandDatastoreTypeSearchFilter(filterSet *schema.Set) (datastoreTypeSearch
 		return filter, nil
 	}
 
-	resourceFilterMap := filterSet.List()[0].(map[string]interface{})
+	resourceFilterMap := filterSet.List()[0].(map[string]any)
 
 	engine, ok := resourceFilterMap["engine"]
 	if ok {
@@ -153,10 +153,10 @@ func filterDatastoreTypesByEngine(datastoreTypes []dbaas.DatastoreType, engine s
 	return filteredDatastoreTypes
 }
 
-func flattenDBaaSDatastoreTypes(datastoreTypes []dbaas.DatastoreType) []interface{} {
-	datastoreTypesList := make([]interface{}, len(datastoreTypes))
+func flattenDBaaSDatastoreTypes(datastoreTypes []dbaas.DatastoreType) []any {
+	datastoreTypesList := make([]any, len(datastoreTypes))
 	for i, datastoreType := range datastoreTypes {
-		datastoreTypesMap := make(map[string]interface{})
+		datastoreTypesMap := make(map[string]any)
 		datastoreTypesMap["id"] = datastoreType.ID
 		datastoreTypesMap["engine"] = datastoreType.Engine
 		datastoreTypesMap["version"] = datastoreType.Version

--- a/selectel/data_source_selectel_dbaas_flavor_v1.go
+++ b/selectel/data_source_selectel_dbaas_flavor_v1.go
@@ -103,7 +103,7 @@ func dataSourceDBaaSFlavorV1() *schema.Resource {
 	}
 }
 
-func dataSourceDBaaSFlavorV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceDBaaSFlavorV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -149,7 +149,7 @@ func expandFlavorSearchFilter(filterSet *schema.Set) (flavorSearchFilter, error)
 		return filter, nil
 	}
 
-	resourceFilterMap := filterSet.List()[0].(map[string]interface{})
+	resourceFilterMap := filterSet.List()[0].(map[string]any)
 
 	vcpus, ok := resourceFilterMap["vcpus"]
 	if ok {
@@ -256,10 +256,10 @@ func filterFlavorByDatastoreTypeID(flavors []dbaas.FlavorResponse, datastoreType
 	return filteredFlavors
 }
 
-func flattenDBaaSFlavors(flavors []dbaas.FlavorResponse) []interface{} {
-	flavorsList := make([]interface{}, len(flavors))
+func flattenDBaaSFlavors(flavors []dbaas.FlavorResponse) []any {
+	flavorsList := make([]any, len(flavors))
 	for i, flavor := range flavors {
-		flavorMap := make(map[string]interface{})
+		flavorMap := make(map[string]any)
 		flavorMap["id"] = flavor.ID
 		flavorMap["name"] = flavor.Name
 		flavorMap["description"] = flavor.Description

--- a/selectel/data_source_selectel_dbaas_prometheus_metric_token_v1.go
+++ b/selectel/data_source_selectel_dbaas_prometheus_metric_token_v1.go
@@ -59,7 +59,7 @@ func dataSourceDBaaSPrometheusMetricTokenV1() *schema.Resource {
 	}
 }
 
-func dataSourceDBaaSPrometheusMetricTokenV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceDBaaSPrometheusMetricTokenV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -88,10 +88,10 @@ func dataSourceDBaaSPrometheusMetricTokenV1Read(ctx context.Context, d *schema.R
 	return nil
 }
 
-func flattenDBaaSPrometheusMetricTokenTypes(tokens []dbaas.PrometheusMetricToken) []interface{} {
-	tokensList := make([]interface{}, len(tokens))
+func flattenDBaaSPrometheusMetricTokenTypes(tokens []dbaas.PrometheusMetricToken) []any {
+	tokensList := make([]any, len(tokens))
 	for i, token := range tokens {
-		tokensMap := make(map[string]interface{})
+		tokensMap := make(map[string]any)
 		tokensMap["id"] = token.ID
 		tokensMap["created_at"] = token.CreatedAt
 		tokensMap["updated_at"] = token.UpdatedAt

--- a/selectel/data_source_selectel_dedicated_configuration_v1.go
+++ b/selectel/data_source_selectel_dedicated_configuration_v1.go
@@ -45,7 +45,7 @@ func dataSourceDedicatedConfigurationV1() *schema.Resource {
 	}
 }
 
-func dataSourceDedicatedConfigurationV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceDedicatedConfigurationV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dsClient, diagErr := getDedicatedClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -131,10 +131,10 @@ func filterDedicatedConfigurations(list []map[string]any, filter *dedicatedConfi
 	return filteredRaw
 }
 
-func flattenDedicatedConfigurations(list []map[string]any) []interface{} {
-	res := make([]interface{}, len(list))
+func flattenDedicatedConfigurations(list []map[string]any) []any {
+	res := make([]any, len(list))
 	for i, e := range list {
-		sMap := make(map[string]interface{})
+		sMap := make(map[string]any)
 		sMap["id"] = e["uuid"]
 		sMap["name"] = e["name"]
 

--- a/selectel/data_source_selectel_dedicated_configuration_v1_test.go
+++ b/selectel/data_source_selectel_dedicated_configuration_v1_test.go
@@ -52,7 +52,7 @@ func testAccDedicatedConfigurationV1Exists(
 			return err
 		}
 
-		var srvFromAPI map[string]interface{}
+		var srvFromAPI map[string]any
 		for _, srv := range serversFromAPI {
 			name, _ := srv["name"].(string)
 			if name == serverName {

--- a/selectel/data_source_selectel_dedicated_location_v1.go
+++ b/selectel/data_source_selectel_dedicated_location_v1.go
@@ -60,7 +60,7 @@ func dataSourceDedicatedLocationV1() *schema.Resource {
 	}
 }
 
-func dataSourceDedicatedLocationV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceDedicatedLocationV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dsClient, diagErr := getDedicatedClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -115,7 +115,7 @@ func expandDedicatedLocationsSearchFilter(d *schema.ResourceData) dedicatedLocat
 		return filter
 	}
 
-	resourceFilterMap := filterSet.List()[0].(map[string]interface{})
+	resourceFilterMap := filterSet.List()[0].(map[string]any)
 
 	name, ok := resourceFilterMap["name"]
 	if ok {
@@ -136,10 +136,10 @@ func filterDedicatedLocations(list dedicated.Locations, filter dedicatedLocation
 	return filtered
 }
 
-func flattenDedicatedLocations(list dedicated.Locations) []interface{} {
-	res := make([]interface{}, len(list))
+func flattenDedicatedLocations(list dedicated.Locations) []any {
+	res := make([]any, len(list))
 	for i, e := range list {
-		sMap := make(map[string]interface{})
+		sMap := make(map[string]any)
 		sMap["id"] = e.UUID
 		sMap["name"] = e.Name
 		sMap["description"] = e.Description

--- a/selectel/data_source_selectel_dedicated_os_v1.go
+++ b/selectel/data_source_selectel_dedicated_os_v1.go
@@ -103,7 +103,7 @@ func dataSourceDedicatedOSV1() *schema.Resource {
 	}
 }
 
-func dataSourceDedicatedOSV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceDedicatedOSV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dsClient, diagErr := getDedicatedClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -169,7 +169,7 @@ func expandDedicatedOperatingSystemsSearchFilter(d *schema.ResourceData) dedicat
 		return filter
 	}
 
-	resourceFilterMap := filterSet.List()[0].(map[string]interface{})
+	resourceFilterMap := filterSet.List()[0].(map[string]any)
 
 	name, ok := resourceFilterMap["name"]
 	if ok {
@@ -232,10 +232,10 @@ func filterDedicatedOperatingSystems(list dedicated.OperatingSystems, filter ded
 	return filtered, nil
 }
 
-func flattenDedicatedOperatingSystems(list dedicated.OperatingSystems) []interface{} {
-	res := make([]interface{}, len(list))
+func flattenDedicatedOperatingSystems(list dedicated.OperatingSystems) []any {
+	res := make([]any, len(list))
 	for i, e := range list {
-		sMap := make(map[string]interface{})
+		sMap := make(map[string]any)
 		sMap["id"] = e.UUID
 		sMap["name"] = e.Name
 		sMap["arch"] = e.Arch

--- a/selectel/data_source_selectel_dedicated_public_subnet_v1.go
+++ b/selectel/data_source_selectel_dedicated_public_subnet_v1.go
@@ -83,7 +83,7 @@ func dataSourceDedicatedPublicSubnetV1() *schema.Resource {
 	}
 }
 
-func dataSourceDedicatedPublicSubnetV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceDedicatedPublicSubnetV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dsClient, diagErr := getDedicatedClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -141,7 +141,7 @@ func expandDedicatedPublicSubnetsSearchFilter(d *schema.ResourceData) dedicatedP
 		return filter
 	}
 
-	resourceFilterMap := filterSet.List()[0].(map[string]interface{})
+	resourceFilterMap := filterSet.List()[0].(map[string]any)
 
 	ip, ok := resourceFilterMap["ip"]
 	if ok {
@@ -184,10 +184,10 @@ func filterDedicatedPublicSubnets(subnets dedicated.Subnets, filter dedicatedPub
 	return filteredSubnets, nil
 }
 
-func flattenDedicatedPublicSubnets(subnets dedicated.Subnets, filter dedicatedPublicSubnetsSearchFilter) []interface{} {
-	subnetsList := make([]interface{}, len(subnets))
+func flattenDedicatedPublicSubnets(subnets dedicated.Subnets, filter dedicatedPublicSubnetsSearchFilter) []any {
+	subnetsList := make([]any, len(subnets))
 	for i, subnet := range subnets {
-		subnetMap := make(map[string]interface{})
+		subnetMap := make(map[string]any)
 		subnetMap["id"] = subnet.UUID
 		subnetMap["network_id"] = subnet.NetworkUUID
 		subnetMap["subnet"] = subnet.Subnet

--- a/selectel/data_source_selectel_domains_domain_v1.go
+++ b/selectel/data_source_selectel_domains_domain_v1.go
@@ -26,7 +26,7 @@ func dataSourceDomainsDomainV1() *schema.Resource {
 	}
 }
 
-func dataSourceDomainsDomainV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceDomainsDomainV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, err := getDomainsClient(meta)
 	if err != nil {
 		return diag.FromErr(err)

--- a/selectel/data_source_selectel_domains_rrset_v2.go
+++ b/selectel/data_source_selectel_domains_rrset_v2.go
@@ -61,7 +61,7 @@ func dataSourceDomainsRRSetV2() *schema.Resource {
 	}
 }
 
-func dataSourceDomainsRRSetV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceDomainsRRSetV2Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, err := getDomainsV2Client(d, meta)
 	if err != nil {
 		return diag.FromErr(err)

--- a/selectel/data_source_selectel_domains_zone_v2.go
+++ b/selectel/data_source_selectel_domains_zone_v2.go
@@ -52,7 +52,7 @@ func dataSourceDomainsZoneV2() *schema.Resource {
 	}
 }
 
-func dataSourceDomainsZoneV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceDomainsZoneV2Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, err := getDomainsV2Client(d, meta)
 	if err != nil {
 		return diag.FromErr(err)

--- a/selectel/data_source_selectel_global_router_quota_v1.go
+++ b/selectel/data_source_selectel_global_router_quota_v1.go
@@ -35,7 +35,7 @@ func dataSourceGlobalRouterQuotaV1() *schema.Resource {
 	}
 }
 
-func dataSourceGlobalRouterQuotaV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceGlobalRouterQuotaV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getGlobalRouterClient(meta)
 	if diagErr != nil {
 		return diagErr

--- a/selectel/data_source_selectel_global_router_service_v1.go
+++ b/selectel/data_source_selectel_global_router_service_v1.go
@@ -29,7 +29,7 @@ func dataSourceGlobalRouterServiceV1() *schema.Resource {
 	}
 }
 
-func dataSourceGlobalRouterServiceV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceGlobalRouterServiceV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getGlobalRouterClient(meta)
 	if diagErr != nil {
 		return diagErr

--- a/selectel/data_source_selectel_global_router_zone_group_v1.go
+++ b/selectel/data_source_selectel_global_router_zone_group_v1.go
@@ -33,7 +33,7 @@ func dataSourceGlobalRouterZoneGroupV1() *schema.Resource {
 	}
 }
 
-func dataSourceGlobalRouterZoneGroupV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceGlobalRouterZoneGroupV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getGlobalRouterClient(meta)
 	if diagErr != nil {
 		return diagErr

--- a/selectel/data_source_selectel_global_router_zone_v1.go
+++ b/selectel/data_source_selectel_global_router_zone_v1.go
@@ -86,7 +86,7 @@ func dataSourceGlobalRouterZoneV1() *schema.Resource {
 	}
 }
 
-func dataSourceGlobalRouterZoneV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceGlobalRouterZoneV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getGlobalRouterClient(meta)
 	if diagErr != nil {
 		return diagErr

--- a/selectel/data_source_selectel_mks_kube_options.go
+++ b/selectel/data_source_selectel_mks_kube_options.go
@@ -57,7 +57,7 @@ func dataSourceMKSFeatureGatesV1() *schema.Resource {
 	}
 }
 
-func dataSourceMKSFeatureGateV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceMKSFeatureGateV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	mksClient, diagErr := getMKSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -84,7 +84,7 @@ func dataSourceMKSFeatureGateV1Read(ctx context.Context, d *schema.ResourceData,
 		return nil
 	}
 
-	filterMap := filterSet.List()[0].(map[string]interface{})
+	filterMap := filterSet.List()[0].(map[string]any)
 	kubeVersion := filterMap["kube_version"].(string)
 
 	if kubeVersion == "" {
@@ -176,7 +176,7 @@ func dataSourceMKSAdmissionControllersV1() *schema.Resource {
 	}
 }
 
-func dataSourceMKSAdmissionControllersV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceMKSAdmissionControllersV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	mksClient, diagErr := getMKSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -203,7 +203,7 @@ func dataSourceMKSAdmissionControllersV1Read(ctx context.Context, d *schema.Reso
 		return nil
 	}
 
-	filterMap := filterSet.List()[0].(map[string]interface{})
+	filterMap := filterSet.List()[0].(map[string]any)
 	kubeVersion := filterMap["kube_version"].(string)
 
 	if kubeVersion == "" {

--- a/selectel/data_source_selectel_mks_kube_versions_v1.go
+++ b/selectel/data_source_selectel_mks_kube_versions_v1.go
@@ -41,7 +41,7 @@ func dataSourceMKSKubeVersionsV1() *schema.Resource {
 	}
 }
 
-func dataSourceMKSKubeVersionsV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceMKSKubeVersionsV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	mksClient, diagErr := getMKSClient(d, meta)
 	if diagErr != nil {
 		return diagErr

--- a/selectel/data_source_selectel_mks_kubeconfig_v1.go
+++ b/selectel/data_source_selectel_mks_kubeconfig_v1.go
@@ -55,7 +55,7 @@ func dataSourceMKSKubeconfigV1() *schema.Resource {
 	}
 }
 
-func dataSourceMKSKubeconfigV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceMKSKubeconfigV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	mksClient, diagErr := getMKSClient(d, meta)
 	if diagErr != nil {
 		return diagErr

--- a/selectel/dbaas.go
+++ b/selectel/dbaas.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"math"
 	"math/rand" // nosemgrep: go.lang.security.audit.crypto.math_random.math-random-used
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -29,7 +30,7 @@ const (
 	replicaRole              = "REPLICA"
 )
 
-func getDBaaSClient(d *schema.ResourceData, meta interface{}) (*dbaas.API, diag.Diagnostics) {
+func getDBaaSClient(d *schema.ResourceData, meta any) (*dbaas.API, diag.Diagnostics) {
 	config := meta.(*Config)
 	projectID := d.Get("project_id").(string)
 	region := d.Get("region").(string)
@@ -79,7 +80,7 @@ func stringListChecksum(s []string) (string, error) {
 	return checksum, nil
 }
 
-func convertFieldToStringByType(field interface{}) string {
+func convertFieldToStringByType(field any) string {
 	switch fieldValue := field.(type) {
 	case int:
 		return strconv.Itoa(fieldValue)
@@ -112,10 +113,10 @@ func resourceDBaaSDatastoreV1FlavorFromSet(flavorSet *schema.Set) (*dbaas.Flavor
 	if flavorSet.Len() == 0 {
 		return nil, nil
 	}
-	var resourceVcpusRaw, resourceRAMRaw, resourceDiskRaw interface{}
+	var resourceVcpusRaw, resourceRAMRaw, resourceDiskRaw any
 	var ok bool
 
-	resourceFlavorMap := flavorSet.List()[0].(map[string]interface{})
+	resourceFlavorMap := flavorSet.List()[0].(map[string]any)
 	if resourceVcpusRaw, ok = resourceFlavorMap["vcpus"]; !ok {
 		return &dbaas.Flavor{}, errors.New("flavor.vcpus value isn't provided")
 	}
@@ -147,7 +148,7 @@ func resourceDBaaSDatastoreV1FlavorToSet(flavor dbaas.Flavor) *schema.Set {
 		F: flavorHashSetFunc(),
 	}
 
-	flavorSet.Add(map[string]interface{}{
+	flavorSet.Add(map[string]any{
 		"vcpus":     flavor.Vcpus,
 		"ram":       flavor.RAM,
 		"disk":      flavor.Disk,
@@ -157,11 +158,11 @@ func resourceDBaaSDatastoreV1FlavorToSet(flavor dbaas.Flavor) *schema.Set {
 	return flavorSet
 }
 
-func resourceDBaaSDatastoreV1InstancesToList(instances []dbaas.Instances) []interface{} {
-	flattenedInstances := make([]interface{}, len(instances))
+func resourceDBaaSDatastoreV1InstancesToList(instances []dbaas.Instances) []any {
+	flattenedInstances := make([]any, len(instances))
 
 	for i, instance := range instances {
-		flattenedInstance := map[string]interface{}{
+		flattenedInstance := map[string]any{
 			"role":        instance.Role,
 			"floating_ip": instance.FloatingIP,
 		}
@@ -175,10 +176,10 @@ func resourceDBaaSDatastoreV1RestoreOptsFromSet(restoreSet *schema.Set) (*dbaas.
 	if restoreSet.Len() == 0 {
 		return nil, nil
 	}
-	var resourceDatastoreIDRaw, resourceTargetTimeRaw interface{}
+	var resourceDatastoreIDRaw, resourceTargetTimeRaw any
 	var ok bool
 
-	resourceRestoreMap := restoreSet.List()[0].(map[string]interface{})
+	resourceRestoreMap := restoreSet.List()[0].(map[string]any)
 	if resourceDatastoreIDRaw, ok = resourceRestoreMap["datastore_id"]; !ok {
 		return &dbaas.Restore{}, errors.New("restore.datastore_id value isn't provided")
 	}
@@ -202,7 +203,7 @@ func resourceDBaaSDatastoreV1FloatingIPsOptsFromSet(floatingIPsSet *schema.Set) 
 		return nil, nil
 	}
 
-	floatingIPMap, ok := floatingIPsSet.List()[0].(map[string]interface{})
+	floatingIPMap, ok := floatingIPsSet.List()[0].(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("invalid format for floating IPs data")
 	}
@@ -278,7 +279,7 @@ func updateDatastoreConfig(ctx context.Context, d *schema.ResourceData, client *
 	if err != nil {
 		return err
 	}
-	config := d.Get("config").(map[string]interface{})
+	config := d.Get("config").(map[string]any)
 
 	for param := range datastore.Config {
 		if _, ok := config[param]; !ok {
@@ -374,13 +375,7 @@ func resizeDatastore(ctx context.Context, d *schema.ResourceData, client *dbaas.
 }
 
 func containDatastoreType(expectedTypes []string, datastoreType string) bool {
-	for _, expectedType := range expectedTypes {
-		if expectedType == datastoreType {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(expectedTypes, datastoreType)
 }
 
 func buildDatastoreTypeErrorMessage(expectedDatastoreTypeEngines []string, datastoreTypeEngine string) string {
@@ -439,7 +434,7 @@ func getDatastoreReplicasInstancesIDsWithoutFloatings(datastore dbaas.Datastore)
 
 // Floating IPs
 
-func refreshDatastoreInstancesOutputsDiff(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+func refreshDatastoreInstancesOutputsDiff(_ context.Context, diff *schema.ResourceDiff, _ any) error {
 	if diff.HasChanges("floating_ips") {
 		if err := diff.SetNewComputed("instances"); err != nil {
 			return err
@@ -657,7 +652,7 @@ func adjustMasterFloatingIPs(ctx context.Context, d *schema.ResourceData, client
 }
 
 func addReplicasFloatingIPs(ctx context.Context, d *schema.ResourceData, client *dbaas.API, replicasWithoutFIPs []string, diff int) error {
-	for i := 0; i < diff; i++ {
+	for i := range diff {
 		err := dbaasFloatingIPCreate(ctx, d, client, replicasWithoutFIPs[i])
 		if err != nil {
 			return fmt.Errorf(
@@ -673,7 +668,7 @@ func addReplicasFloatingIPs(ctx context.Context, d *schema.ResourceData, client 
 
 func removeReplicasFloatingIPs(ctx context.Context, d *schema.ResourceData, client *dbaas.API, replicasWithFIPs []string, diff int) error {
 	needed := int(math.Abs(float64(diff)))
-	for i := 0; i < needed; i++ {
+	for i := range needed {
 		err := dbaasFloatingIPDelete(ctx, d, client, replicasWithFIPs[i])
 		if err != nil {
 			return fmt.Errorf(

--- a/selectel/dbaas_postgresql_utils.go
+++ b/selectel/dbaas_postgresql_utils.go
@@ -11,10 +11,10 @@ import (
 )
 
 func parsePoolerSet(poolerSet *schema.Set) (string, int, error) {
-	var resourceModeRaw, resourceSizeRaw interface{}
+	var resourceModeRaw, resourceSizeRaw any
 	var ok bool
 
-	resourcePoolerMap := poolerSet.List()[0].(map[string]interface{})
+	resourcePoolerMap := poolerSet.List()[0].(map[string]any)
 	if resourceModeRaw, ok = resourcePoolerMap["mode"]; !ok {
 		return "", 0, errors.New("pooler.mode value isn't provided")
 	}

--- a/selectel/dedicated.go
+++ b/selectel/dedicated.go
@@ -19,11 +19,11 @@ import (
 
 // serversMapsFromStructs converts the provided license.Servers to
 // the slice of maps correspondingly to the resource's schema.
-func serversMapsFromStructs(serverStructs []servers.Server) []map[string]interface{} {
-	associatedServers := make([]map[string]interface{}, len(serverStructs))
+func serversMapsFromStructs(serverStructs []servers.Server) []map[string]any {
+	associatedServers := make([]map[string]any, len(serverStructs))
 
 	for i, server := range serverStructs {
-		associatedServers[i] = map[string]interface{}{
+		associatedServers[i] = map[string]any{
 			"id":     server.ID,
 			"name":   server.Name,
 			"status": server.Status,
@@ -34,12 +34,12 @@ func serversMapsFromStructs(serverStructs []servers.Server) []map[string]interfa
 }
 
 // hashServers is a hash function to use with the "servers" set.
-func hashServers(v interface{}) int {
-	m := v.(map[string]interface{})
+func hashServers(v any) int {
+	m := v.(map[string]any)
 	return hashcode.String(fmt.Sprintf("%s-", m["id"].(string)))
 }
 
-func getDedicatedClient(d *schema.ResourceData, meta interface{}) (*dedicated.ServiceClient, diag.Diagnostics) {
+func getDedicatedClient(d *schema.ResourceData, meta any) (*dedicated.ServiceClient, diag.Diagnostics) {
 	config := meta.(*Config)
 	projectID := d.Get(dedicatedServerSchemaKeyProjectID).(string)
 
@@ -356,12 +356,12 @@ func resourceDedicatedServerV1ReadPartitionsConfig(d *schema.ResourceData) (*Par
 		return res, nil
 	}
 
-	partitionsConfigRaw, ok := v.([]interface{})
+	partitionsConfigRaw, ok := v.([]any)
 	if !ok || len(partitionsConfigRaw) != 1 {
 		return nil, errors.New("partitions_config has unexpected type")
 	}
 
-	partitionsConfig, ok := partitionsConfigRaw[0].(map[string]interface{})
+	partitionsConfig, ok := partitionsConfigRaw[0].(map[string]any)
 	if !ok {
 		return nil, errors.New("partitions_config has unexpected type")
 	}
@@ -380,16 +380,16 @@ func resourceDedicatedServerV1ReadPartitionsConfig(d *schema.ResourceData) (*Par
 	return res, nil
 }
 
-func resourceDedicatedServerV1ReadPartitionsConfigSoftRaid(partitionsConfig map[string]interface{}) ([]*SoftRaidConfigItem, error) {
-	srCfgRaw, ok := partitionsConfig[dedicatedServerSchemaKeySoftRaidConfig].([]interface{})
+func resourceDedicatedServerV1ReadPartitionsConfigSoftRaid(partitionsConfig map[string]any) ([]*SoftRaidConfigItem, error) {
+	srCfgRaw, ok := partitionsConfig[dedicatedServerSchemaKeySoftRaidConfig].([]any)
 	if !ok {
-		srCfgRaw = make([]interface{}, 0)
+		srCfgRaw = make([]any, 0)
 	}
 
 	res := make([]*SoftRaidConfigItem, 0, len(srCfgRaw))
 
 	for idx, itemRaw := range srCfgRaw {
-		item, ok := itemRaw.(map[string]interface{})
+		item, ok := itemRaw.(map[string]any)
 		if !ok {
 			return nil, fmt.Errorf("partitions_config.soft_raid_config[%d] has unexpected type", idx)
 		}
@@ -419,16 +419,16 @@ func resourceDedicatedServerV1ReadPartitionsConfigSoftRaid(partitionsConfig map[
 	return res, nil
 }
 
-func resourceDedicatedServerV1ReadPartitionsConfigDiskPartitions(partitionsConfig map[string]interface{}) ([]*DiskPartitionsItem, error) {
-	dpCfgRaw, ok := partitionsConfig[dedicatedServerSchemaKeyDiskPartitions].([]interface{})
+func resourceDedicatedServerV1ReadPartitionsConfigDiskPartitions(partitionsConfig map[string]any) ([]*DiskPartitionsItem, error) {
+	dpCfgRaw, ok := partitionsConfig[dedicatedServerSchemaKeyDiskPartitions].([]any)
 	if !ok {
-		dpCfgRaw = make([]interface{}, 0)
+		dpCfgRaw = make([]any, 0)
 	}
 
 	res := make([]*DiskPartitionsItem, 0, len(dpCfgRaw))
 
 	for idx, itemRaw := range dpCfgRaw {
-		item, ok := itemRaw.(map[string]interface{})
+		item, ok := itemRaw.(map[string]any)
 		if !ok {
 			return nil, fmt.Errorf("partitions_config.disk_partitions[%d] has unexpected type", idx)
 		}

--- a/selectel/dedicated_test.go
+++ b/selectel/dedicated_test.go
@@ -19,7 +19,7 @@ func TestServersMapsFromStructs(t *testing.T) {
 			Status: "ACTIVE",
 		},
 	}
-	expectedServersMaps := []map[string]interface{}{
+	expectedServersMaps := []map[string]any{
 		{
 			"id":     "a208023f-69fe-4a9e-8285-dd44e94a854a",
 			"name":   "fake",

--- a/selectel/domains.go
+++ b/selectel/domains.go
@@ -16,7 +16,7 @@ const (
 	domainsV1DefaultRetry        = 5
 )
 
-func getDomainsClient(meta interface{}) (*domainsV1.ServiceClient, error) {
+func getDomainsClient(meta any) (*domainsV1.ServiceClient, error) {
 	config := meta.(*Config)
 
 	selvpcClient, err := config.GetSelVPCClient()
@@ -72,14 +72,15 @@ func domainsV1ParseDomainRecordIDsPair(id string) (int, int, error) {
 	return domainID, recordID, nil
 }
 
-func getIntPtrOrNil(v interface{}) *int {
+func getIntPtrOrNil(v any) *int {
 	if v == nil {
 		return nil
 	}
 
-	return intPtr(v.(int))
+	return new(v.(int))
 }
 
+//go:fix inline
 func intPtr(v int) *int {
-	return &v
+	return new(v)
 }

--- a/selectel/domains_test.go
+++ b/selectel/domains_test.go
@@ -54,12 +54,12 @@ func TestDomainsV1ParseDomainRecordIDsPair(t *testing.T) {
 
 func TestGetIntPtrOrNil(_ *testing.T) {
 	tableTest := []struct {
-		input    interface{}
+		input    any
 		expected *int
 	}{
 		{
 			input:    123,
-			expected: intPtr(123),
+			expected: new(123),
 		},
 		{
 			input:    nil,

--- a/selectel/domains_v2.go
+++ b/selectel/domains_v2.go
@@ -16,7 +16,7 @@ import (
 
 var ErrProjectIDNotSetupForDNSV2 = errors.New("env variable INFRA_PROJECT_ID or variable project_id must be set for the dns v2")
 
-func getDomainsV2Client(d *schema.ResourceData, meta interface{}) (domainsV2.DNSClient[domainsV2.Zone, domainsV2.RRSet], error) {
+func getDomainsV2Client(d *schema.ResourceData, meta any) (domainsV2.DNSClient[domainsV2.Zone, domainsV2.RRSet], error) {
 	config := meta.(*Config)
 	projectID := d.Get("project_id").(string)
 
@@ -133,10 +133,10 @@ func setRRSetToResourceData(d *schema.ResourceData, rrset *domainsV2.RRSet) erro
 }
 
 // generateSetFromRecords - generate terraform TypeList from records in RRSet.
-func generateSetFromRecords(records []domainsV2.RecordItem) []interface{} {
-	recordsAsList := []interface{}{}
+func generateSetFromRecords(records []domainsV2.RecordItem) []any {
+	recordsAsList := []any{}
 	for _, record := range records {
-		recordsAsList = append(recordsAsList, map[string]interface{}{
+		recordsAsList = append(recordsAsList, map[string]any{
 			"content":  record.Content,
 			"disabled": record.Disabled,
 		})
@@ -149,7 +149,7 @@ func generateSetFromRecords(records []domainsV2.RecordItem) []interface{} {
 func generateRecordsFromSet(recordsSet *schema.Set) []domainsV2.RecordItem {
 	records := []domainsV2.RecordItem{}
 	for _, recordItem := range recordsSet.List() {
-		record, isOk := recordItem.(map[string]interface{})
+		record, isOk := recordItem.(map[string]any)
 		if !isOk {
 			continue
 		}

--- a/selectel/global_router.go
+++ b/selectel/global_router.go
@@ -25,7 +25,7 @@ var errQuotaNoResults = errors.New(
 var errQuotaMultipleResults = errors.New(
 	"your query returned more than one result. please try a more specific search criteria")
 
-func getGlobalRouterClient(meta interface{}) (*globalrouter.ServiceClient, diag.Diagnostics) {
+func getGlobalRouterClient(meta any) (*globalrouter.ServiceClient, diag.Diagnostics) {
 	config := meta.(*Config)
 	selvpcClient, err := config.GetSelVPCClient()
 	if err != nil {

--- a/selectel/iam.go
+++ b/selectel/iam.go
@@ -25,7 +25,7 @@ var (
 	deprecatedRolesCacheOnce sync.Once
 )
 
-func getIAMClient(meta interface{}) (*iam.Client, diag.Diagnostics) {
+func getIAMClient(meta any) (*iam.Client, diag.Diagnostics) {
 	config := meta.(*Config)
 
 	selvpcClient, err := config.GetSelVPCClient()
@@ -79,20 +79,20 @@ func diffRoles(oldRoles, newRoles []roles.Role) ([]roles.Role, []roles.Role) {
 	return rolesToUnassign, rolesToAssign
 }
 
-func convertIAMListToUserFederation(federationList []interface{}) (*users.Federation, error) {
+func convertIAMListToUserFederation(federationList []any) (*users.Federation, error) {
 	if len(federationList) == 0 {
 		return nil, nil
 	}
 	if len(federationList) > 1 {
 		return nil, errors.New("more than one federation value provided")
 	}
-	var idRaw, externalIDRaw interface{}
+	var idRaw, externalIDRaw any
 	var ok bool
 
-	if idRaw, ok = federationList[0].(map[string]interface{})["id"]; !ok {
+	if idRaw, ok = federationList[0].(map[string]any)["id"]; !ok {
 		return nil, errors.New("federation.id value isn't provided")
 	}
-	if externalIDRaw, ok = federationList[0].(map[string]interface{})["external_id"]; !ok {
+	if externalIDRaw, ok = federationList[0].(map[string]any)["external_id"]; !ok {
 		return nil, errors.New("federation.external_id value isn't provided")
 	}
 
@@ -111,11 +111,11 @@ func convertIAMSetToRoles(rolesSet *schema.Set) ([]roles.Role, error) {
 	rolesList := rolesSet.List()
 
 	output := make([]roles.Role, len(rolesList))
-	var roleNameRaw, scopeRaw, projectIDRaw interface{}
+	var roleNameRaw, scopeRaw, projectIDRaw any
 
 	for i := range rolesList {
 		var roleName, scope, projectID string
-		resourceRoleMap := rolesList[i].(map[string]interface{})
+		resourceRoleMap := rolesList[i].(map[string]any)
 
 		if roleNameRaw = resourceRoleMap["role_name"]; roleNameRaw == "" {
 			return nil, errors.New("role_name value isn't provided")
@@ -146,10 +146,10 @@ func convertIAMSetToRoles(rolesSet *schema.Set) ([]roles.Role, error) {
 	return output, nil
 }
 
-func convertIAMRolesToSet(roles []roles.Role) []interface{} {
-	result := make([]interface{}, 0, len(roles))
+func convertIAMRolesToSet(roles []roles.Role) []any {
+	result := make([]any, 0, len(roles))
 	for _, role := range roles {
-		result = append(result, map[string]interface{}{
+		result = append(result, map[string]any{
 			"role_name":  role.RoleName,
 			"scope":      role.Scope,
 			"project_id": role.ProjectID,
@@ -159,20 +159,20 @@ func convertIAMRolesToSet(roles []roles.Role) []interface{} {
 	return result
 }
 
-func convertIAMFederationToList(federation *users.Federation) []interface{} {
+func convertIAMFederationToList(federation *users.Federation) []any {
 	if federation == nil {
 		return nil
 	}
 
-	return []interface{}{
-		map[string]interface{}{
+	return []any{
+		map[string]any{
 			"id":          federation.ID,
 			"external_id": federation.ExternalID,
 		},
 	}
 }
 
-func checkDeprecatedRoles(ctx context.Context, meta interface{}, assignedRoles []roles.Role) diag.Diagnostics {
+func checkDeprecatedRoles(ctx context.Context, meta any, assignedRoles []roles.Role) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	if len(assignedRoles) == 0 {
@@ -197,7 +197,7 @@ func checkDeprecatedRoles(ctx context.Context, meta interface{}, assignedRoles [
 	return diags
 }
 
-func getDeprecatedRoles(ctx context.Context, meta interface{}) (map[string]bool, diag.Diagnostics) {
+func getDeprecatedRoles(ctx context.Context, meta any) (map[string]bool, diag.Diagnostics) {
 	deprecatedRolesCacheOnce.Do(func() {
 		iamClient, diagErr := getIAMClient(meta)
 		if diagErr != nil {

--- a/selectel/internal/hashcode/hashcode_test.go
+++ b/selectel/internal/hashcode/hashcode_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestString(t *testing.T) {
 	v := "hello, world"
 	expected := String(v)
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		actual := String(v)
 		if actual != expected {
 			t.Fatalf("bad: %#v\n\t%#v", actual, expected)

--- a/selectel/internal/reflect/map.go
+++ b/selectel/internal/reflect/map.go
@@ -2,7 +2,7 @@ package reflect
 
 import "reflect"
 
-func IsSetContainsSubset(subset, set map[string]interface{}) bool {
+func IsSetContainsSubset(subset, set map[string]any) bool {
 	for k, subsetValue := range subset {
 		setValue, ok := set[k]
 		if !ok {
@@ -10,14 +10,14 @@ func IsSetContainsSubset(subset, set map[string]interface{}) bool {
 		}
 
 		switch subsetValueTyped := subsetValue.(type) {
-		case map[string]interface{}:
-			setValueTyped, ok := setValue.(map[string]interface{})
+		case map[string]any:
+			setValueTyped, ok := setValue.(map[string]any)
 			if !ok || !IsSetContainsSubset(subsetValueTyped, setValueTyped) {
 				return false
 			}
 
-		case []interface{}:
-			setValueTyped, ok := setValue.([]interface{})
+		case []any:
+			setValueTyped, ok := setValue.([]any)
 			if !ok {
 				return false
 			}
@@ -35,20 +35,20 @@ func IsSetContainsSubset(subset, set map[string]interface{}) bool {
 	return true
 }
 
-func isArrayContainsSubarray(subarray, array []interface{}) bool {
+func isArrayContainsSubarray(subarray, array []any) bool {
 	for _, subarrayElement := range subarray {
 		found := false
 		for _, arrayElement := range array {
 			switch subarrayElementTyped := subarrayElement.(type) {
-			case map[string]interface{}:
-				arrayElementTyped, ok := arrayElement.(map[string]interface{})
+			case map[string]any:
+				arrayElementTyped, ok := arrayElement.(map[string]any)
 				if ok && IsSetContainsSubset(subarrayElementTyped, arrayElementTyped) {
 					found = true
 					break
 				}
 
-			case []interface{}:
-				arrayElementTyped, ok := arrayElement.([]interface{})
+			case []any:
+				arrayElementTyped, ok := arrayElement.([]any)
 				if ok && isArrayContainsSubarray(subarrayElementTyped, arrayElementTyped) {
 					found = true
 					break

--- a/selectel/internal/reflect/map_test.go
+++ b/selectel/internal/reflect/map_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func jsonToMap(t *testing.T, s string) map[string]interface{} {
-	var m map[string]interface{}
+func jsonToMap(t *testing.T, s string) map[string]any {
+	var m map[string]any
 	err := json.Unmarshal([]byte(s), &m)
 	require.NoError(t, err)
 

--- a/selectel/messages.go
+++ b/selectel/messages.go
@@ -2,7 +2,7 @@ package selectel
 
 import "fmt"
 
-func msgCreate(object string, options interface{}) string {
+func msgCreate(object string, options any) string {
 	return fmt.Sprintf("[DEBUG] Creating %s with options: %+v", object, options)
 }
 
@@ -10,7 +10,7 @@ func msgGet(object, id string) string {
 	return fmt.Sprintf("[DEBUG] Getting %s '%s'", object, id)
 }
 
-func msgUpdate(object, id string, options interface{}) string {
+func msgUpdate(object, id string, options any) string {
 	return fmt.Sprintf("[DEBUG] Updating %s '%s' with options: %+v", object, id, options)
 }
 

--- a/selectel/mks.go
+++ b/selectel/mks.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -93,7 +94,7 @@ func waitForMKSNodegroupV1ActiveState(
 func mksNodegroupV1StateRefreshFunc(
 	ctx context.Context, client *v1.ServiceClient, clusterID, nodegroupID string,
 ) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		ng, _, err := nodegroup.Get(ctx, client, clusterID, nodegroupID)
 		if err != nil {
 			return nil, "", err
@@ -106,7 +107,7 @@ func mksNodegroupV1StateRefreshFunc(
 func mksClusterV1StateRefreshFunc(
 	ctx context.Context, client *v1.ServiceClient, clusterID string,
 ) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		c, _, err := cluster.Get(ctx, client, clusterID)
 		if err != nil {
 			return nil, "", err
@@ -486,10 +487,10 @@ func mksNodegroupV1ParseID(id string) (string, string, error) {
 	return parts[0], parts[1], nil
 }
 
-func flattenMKSNodegroupV1Nodes(views []*node.View) []map[string]interface{} {
-	nodes := make([]map[string]interface{}, len(views))
+func flattenMKSNodegroupV1Nodes(views []*node.View) []map[string]any {
+	nodes := make([]map[string]any, len(views))
 	for i, view := range views {
-		nodes[i] = make(map[string]interface{})
+		nodes[i] = make(map[string]any)
 		nodes[i]["id"] = view.ID
 		nodes[i]["ip"] = view.IP
 		nodes[i]["hostname"] = view.Hostname
@@ -498,10 +499,10 @@ func flattenMKSNodegroupV1Nodes(views []*node.View) []map[string]interface{} {
 	return nodes
 }
 
-func flattenMKSNodegroupV1Taints(views []nodegroup.Taint) []interface{} {
-	taints := make([]interface{}, len(views))
+func flattenMKSNodegroupV1Taints(views []nodegroup.Taint) []any {
+	taints := make([]any, len(views))
 	for i, view := range views {
-		taints[i] = map[string]interface{}{
+		taints[i] = map[string]any{
 			"key":    view.Key,
 			"value":  view.Value,
 			"effect": string(view.Effect),
@@ -511,10 +512,10 @@ func flattenMKSNodegroupV1Taints(views []nodegroup.Taint) []interface{} {
 	return taints
 }
 
-func flattenFeatureGates(views []*kubeoptions.View) []interface{} {
-	availableFeatureGates := make([]interface{}, len(views))
+func flattenFeatureGates(views []*kubeoptions.View) []any {
+	availableFeatureGates := make([]any, len(views))
 	for i, fg := range views {
-		availableFeatureGates[i] = map[string]interface{}{
+		availableFeatureGates[i] = map[string]any{
 			"kube_version": fg.KubeVersion,
 			"names":        fg.Names,
 		}
@@ -523,9 +524,9 @@ func flattenFeatureGates(views []*kubeoptions.View) []interface{} {
 	return availableFeatureGates
 }
 
-func flattenFeatureGatesFromSlice(kubeVersion string, featureGates []string) []interface{} {
-	availableFeatureGates := make([]interface{}, 1)
-	availableFeatureGates[0] = map[string]interface{}{
+func flattenFeatureGatesFromSlice(kubeVersion string, featureGates []string) []any {
+	availableFeatureGates := make([]any, 1)
+	availableFeatureGates[0] = map[string]any{
 		"kube_version": kubeVersion,
 		"names":        featureGates,
 	}
@@ -533,10 +534,10 @@ func flattenFeatureGatesFromSlice(kubeVersion string, featureGates []string) []i
 	return availableFeatureGates
 }
 
-func flattenAdmissionControllers(views []*kubeoptions.View) []interface{} {
-	availableAdmissionControllers := make([]interface{}, len(views))
+func flattenAdmissionControllers(views []*kubeoptions.View) []any {
+	availableAdmissionControllers := make([]any, len(views))
 	for i, ac := range views {
-		availableAdmissionControllers[i] = map[string]interface{}{
+		availableAdmissionControllers[i] = map[string]any{
 			"kube_version": ac.KubeVersion,
 			"names":        ac.Names,
 		}
@@ -545,9 +546,9 @@ func flattenAdmissionControllers(views []*kubeoptions.View) []interface{} {
 	return availableAdmissionControllers
 }
 
-func flattenAdmissionControllersFromSlice(kubeVersion string, admissionControllers []string) []interface{} {
-	availableAdmissionControllers := make([]interface{}, 1)
-	availableAdmissionControllers[0] = map[string]interface{}{
+func flattenAdmissionControllersFromSlice(kubeVersion string, admissionControllers []string) []any {
+	availableAdmissionControllers := make([]any, 1)
+	availableAdmissionControllers[0] = map[string]any{
 		"kube_version": kubeVersion,
 		"names":        admissionControllers,
 	}
@@ -555,8 +556,8 @@ func flattenAdmissionControllersFromSlice(kubeVersion string, admissionControlle
 	return availableAdmissionControllers
 }
 
-func flattenMKSClusterV1OIDC(view *cluster.GetView) []interface{} {
-	return []interface{}{map[string]interface{}{
+func flattenMKSClusterV1OIDC(view *cluster.GetView) []any {
+	return []any{map[string]any{
 		"enabled":        view.KubernetesOptions.OIDC.Enabled,
 		"provider_name":  view.KubernetesOptions.OIDC.ProviderName,
 		"issuer_url":     view.KubernetesOptions.OIDC.IssuerURL,
@@ -588,11 +589,11 @@ func flattenMKSClusterV1CNICiliumSettings(view *cluster.GetView) []any {
 	}}
 }
 
-func expandMKSNodegroupV1Taints(taints []interface{}) []nodegroup.Taint {
+func expandMKSNodegroupV1Taints(taints []any) []nodegroup.Taint {
 	result := make([]nodegroup.Taint, len(taints))
 	for i := range taints {
 		taint := nodegroup.Taint{}
-		obj := taints[i].(map[string]interface{})
+		obj := taints[i].(map[string]any)
 		taint.Key = obj["key"].(string)
 		taint.Value = obj["value"].(string)
 
@@ -611,7 +612,7 @@ func expandMKSNodegroupV1Taints(taints []interface{}) []nodegroup.Taint {
 	return result
 }
 
-func expandMKSNodegroupV1Labels(labels map[string]interface{}) map[string]string {
+func expandMKSNodegroupV1Labels(labels map[string]any) map[string]string {
 	result := make(map[string]string)
 
 	for k, v := range labels {
@@ -628,7 +629,7 @@ func expandMKSClusterV1OIDC(d *schema.ResourceData) cluster.OIDC {
 	}
 
 	// Resource always comes with only first element because of validation
-	resourceMap := nestedResource[0].(map[string]interface{})
+	resourceMap := nestedResource[0].(map[string]any)
 
 	return cluster.OIDC{
 		Enabled:       resourceMap["enabled"].(bool),
@@ -663,11 +664,9 @@ func expandAndValidateMKSClusterV1OIDC(d *schema.ResourceData) (cluster.OIDC, er
 	oidc := expandMKSClusterV1OIDC(d)
 
 	if oidc.Enabled {
-		for _, s := range []string{oidc.ProviderName, oidc.IssuerURL, oidc.ClientID} {
-			if s == "" {
-				return cluster.OIDC{}, errors.New("\"provider_name\", \"issuer_url\" and \"client_id\" " +
-					"should not be empty in case of enabled oidc")
-			}
+		if slices.Contains([]string{oidc.ProviderName, oidc.IssuerURL, oidc.ClientID}, "") {
+			return cluster.OIDC{}, errors.New("\"provider_name\", \"issuer_url\" and \"client_id\" " +
+				"should not be empty in case of enabled oidc")
 		}
 	} else {
 		for _, s := range []string{oidc.ProviderName, oidc.IssuerURL, oidc.ClientID, oidc.UsernameClaim, oidc.GroupsClaim} {
@@ -699,7 +698,7 @@ func expandAndValidateMKSClusterV1CNICiliumSettings(
 	return cniCiliumSettings, nil
 }
 
-func getMKSClient(d *schema.ResourceData, meta interface{}) (*v1.ServiceClient, diag.Diagnostics) {
+func getMKSClient(d *schema.ResourceData, meta any) (*v1.ServiceClient, diag.Diagnostics) {
 	config := meta.(*Config)
 	projectID := d.Get("project_id").(string)
 	region := d.Get("region").(string)
@@ -723,7 +722,7 @@ func getMKSClient(d *schema.ResourceData, meta interface{}) (*v1.ServiceClient, 
 	return mksClient, nil
 }
 
-func interfaceListChecksum(items []interface{}) (string, error) {
+func interfaceListChecksum(items []any) (string, error) {
 	flatItems := make([]string, len(items))
 	for i, item := range items {
 		flatItems[i] = fmt.Sprintf("%v", item)

--- a/selectel/mks_test.go
+++ b/selectel/mks_test.go
@@ -446,7 +446,7 @@ func TestFlattenMKSNodegroupV1Nodes(t *testing.T) {
 		},
 	}
 
-	expected := []map[string]interface{}{
+	expected := []map[string]any{
 		{
 			"id":       "94838b31-9ae0-4a23-88ad-256e4f13d345",
 			"ip":       "198.51.100.101",
@@ -482,18 +482,18 @@ func TestFlattenMKSNodegroupV1Taints(t *testing.T) {
 		},
 	}
 
-	expected := []interface{}{
-		map[string]interface{}{
+	expected := []any{
+		map[string]any{
 			"key":    "test-key-0",
 			"value":  "test-value-0",
 			"effect": "NoSchedule",
 		},
-		map[string]interface{}{
+		map[string]any{
 			"key":    "test-key-1",
 			"value":  "test-value-1",
 			"effect": "NoExecute",
 		},
-		map[string]interface{}{
+		map[string]any{
 			"key":    "test-key-2",
 			"value":  "test-value-2",
 			"effect": "PreferNoSchedule",
@@ -505,7 +505,7 @@ func TestFlattenMKSNodegroupV1Taints(t *testing.T) {
 }
 
 func TestExpandMKSNodegroupV1Labels(t *testing.T) {
-	labels := map[string]interface{}{
+	labels := map[string]any{
 		"label-key0": "label-value0",
 		"label-key1": "label-value1",
 		"label-key2": "label-value2",
@@ -521,18 +521,18 @@ func TestExpandMKSNodegroupV1Labels(t *testing.T) {
 }
 
 func TestExpandMKSNodegroupV1Taints(t *testing.T) {
-	taints := []interface{}{
-		map[string]interface{}{
+	taints := []any{
+		map[string]any{
 			"key":    "test-key-0",
 			"value":  "test-value-0",
 			"effect": "NoSchedule",
 		},
-		map[string]interface{}{
+		map[string]any{
 			"key":    "test-key-1",
 			"value":  "test-value-1",
 			"effect": "NoExecute",
 		},
-		map[string]interface{}{
+		map[string]any{
 			"key":    "test-key-2",
 			"value":  "test-value-2",
 			"effect": "PreferNoSchedule",

--- a/selectel/networking.go
+++ b/selectel/networking.go
@@ -35,11 +35,11 @@ func getIPVersionFromPrefixLength(prefixLength int) string {
 
 // subnetsMapsFromStructs converts the provided subnets.Subnet to
 // the slice of maps correspondingly to the resource's schema.
-func subnetsMapsFromStructs(subnetsStructs []subnets.Subnet) []map[string]interface{} {
-	associatedSubnets := make([]map[string]interface{}, len(subnetsStructs))
+func subnetsMapsFromStructs(subnetsStructs []subnets.Subnet) []map[string]any {
+	associatedSubnets := make([]map[string]any, len(subnetsStructs))
 
 	for i, subnet := range subnetsStructs {
-		associatedSubnets[i] = map[string]interface{}{
+		associatedSubnets[i] = map[string]any{
 			"network_id":      subnet.NetworkID,
 			"subnet_id":       subnet.SubnetID,
 			"region":          subnet.Region,

--- a/selectel/networking_test.go
+++ b/selectel/networking_test.go
@@ -62,7 +62,7 @@ func TestSubnetsMapsFromStructs(t *testing.T) {
 			VTEPIPAddress: "10.10.0.201",
 		},
 	}
-	expectedSubnetsMaps := []map[string]interface{}{
+	expectedSubnetsMaps := []map[string]any{
 		{
 			"network_id":      "912bd5d0-cb11-4a7f-af7c-ea84c8e7db2e",
 			"subnet_id":       "4912cca9-cad2-49c1-a69a-929cd4cf9559",

--- a/selectel/private_dns.go
+++ b/selectel/private_dns.go
@@ -16,7 +16,7 @@ const (
 	privateDNSDefaultRetry        = 5
 )
 
-func getPrivateDNSClient(d *schema.ResourceData, meta interface{}) (*privatedns.PrivateDNSClient, diag.Diagnostics) {
+func getPrivateDNSClient(d *schema.ResourceData, meta any) (*privatedns.PrivateDNSClient, diag.Diagnostics) {
 	config := meta.(*Config)
 	projectID := d.Get("project_id").(string)
 	region := d.Get("region").(string)

--- a/selectel/project.go
+++ b/selectel/project.go
@@ -28,11 +28,11 @@ func resourceVPCProjectV2QuotasOptsFromSet(
 
 	// Iterate over each billing resource quotas map.
 	for _, resourceQuotasData := range quotaSet.List() {
-		var resourceNameRaw, resourceQuotasRaw interface{}
+		var resourceNameRaw, resourceQuotasRaw any
 		var ok bool
 
 		// Cast type of the current resource quotas map and check provided values.
-		resourceQuotasMap := resourceQuotasData.(map[string]interface{})
+		resourceQuotasMap := resourceQuotasData.(map[string]any)
 		if resourceNameRaw, ok = resourceQuotasMap["resource_name"]; !ok {
 			return nil, errors.New("resource_name value isn't provided")
 		}
@@ -52,7 +52,7 @@ func resourceVPCProjectV2QuotasOptsFromSet(
 				resourceQuotasEntityZone   string
 				resourceQuotasEntityValue  int
 			)
-			resourceQuotasEntity := resourceQuotasEntityRaw.(map[string]interface{})
+			resourceQuotasEntity := resourceQuotasEntityRaw.(map[string]any)
 			if region, ok := resourceQuotasEntity["region"]; ok {
 				resourceQuotasEntityRegion = region.(string)
 			}
@@ -109,7 +109,7 @@ func resourceVPCProjectV2QuotasToSet(quotasStructures []resellQuotas.Quota) *sch
 			F: resourceQuotasHashSetFunc(),
 		}
 		for _, resourceQuotasEntity := range quota.ResourceQuotasEntities {
-			resourceQuotasSet.Add(map[string]interface{}{
+			resourceQuotasSet.Add(map[string]any{
 				"region": resourceQuotasEntity.Region,
 				"zone":   resourceQuotasEntity.Zone,
 				"value":  resourceQuotasEntity.Value,
@@ -118,7 +118,7 @@ func resourceVPCProjectV2QuotasToSet(quotasStructures []resellQuotas.Quota) *sch
 		}
 
 		// Populate single quota element.
-		quotaSet.Add(map[string]interface{}{
+		quotaSet.Add(map[string]any{
 			"resource_name":   quota.Name,
 			"resource_quotas": resourceQuotasSet,
 		})
@@ -130,7 +130,7 @@ func resourceVPCProjectV2QuotasToSet(quotasStructures []resellQuotas.Quota) *sch
 // resourceProjectV2UpdateThemeOptsFromMap converts the provided themeOptsMap to
 // the *project.ThemeUpdateOpts.
 // It can be used to make requests with project theme parameters.
-func resourceProjectV2UpdateThemeOptsFromMap(themeOptsMap map[string]interface{}) *projects.ThemeUpdateOpts {
+func resourceProjectV2UpdateThemeOptsFromMap(themeOptsMap map[string]any) *projects.ThemeUpdateOpts {
 	themeUpdateOpts := &projects.ThemeUpdateOpts{}
 
 	var themeColor, themeLogo string
@@ -184,9 +184,9 @@ func resourceQuotasHashSetFunc() schema.SchemaSetFunc {
 }
 
 // hashResourceQuotas is a hash function to use with the "resource_quotas" set.
-func hashResourceQuotas(v interface{}) int {
+func hashResourceQuotas(v any) int {
 	var buf bytes.Buffer
-	m := v.(map[string]interface{})
+	m := v.(map[string]any)
 	if m["region"] != "" {
 		buf.WriteString(fmt.Sprintf("%s-", m["region"].(string)))
 	}

--- a/selectel/provider.go
+++ b/selectel/provider.go
@@ -204,7 +204,7 @@ func Provider(providerVersion string) *schema.Provider {
 		},
 	}
 
-	p.ConfigureContextFunc = func(_ context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
+	p.ConfigureContextFunc = func(_ context.Context, d *schema.ResourceData) (any, diag.Diagnostics) {
 		userAgent := p.UserAgent(version.ProviderName, providerVersion)
 		client, diagErr := configureProvider(d, userAgent)
 		if diagErr != nil {
@@ -217,7 +217,7 @@ func Provider(providerVersion string) *schema.Provider {
 	return p
 }
 
-func configureProvider(d *schema.ResourceData, userAgent string) (interface{}, diag.Diagnostics) {
+func configureProvider(d *schema.ResourceData, userAgent string) (any, diag.Diagnostics) {
 	config, diagError := getConfig(d, userAgent)
 	if diagError != nil {
 		return nil, diagError

--- a/selectel/regions_test.go
+++ b/selectel/regions_test.go
@@ -15,7 +15,7 @@ func TestExpandVPCV2Regions(t *testing.T) {
 	r := resourceVPCKeypairV2()
 	d := r.TestResourceData()
 	d.SetId("1")
-	regions := []interface{}{"ru-1", "ru-2", "ru-3"}
+	regions := []any{"ru-1", "ru-2", "ru-3"}
 	d.Set("regions", regions)
 
 	expected := []string{"ru-1", "ru-2", "ru-3"}

--- a/selectel/resource_selectel_cloudbackup_plan_v2.go
+++ b/selectel/resource_selectel_cloudbackup_plan_v2.go
@@ -101,7 +101,7 @@ func resourceCloudBackupPlanV2() *schema.Resource {
 	}
 }
 
-func resourceCloudBackupPlanV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCloudBackupPlanV2Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getScheduledBackupClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -147,24 +147,24 @@ func resourceCloudBackupPlanV2Create(ctx context.Context, d *schema.ResourceData
 func readCloudBackupPlanV2Resource(d *schema.ResourceData) ([]*cloudbackup.PlanResource, diag.Diagnostics) {
 	rRaw := d.Get("resources")
 
-	rListRaw, ok := rRaw.([]interface{})
+	rListRaw, ok := rRaw.([]any)
 	if !ok {
 		return nil, diag.Errorf("resources field has unexpected type")
 	}
 
-	resourcesRawMap, ok := rListRaw[0].(map[string]interface{})
+	resourcesRawMap, ok := rListRaw[0].(map[string]any)
 	if !ok {
 		return nil, diag.Errorf("resources list has unexpected type")
 	}
 
-	resourcesRaw, ok := resourcesRawMap["resource"].([]interface{})
+	resourcesRaw, ok := resourcesRawMap["resource"].([]any)
 	if !ok {
 		return nil, diag.Errorf("resources.resource field has unexpected type")
 	}
 
 	resources := make([]*cloudbackup.PlanResource, 0, len(resourcesRaw))
 	for idx, r := range resourcesRaw {
-		item, ok := r.(map[string]interface{})
+		item, ok := r.(map[string]any)
 		if !ok {
 			return nil, diag.Errorf("resources[%d] has unexpected type", idx)
 		}
@@ -194,7 +194,7 @@ func readCloudBackupPlanV2Resource(d *schema.ResourceData) ([]*cloudbackup.PlanR
 	return resources, nil
 }
 
-func resourceCloudBackupPlanV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCloudBackupPlanV2Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getScheduledBackupClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -215,23 +215,23 @@ func resourceCloudBackupPlanV2Read(ctx context.Context, d *schema.ResourceData, 
 	d.Set("schedule_type", res.ScheduleType)
 	d.Set("schedule_pattern", res.SchedulePattern)
 
-	resources := make([]map[string]interface{}, 0, len(res.Resources))
+	resources := make([]map[string]any, 0, len(res.Resources))
 	for _, r := range res.Resources {
-		resources = append(resources, map[string]interface{}{
+		resources = append(resources, map[string]any{
 			"id":   r.ID,
 			"name": r.Name,
 			"type": r.Type,
 		})
 	}
 
-	d.Set("resources", []interface{}{map[string]interface{}{
+	d.Set("resources", []any{map[string]any{
 		"resource": resources,
 	}})
 
 	return nil
 }
 
-func resourceCloudBackupPlanV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCloudBackupPlanV2Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getScheduledBackupClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -280,7 +280,7 @@ func resourceCloudBackupPlanV2Update(ctx context.Context, d *schema.ResourceData
 	return resourceCloudBackupPlanV2Read(ctx, d, meta)
 }
 
-func resourceCloudBackupPlanV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCloudBackupPlanV2Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getScheduledBackupClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -303,7 +303,7 @@ func resourceCloudBackupPlanV2Delete(ctx context.Context, d *schema.ResourceData
 	return nil
 }
 
-func resourceCloudBackupPlanV2ImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCloudBackupPlanV2ImportState(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if config.ProjectID == "" {
 		return nil, errors.New("project_id must be set for the resource import")

--- a/selectel/resource_selectel_craas_registry_v1.go
+++ b/selectel/resource_selectel_craas_registry_v1.go
@@ -50,7 +50,7 @@ func resourceCRaaSRegistryV1() *schema.Resource {
 	}
 }
 
-func resourceCRaaSRegistryV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCRaaSRegistryV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	craasClient, diagErr := getCRaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -76,7 +76,7 @@ func resourceCRaaSRegistryV1Create(ctx context.Context, d *schema.ResourceData, 
 	return resourceCRaaSRegistryV1Read(ctx, d, meta)
 }
 
-func resourceCRaaSRegistryV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCRaaSRegistryV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	craasClient, diagErr := getCRaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -107,7 +107,7 @@ func resourceCRaaSRegistryV1Read(ctx context.Context, d *schema.ResourceData, me
 	return nil
 }
 
-func resourceCRaaSRegistryV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCRaaSRegistryV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	craasClient, diagErr := getCRaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -123,7 +123,7 @@ func resourceCRaaSRegistryV1Delete(ctx context.Context, d *schema.ResourceData, 
 		Pending: []string{strconv.Itoa(http.StatusOK)},
 		Target:  []string{strconv.Itoa(http.StatusNotFound)},
 		Timeout: d.Timeout(schema.TimeoutDelete),
-		Refresh: func() (result interface{}, state string, err error) {
+		Refresh: func() (result any, state string, err error) {
 			result, response, err := registry.Get(ctx, craasClient, d.Id())
 			if err != nil {
 				if response != nil {
@@ -148,7 +148,7 @@ func resourceCRaaSRegistryV1Delete(ctx context.Context, d *schema.ResourceData, 
 	return nil
 }
 
-func resourceCRaaSRegistryV1ImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCRaaSRegistryV1ImportState(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if config.ProjectID == "" {
 		return nil, errors.New("INFRA_PROJECT_ID must be set for the CRaaS registry resource import")

--- a/selectel/resource_selectel_craas_token_v1.go
+++ b/selectel/resource_selectel_craas_token_v1.go
@@ -48,7 +48,7 @@ func resourceCRaaSTokenV1() *schema.Resource {
 	}
 }
 
-func resourceCRaaSTokenV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCRaaSTokenV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	craasClient, diagErr := getCRaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -72,7 +72,7 @@ func resourceCRaaSTokenV1Create(ctx context.Context, d *schema.ResourceData, met
 	return resourceCRaaSTokenV1Read(ctx, d, meta)
 }
 
-func resourceCRaaSTokenV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCRaaSTokenV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	craasClient, diagErr := getCRaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -97,7 +97,7 @@ func resourceCRaaSTokenV1Read(ctx context.Context, d *schema.ResourceData, meta 
 	return nil
 }
 
-func resourceCRaaSTokenV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCRaaSTokenV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	craasClient, diagErr := getCRaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr

--- a/selectel/resource_selectel_craas_token_v2.go
+++ b/selectel/resource_selectel_craas_token_v2.go
@@ -72,7 +72,7 @@ func resourceCRaaSTokenV2() *schema.Resource {
 	}
 }
 
-func resourceCRaaSTokenV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCRaaSTokenV2Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	craasClient, diagErr := getCRaaSClientV2(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -82,7 +82,7 @@ func resourceCRaaSTokenV2Create(ctx context.Context, d *schema.ResourceData, met
 	modeRW := d.Get("mode_rw").(bool)
 	allRegistries := d.Get("all_registries").(bool)
 	isSet := d.Get("is_set").(bool)
-	registries := d.Get("registry_ids").([]interface{})
+	registries := d.Get("registry_ids").([]any)
 	registriesIDs := make([]string, len(registries))
 	for i, v := range registries {
 		registriesIDs[i] = v.(string)
@@ -120,7 +120,7 @@ func resourceCRaaSTokenV2Create(ctx context.Context, d *schema.ResourceData, met
 	return resourceCRaaSTokenV2Read(ctx, d, meta)
 }
 
-func resourceCRaaSTokenV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCRaaSTokenV2Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	craasClient, diagErr := getCRaaSClientV2(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -151,7 +151,7 @@ func resourceCRaaSTokenV2Read(ctx context.Context, d *schema.ResourceData, meta 
 	return nil
 }
 
-func resourceCRaaSTokenV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCRaaSTokenV2Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	craasClient, diagErr := getCRaaSClientV2(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -170,7 +170,7 @@ func resourceCRaaSTokenV2Delete(ctx context.Context, d *schema.ResourceData, met
 	return nil
 }
 
-func resourceCRaaSTokenV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCRaaSTokenV2Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	craasClient, diagErr := getCRaaSClientV2(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -181,7 +181,7 @@ func resourceCRaaSTokenV2Update(ctx context.Context, d *schema.ResourceData, met
 	)
 	name := d.Get("name").(string)
 	sc.AllRegistries = d.Get("all_registries").(bool)
-	registries := d.Get("registry_ids").([]interface{})
+	registries := d.Get("registry_ids").([]any)
 	sc.RegistryIDs = make([]string, len(registries))
 	for i, v := range registries {
 		sc.RegistryIDs[i] = v.(string)

--- a/selectel/resource_selectel_dbaas_database_v1.go
+++ b/selectel/resource_selectel_dbaas_database_v1.go
@@ -34,7 +34,7 @@ func resourceDBaaSDatabaseV1() *schema.Resource {
 	}
 }
 
-func resourceDBaaSDatabaseV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSDatabaseV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -66,7 +66,7 @@ func resourceDBaaSDatabaseV1Create(ctx context.Context, d *schema.ResourceData, 
 	return resourceDBaaSDatabaseV1Read(ctx, d, meta)
 }
 
-func resourceDBaaSDatabaseV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSDatabaseV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -93,7 +93,7 @@ func resourceDBaaSDatabaseV1Read(ctx context.Context, d *schema.ResourceData, me
 	return nil
 }
 
-func resourceDBaaSDatabaseV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSDatabaseV1Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -121,7 +121,7 @@ func resourceDBaaSDatabaseV1Update(ctx context.Context, d *schema.ResourceData, 
 	return resourceDBaaSDatabaseV1Read(ctx, d, meta)
 }
 
-func resourceDBaaSDatabaseV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSDatabaseV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -151,7 +151,7 @@ func resourceDBaaSDatabaseV1Delete(ctx context.Context, d *schema.ResourceData, 
 	return nil
 }
 
-func resourceDBaaSDatabaseV1ImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceDBaaSDatabaseV1ImportState(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if config.ProjectID == "" {
 		return nil, errors.New("INFRA_PROJECT_ID must be set for the resource import")

--- a/selectel/resource_selectel_dbaas_datastore_v1.go
+++ b/selectel/resource_selectel_dbaas_datastore_v1.go
@@ -38,7 +38,7 @@ func resourceDBaaSDatastoreV1() *schema.Resource {
 	}
 }
 
-func resourceDBaaSDatastoreV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSDatastoreV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -77,7 +77,7 @@ func resourceDBaaSDatastoreV1Create(ctx context.Context, d *schema.ResourceData,
 		NodeCount:   d.Get("node_count").(int),
 		Pooler:      pooler,
 		Restore:     restore,
-		Config:      d.Get("config").(map[string]interface{}),
+		Config:      d.Get("config").(map[string]any),
 		FloatingIPs: floatingIPsSchema,
 	}
 
@@ -138,7 +138,7 @@ func resourceDBaaSDatastoreV1Create(ctx context.Context, d *schema.ResourceData,
 	return resourceDBaaSDatastoreV1Read(ctx, d, meta)
 }
 
-func resourceDBaaSDatastoreV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSDatastoreV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -188,7 +188,7 @@ func resourceDBaaSDatastoreV1Read(ctx context.Context, d *schema.ResourceData, m
 }
 
 //nolint:gocognit
-func resourceDBaaSDatastoreV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSDatastoreV1Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -257,7 +257,7 @@ func resourceDBaaSDatastoreV1Update(ctx context.Context, d *schema.ResourceData,
 	return resourceDBaaSDatastoreV1Read(ctx, d, meta)
 }
 
-func resourceDBaaSDatastoreV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSDatastoreV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -287,7 +287,7 @@ func resourceDBaaSDatastoreV1Delete(ctx context.Context, d *schema.ResourceData,
 	return nil
 }
 
-func resourceDBaaSDatastoreV1ImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceDBaaSDatastoreV1ImportState(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if config.ProjectID == "" {
 		return nil, errors.New("INFRA_PROJECT_ID must be set for the resource import")

--- a/selectel/resource_selectel_dbaas_extension_v1.go
+++ b/selectel/resource_selectel_dbaas_extension_v1.go
@@ -33,7 +33,7 @@ func resourceDBaaSExtensionV1() *schema.Resource {
 	}
 }
 
-func resourceDBaaSExtensionV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSExtensionV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -63,7 +63,7 @@ func resourceDBaaSExtensionV1Create(ctx context.Context, d *schema.ResourceData,
 	return resourceDBaaSExtensionV1Read(ctx, d, meta)
 }
 
-func resourceDBaaSExtensionV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSExtensionV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -82,7 +82,7 @@ func resourceDBaaSExtensionV1Read(ctx context.Context, d *schema.ResourceData, m
 	return nil
 }
 
-func resourceDBaaSExtensionV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSExtensionV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -112,7 +112,7 @@ func resourceDBaaSExtensionV1Delete(ctx context.Context, d *schema.ResourceData,
 	return nil
 }
 
-func resourceDBaaSExtensionV1ImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceDBaaSExtensionV1ImportState(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if config.ProjectID == "" {
 		return nil, errors.New("INFRA_PROJECT_ID must be set for the resource import")

--- a/selectel/resource_selectel_dbaas_firewall_v1.go
+++ b/selectel/resource_selectel_dbaas_firewall_v1.go
@@ -31,7 +31,7 @@ func resourceDBaaSFirewallV1() *schema.Resource {
 	}
 }
 
-func resourceDBaaSFirewallV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSFirewallV1Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	datastoreID := d.Get("datastore_id").(string)
 
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
@@ -39,7 +39,7 @@ func resourceDBaaSFirewallV1Update(ctx context.Context, d *schema.ResourceData, 
 		return diagErr
 	}
 
-	rawIPs := d.Get("ips").([]interface{})
+	rawIPs := d.Get("ips").([]any)
 	firewallOpts, err := resourceDBaaSDatastoreV1FirewallOptsFromList(rawIPs)
 	if err != nil {
 		return diag.FromErr(errParseDatastoreV1Firewall(err))
@@ -61,7 +61,7 @@ func resourceDBaaSFirewallV1Update(ctx context.Context, d *schema.ResourceData, 
 	return resourceDBaaSFirewallV1Read(ctx, d, meta)
 }
 
-func resourceDBaaSFirewallV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSFirewallV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	datastoreID := d.Get("datastore_id").(string)
 
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
@@ -84,7 +84,7 @@ func resourceDBaaSFirewallV1Read(ctx context.Context, d *schema.ResourceData, me
 	return nil
 }
 
-func resourceDBaaSFirewallV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSFirewallV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	datastoreID := d.Get("datastore_id").(string)
 
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
@@ -110,7 +110,7 @@ func resourceDBaaSFirewallV1Delete(ctx context.Context, d *schema.ResourceData, 
 	return nil
 }
 
-func resourceDBaaSFirewallV1ImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceDBaaSFirewallV1ImportState(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if config.ProjectID == "" {
 		return nil, errors.New("INFRA_PROJECT_ID must be set for the resource import")
@@ -134,14 +134,14 @@ func resourceDBaaSDatastoreV1FirewallOptsFromSet(firewallSet *schema.Set) (dbaas
 		return getEmptyFirewallOpts(), nil
 	}
 
-	var resourceIPsRaw interface{}
+	var resourceIPsRaw any
 	var ok bool
 
-	resourceFirewallRaw := firewallSet.List()[0].(map[string]interface{})
+	resourceFirewallRaw := firewallSet.List()[0].(map[string]any)
 	if resourceIPsRaw, ok = resourceFirewallRaw["ips"]; !ok {
 		return dbaas.DatastoreFirewallOpts{}, errors.New("firewall.ips value isn't provided")
 	}
-	resourceIPRaw := resourceIPsRaw.([]interface{})
+	resourceIPRaw := resourceIPsRaw.([]any)
 	var firewall dbaas.DatastoreFirewallOpts
 	for _, ip := range resourceIPRaw {
 		firewall.IPs = append(firewall.IPs, ip.(string))
@@ -150,7 +150,7 @@ func resourceDBaaSDatastoreV1FirewallOptsFromSet(firewallSet *schema.Set) (dbaas
 	return firewall, nil
 }
 
-func resourceDBaaSDatastoreV1FirewallOptsFromList(rawList []interface{}) (dbaas.DatastoreFirewallOpts, error) {
+func resourceDBaaSDatastoreV1FirewallOptsFromList(rawList []any) (dbaas.DatastoreFirewallOpts, error) {
 	if len(rawList) == 0 {
 		return getEmptyFirewallOpts(), nil
 	}

--- a/selectel/resource_selectel_dbaas_grant_v1.go
+++ b/selectel/resource_selectel_dbaas_grant_v1.go
@@ -33,7 +33,7 @@ func resourceDBaaSGrantV1() *schema.Resource {
 	}
 }
 
-func resourceDBaaSGrantV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSGrantV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -63,7 +63,7 @@ func resourceDBaaSGrantV1Create(ctx context.Context, d *schema.ResourceData, met
 	return resourceDBaaSGrantV1Read(ctx, d, meta)
 }
 
-func resourceDBaaSGrantV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSGrantV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -82,7 +82,7 @@ func resourceDBaaSGrantV1Read(ctx context.Context, d *schema.ResourceData, meta 
 	return nil
 }
 
-func resourceDBaaSGrantV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSGrantV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -112,7 +112,7 @@ func resourceDBaaSGrantV1Delete(ctx context.Context, d *schema.ResourceData, met
 	return nil
 }
 
-func resourceDBaaSGrantV1ImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceDBaaSGrantV1ImportState(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if config.ProjectID == "" {
 		return nil, errors.New("INFRA_PROJECT_ID must be set for the resource import")

--- a/selectel/resource_selectel_dbaas_kafka_acl_v1.go
+++ b/selectel/resource_selectel_dbaas_kafka_acl_v1.go
@@ -34,7 +34,7 @@ func resourceDBaaSKafkaACLV1() *schema.Resource {
 	}
 }
 
-func resourceDBaaSACLV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSACLV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -67,7 +67,7 @@ func resourceDBaaSACLV1Create(ctx context.Context, d *schema.ResourceData, meta 
 	return resourceDBaaSACLV1Read(ctx, d, meta)
 }
 
-func resourceDBaaSACLV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSACLV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -90,7 +90,7 @@ func resourceDBaaSACLV1Read(ctx context.Context, d *schema.ResourceData, meta in
 	return nil
 }
 
-func resourceDBaaSACLV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSACLV1Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -119,7 +119,7 @@ func resourceDBaaSACLV1Update(ctx context.Context, d *schema.ResourceData, meta 
 	return resourceDBaaSACLV1Read(ctx, d, meta)
 }
 
-func resourceDBaaSACLV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSACLV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -149,7 +149,7 @@ func resourceDBaaSACLV1Delete(ctx context.Context, d *schema.ResourceData, meta 
 	return nil
 }
 
-func resourceDBaaSACLV1ImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceDBaaSACLV1ImportState(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if config.ProjectID == "" {
 		return nil, errors.New("INFRA_PROJECT_ID must be set for the resource import")

--- a/selectel/resource_selectel_dbaas_kafka_datastore_v1.go
+++ b/selectel/resource_selectel_dbaas_kafka_datastore_v1.go
@@ -34,7 +34,7 @@ func resourceDBaaSKafkaDatastoreV1() *schema.Resource {
 	}
 }
 
-func resourceDBaaSKafkaDatastoreV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSKafkaDatastoreV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -59,7 +59,7 @@ func resourceDBaaSKafkaDatastoreV1Create(ctx context.Context, d *schema.Resource
 		TypeID:    typeID,
 		SubnetID:  d.Get("subnet_id").(string),
 		NodeCount: d.Get("node_count").(int),
-		Config:    d.Get("config").(map[string]interface{}),
+		Config:    d.Get("config").(map[string]any),
 	}
 
 	sgRaw, sgOk := d.GetOk("security_groups")
@@ -109,7 +109,7 @@ func resourceDBaaSKafkaDatastoreV1Create(ctx context.Context, d *schema.Resource
 	return resourceDBaaSKafkaDatastoreV1Read(ctx, d, meta)
 }
 
-func resourceDBaaSKafkaDatastoreV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSKafkaDatastoreV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -156,7 +156,7 @@ func resourceDBaaSKafkaDatastoreV1Read(ctx context.Context, d *schema.ResourceDa
 	return nil
 }
 
-func resourceDBaaSKafkaDatastoreV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSKafkaDatastoreV1Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -201,7 +201,7 @@ func resourceDBaaSKafkaDatastoreV1Update(ctx context.Context, d *schema.Resource
 	return resourceDBaaSKafkaDatastoreV1Read(ctx, d, meta)
 }
 
-func resourceDBaaSKafkaDatastoreV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSKafkaDatastoreV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -231,7 +231,7 @@ func resourceDBaaSKafkaDatastoreV1Delete(ctx context.Context, d *schema.Resource
 	return nil
 }
 
-func resourceDBaaSKafkaDatastoreV1ImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceDBaaSKafkaDatastoreV1ImportState(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if config.ProjectID == "" {
 		return nil, errors.New("INFRA_PROJECT_ID must be set for the resource import")

--- a/selectel/resource_selectel_dbaas_kafka_topic_v1.go
+++ b/selectel/resource_selectel_dbaas_kafka_topic_v1.go
@@ -34,7 +34,7 @@ func resourceDBaaSKafkaTopicV1() *schema.Resource {
 	}
 }
 
-func resourceDBaaSTopicV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSTopicV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -64,7 +64,7 @@ func resourceDBaaSTopicV1Create(ctx context.Context, d *schema.ResourceData, met
 	return resourceDBaaSTopicV1Read(ctx, d, meta)
 }
 
-func resourceDBaaSTopicV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSTopicV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -83,7 +83,7 @@ func resourceDBaaSTopicV1Read(ctx context.Context, d *schema.ResourceData, meta 
 	return nil
 }
 
-func resourceDBaaSTopicV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSTopicV1Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -112,7 +112,7 @@ func resourceDBaaSTopicV1Update(ctx context.Context, d *schema.ResourceData, met
 	return resourceDBaaSTopicV1Read(ctx, d, meta)
 }
 
-func resourceDBaaSTopicV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSTopicV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -142,7 +142,7 @@ func resourceDBaaSTopicV1Delete(ctx context.Context, d *schema.ResourceData, met
 	return nil
 }
 
-func resourceDBaaSTopicV1ImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceDBaaSTopicV1ImportState(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if config.ProjectID == "" {
 		return nil, errors.New("INFRA_PROJECT_ID must be set for the resource import")

--- a/selectel/resource_selectel_dbaas_mysql_database_v1.go
+++ b/selectel/resource_selectel_dbaas_mysql_database_v1.go
@@ -33,7 +33,7 @@ func resourceDBaaSMySQLDatabaseV1() *schema.Resource {
 	}
 }
 
-func resourceDBaaSMySQLDatabaseV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSMySQLDatabaseV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -62,7 +62,7 @@ func resourceDBaaSMySQLDatabaseV1Create(ctx context.Context, d *schema.ResourceD
 	return resourceDBaaSMySQLDatabaseV1Read(ctx, d, meta)
 }
 
-func resourceDBaaSMySQLDatabaseV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSMySQLDatabaseV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -80,7 +80,7 @@ func resourceDBaaSMySQLDatabaseV1Read(ctx context.Context, d *schema.ResourceDat
 	return nil
 }
 
-func resourceDBaaSMySQLDatabaseV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSMySQLDatabaseV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -110,7 +110,7 @@ func resourceDBaaSMySQLDatabaseV1Delete(ctx context.Context, d *schema.ResourceD
 	return nil
 }
 
-func resourceDBaaSMySQLDatabaseV1ImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceDBaaSMySQLDatabaseV1ImportState(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if config.ProjectID == "" {
 		return nil, errors.New("INFRA_PROJECT_ID must be set for the resource import")

--- a/selectel/resource_selectel_dbaas_mysql_datastore_v1.go
+++ b/selectel/resource_selectel_dbaas_mysql_datastore_v1.go
@@ -38,7 +38,7 @@ func resourceDBaaSMySQLDatastoreV1() *schema.Resource {
 	}
 }
 
-func resourceDBaaSMySQLDatastoreV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSMySQLDatastoreV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -75,7 +75,7 @@ func resourceDBaaSMySQLDatastoreV1Create(ctx context.Context, d *schema.Resource
 		SubnetID:    d.Get("subnet_id").(string),
 		NodeCount:   d.Get("node_count").(int),
 		Restore:     restore,
-		Config:      d.Get("config").(map[string]interface{}),
+		Config:      d.Get("config").(map[string]any),
 		FloatingIPs: floatingIPsSchema,
 	}
 
@@ -131,7 +131,7 @@ func resourceDBaaSMySQLDatastoreV1Create(ctx context.Context, d *schema.Resource
 	return resourceDBaaSMySQLDatastoreV1Read(ctx, d, meta)
 }
 
-func resourceDBaaSMySQLDatastoreV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSMySQLDatastoreV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -179,7 +179,7 @@ func resourceDBaaSMySQLDatastoreV1Read(ctx context.Context, d *schema.ResourceDa
 	return nil
 }
 
-func resourceDBaaSMySQLDatastoreV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSMySQLDatastoreV1Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -236,7 +236,7 @@ func resourceDBaaSMySQLDatastoreV1Update(ctx context.Context, d *schema.Resource
 	return resourceDBaaSMySQLDatastoreV1Read(ctx, d, meta)
 }
 
-func resourceDBaaSMySQLDatastoreV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSMySQLDatastoreV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -266,7 +266,7 @@ func resourceDBaaSMySQLDatastoreV1Delete(ctx context.Context, d *schema.Resource
 	return nil
 }
 
-func resourceDBaaSMySQLDatastoreV1ImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceDBaaSMySQLDatastoreV1ImportState(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if config.ProjectID == "" {
 		return nil, errors.New("INFRA_PROJECT_ID must be set for the resource import")

--- a/selectel/resource_selectel_dbaas_postgresql_database_v1.go
+++ b/selectel/resource_selectel_dbaas_postgresql_database_v1.go
@@ -34,7 +34,7 @@ func resourceDBaaSPostgreSQLDatabaseV1() *schema.Resource {
 	}
 }
 
-func resourceDBaaSPostgreSQLDatabaseV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSPostgreSQLDatabaseV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -66,7 +66,7 @@ func resourceDBaaSPostgreSQLDatabaseV1Create(ctx context.Context, d *schema.Reso
 	return resourceDBaaSPostgreSQLDatabaseV1Read(ctx, d, meta)
 }
 
-func resourceDBaaSPostgreSQLDatabaseV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSPostgreSQLDatabaseV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -93,7 +93,7 @@ func resourceDBaaSPostgreSQLDatabaseV1Read(ctx context.Context, d *schema.Resour
 	return nil
 }
 
-func resourceDBaaSPostgreSQLDatabaseV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSPostgreSQLDatabaseV1Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -121,7 +121,7 @@ func resourceDBaaSPostgreSQLDatabaseV1Update(ctx context.Context, d *schema.Reso
 	return resourceDBaaSPostgreSQLDatabaseV1Read(ctx, d, meta)
 }
 
-func resourceDBaaSPostgreSQLDatabaseV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSPostgreSQLDatabaseV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -151,7 +151,7 @@ func resourceDBaaSPostgreSQLDatabaseV1Delete(ctx context.Context, d *schema.Reso
 	return nil
 }
 
-func resourceDBaaSPostgreSQLDatabaseV1ImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceDBaaSPostgreSQLDatabaseV1ImportState(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if config.ProjectID == "" {
 		return nil, errors.New("INFRA_PROJECT_ID must be set for the resource import")

--- a/selectel/resource_selectel_dbaas_postgresql_datastore_v1.go
+++ b/selectel/resource_selectel_dbaas_postgresql_datastore_v1.go
@@ -38,7 +38,7 @@ func resourceDBaaSPostgreSQLDatastoreV1() *schema.Resource {
 	}
 }
 
-func resourceDBaaSPostgreSQLDatastoreV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSPostgreSQLDatastoreV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -83,7 +83,7 @@ func resourceDBaaSPostgreSQLDatastoreV1Create(ctx context.Context, d *schema.Res
 		NodeCount:   d.Get("node_count").(int),
 		Pooler:      pooler,
 		Restore:     restore,
-		Config:      d.Get("config").(map[string]interface{}),
+		Config:      d.Get("config").(map[string]any),
 		FloatingIPs: floatingIPsSchema,
 	}
 
@@ -139,7 +139,7 @@ func resourceDBaaSPostgreSQLDatastoreV1Create(ctx context.Context, d *schema.Res
 	return resourceDBaaSPostgreSQLDatastoreV1Read(ctx, d, meta)
 }
 
-func resourceDBaaSPostgreSQLDatastoreV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSPostgreSQLDatastoreV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -187,7 +187,7 @@ func resourceDBaaSPostgreSQLDatastoreV1Read(ctx context.Context, d *schema.Resou
 	return nil
 }
 
-func resourceDBaaSPostgreSQLDatastoreV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSPostgreSQLDatastoreV1Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -250,7 +250,7 @@ func resourceDBaaSPostgreSQLDatastoreV1Update(ctx context.Context, d *schema.Res
 	return resourceDBaaSPostgreSQLDatastoreV1Read(ctx, d, meta)
 }
 
-func resourceDBaaSPostgreSQLDatastoreV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSPostgreSQLDatastoreV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -280,7 +280,7 @@ func resourceDBaaSPostgreSQLDatastoreV1Delete(ctx context.Context, d *schema.Res
 	return nil
 }
 
-func resourceDBaaSPostgreSQLDatastoreV1ImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceDBaaSPostgreSQLDatastoreV1ImportState(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if config.ProjectID == "" {
 		return nil, errors.New("INFRA_PROJECT_ID must be set for the resource import")

--- a/selectel/resource_selectel_dbaas_postgresql_extension_v1.go
+++ b/selectel/resource_selectel_dbaas_postgresql_extension_v1.go
@@ -33,7 +33,7 @@ func resourceDBaaSPostgreSQLExtensionV1() *schema.Resource {
 	}
 }
 
-func resourceDBaaSPostgreSQLExtensionV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSPostgreSQLExtensionV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -63,7 +63,7 @@ func resourceDBaaSPostgreSQLExtensionV1Create(ctx context.Context, d *schema.Res
 	return resourceDBaaSPostgreSQLExtensionV1Read(ctx, d, meta)
 }
 
-func resourceDBaaSPostgreSQLExtensionV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSPostgreSQLExtensionV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -82,7 +82,7 @@ func resourceDBaaSPostgreSQLExtensionV1Read(ctx context.Context, d *schema.Resou
 	return nil
 }
 
-func resourceDBaaSPostgreSQLExtensionV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSPostgreSQLExtensionV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -112,7 +112,7 @@ func resourceDBaaSPostgreSQLExtensionV1Delete(ctx context.Context, d *schema.Res
 	return nil
 }
 
-func resourceDBaaSPostgreSQLExtensionV1ImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceDBaaSPostgreSQLExtensionV1ImportState(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if config.ProjectID == "" {
 		return nil, errors.New("INFRA_PROJECT_ID must be set for the resource import")

--- a/selectel/resource_selectel_dbaas_postgresql_logical_replication_slot_v1.go
+++ b/selectel/resource_selectel_dbaas_postgresql_logical_replication_slot_v1.go
@@ -33,7 +33,7 @@ func resourceDBaaSPostgreSQLLogicalReplicationSlotV1() *schema.Resource {
 	}
 }
 
-func resourceDBaaSPostgreSQLLogicalReplicationSlotV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSPostgreSQLLogicalReplicationSlotV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -63,7 +63,7 @@ func resourceDBaaSPostgreSQLLogicalReplicationSlotV1Create(ctx context.Context, 
 	return resourceDBaaSPostgreSQLLogicalReplicationSlotV1Read(ctx, d, meta)
 }
 
-func resourceDBaaSPostgreSQLLogicalReplicationSlotV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSPostgreSQLLogicalReplicationSlotV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -82,7 +82,7 @@ func resourceDBaaSPostgreSQLLogicalReplicationSlotV1Read(ctx context.Context, d 
 	return nil
 }
 
-func resourceDBaaSPostgreSQLLogicalReplicationSlotV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSPostgreSQLLogicalReplicationSlotV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -112,7 +112,7 @@ func resourceDBaaSPostgreSQLLogicalReplicationSlotV1Delete(ctx context.Context, 
 	return nil
 }
 
-func resourceDBaaSPostgreSQLLogicalReplicationSlotV1ImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceDBaaSPostgreSQLLogicalReplicationSlotV1ImportState(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if config.ProjectID == "" {
 		return nil, errors.New("INFRA_PROJECT_ID must be set for the resource import")

--- a/selectel/resource_selectel_dbaas_prometheus_metric_token_v1.go
+++ b/selectel/resource_selectel_dbaas_prometheus_metric_token_v1.go
@@ -33,7 +33,7 @@ func resourceDBaaSPrometheusMetricTokenV1() *schema.Resource {
 	}
 }
 
-func resourceDBaaSPrometheusMetricTokenV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSPrometheusMetricTokenV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -54,7 +54,7 @@ func resourceDBaaSPrometheusMetricTokenV1Create(ctx context.Context, d *schema.R
 	return resourceDBaaSPrometheusMetricTokenV1Read(ctx, d, meta)
 }
 
-func resourceDBaaSPrometheusMetricTokenV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSPrometheusMetricTokenV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -71,7 +71,7 @@ func resourceDBaaSPrometheusMetricTokenV1Read(ctx context.Context, d *schema.Res
 	return nil
 }
 
-func resourceDBaaSPrometheusMetricTokenV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSPrometheusMetricTokenV1Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -92,7 +92,7 @@ func resourceDBaaSPrometheusMetricTokenV1Update(ctx context.Context, d *schema.R
 	return resourceDBaaSPrometheusMetricTokenV1Read(ctx, d, meta)
 }
 
-func resourceDBaaSPrometheusMetricTokenV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSPrometheusMetricTokenV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -122,7 +122,7 @@ func resourceDBaaSPrometheusMetricTokenV1Delete(ctx context.Context, d *schema.R
 	return nil
 }
 
-func resourceDBaaSPrometheusMetricTokenV1ImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceDBaaSPrometheusMetricTokenV1ImportState(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if config.ProjectID == "" {
 		return nil, errors.New("INFRA_PROJECT_ID must be set for the resource import")
@@ -138,7 +138,7 @@ func resourceDBaaSPrometheusMetricTokenV1ImportState(_ context.Context, d *schem
 }
 
 func dbaasPrometheusMetricTokenV1DeleteStateRefreshFunc(ctx context.Context, client *dbaas.API, prometheusMetricsTokenID string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		d, err := client.PrometheusMetricToken(ctx, prometheusMetricsTokenID)
 		if err != nil {
 			var dbaasError *dbaas.DBaaSAPIError

--- a/selectel/resource_selectel_dbaas_redis_datastore_v1.go
+++ b/selectel/resource_selectel_dbaas_redis_datastore_v1.go
@@ -38,7 +38,7 @@ func resourceDBaaSRedisDatastoreV1() *schema.Resource {
 	}
 }
 
-func resourceDBaaSRedisDatastoreV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSRedisDatastoreV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -71,7 +71,7 @@ func resourceDBaaSRedisDatastoreV1Create(ctx context.Context, d *schema.Resource
 		SubnetID:    d.Get("subnet_id").(string),
 		NodeCount:   d.Get("node_count").(int),
 		Restore:     restore,
-		Config:      d.Get("config").(map[string]interface{}),
+		Config:      d.Get("config").(map[string]any),
 		FloatingIPs: floatingIPsSchema,
 	}
 
@@ -122,7 +122,7 @@ func resourceDBaaSRedisDatastoreV1Create(ctx context.Context, d *schema.Resource
 	return resourceDBaaSRedisDatastoreV1Read(ctx, d, meta)
 }
 
-func resourceDBaaSRedisDatastoreV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSRedisDatastoreV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -170,7 +170,7 @@ func resourceDBaaSRedisDatastoreV1Read(ctx context.Context, d *schema.ResourceDa
 	return nil
 }
 
-func resourceDBaaSRedisDatastoreV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSRedisDatastoreV1Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -233,7 +233,7 @@ func resourceDBaaSRedisDatastoreV1Update(ctx context.Context, d *schema.Resource
 	return resourceDBaaSRedisDatastoreV1Read(ctx, d, meta)
 }
 
-func resourceDBaaSRedisDatastoreV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSRedisDatastoreV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -263,7 +263,7 @@ func resourceDBaaSRedisDatastoreV1Delete(ctx context.Context, d *schema.Resource
 	return nil
 }
 
-func resourceDBaaSRedisDatastoreV1ImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceDBaaSRedisDatastoreV1ImportState(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if config.ProjectID == "" {
 		return nil, errors.New("INFRA_PROJECT_ID must be set for the resource import")

--- a/selectel/resource_selectel_dbaas_user_v1.go
+++ b/selectel/resource_selectel_dbaas_user_v1.go
@@ -34,7 +34,7 @@ func resourceDBaaSUserV1() *schema.Resource {
 	}
 }
 
-func resourceDBaaSUserV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSUserV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -64,7 +64,7 @@ func resourceDBaaSUserV1Create(ctx context.Context, d *schema.ResourceData, meta
 	return resourceDBaaSUserV1Read(ctx, d, meta)
 }
 
-func resourceDBaaSUserV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSUserV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -82,7 +82,7 @@ func resourceDBaaSUserV1Read(ctx context.Context, d *schema.ResourceData, meta i
 	return nil
 }
 
-func resourceDBaaSUserV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSUserV1Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -110,7 +110,7 @@ func resourceDBaaSUserV1Update(ctx context.Context, d *schema.ResourceData, meta
 	return resourceDBaaSUserV1Read(ctx, d, meta)
 }
 
-func resourceDBaaSUserV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDBaaSUserV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dbaasClient, diagErr := getDBaaSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -140,7 +140,7 @@ func resourceDBaaSUserV1Delete(ctx context.Context, d *schema.ResourceData, meta
 	return nil
 }
 
-func resourceDBaaSUserV1ImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceDBaaSUserV1ImportState(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if config.ProjectID == "" {
 		return nil, errors.New("INFRA_PROJECT_ID must be set for the resource import")

--- a/selectel/resource_selectel_dedicated_server_v1.go
+++ b/selectel/resource_selectel_dedicated_server_v1.go
@@ -32,7 +32,7 @@ func resourceDedicatedServerV1() *schema.Resource {
 	}
 }
 
-func resourceDedicatedServerV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDedicatedServerV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dsClient, diagErr := getDedicatedClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -392,7 +392,7 @@ func resourceDedicatedServerV1CreateValidatePreconditions(
 	return nil
 }
 
-func resourceDedicatedServerV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDedicatedServerV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dsClient, diagErr := getDedicatedClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -474,7 +474,7 @@ func resourceDedicatedServerV1Read(ctx context.Context, d *schema.ResourceData, 
 	return nil
 }
 
-func resourceDedicatedServerV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDedicatedServerV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	dsClient, diagErr := getDedicatedClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -498,7 +498,7 @@ func resourceDedicatedServerV1Delete(ctx context.Context, d *schema.ResourceData
 	return nil
 }
 
-func resourceDedicatedServerV1UpdateWithStateRollback(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDedicatedServerV1UpdateWithStateRollback(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	d.Partial(true)
 
 	dsClient, diagErr := getDedicatedClient(d, meta)
@@ -753,7 +753,7 @@ func resourceDedicatedServerV1UpdateValidatePreconditionsAdditionalOSParams(
 	return nil
 }
 
-func resourceDedicatedServerV1ImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceDedicatedServerV1ImportState(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if config.ProjectID == "" {
 		return nil, errors.New("project_id must be set for the resource import")

--- a/selectel/resource_selectel_dedicated_server_v1_test.go
+++ b/selectel/resource_selectel_dedicated_server_v1_test.go
@@ -521,7 +521,7 @@ func Test_resourceDedicatedServerV1UpdateValidatePreconditions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			res := resourceDedicatedServerV1()
 
-			initMap := map[string]interface{}{}
+			initMap := map[string]any{}
 			for _, key := range tt.changes {
 				initMap[key] = "changed"
 			}

--- a/selectel/resource_selectel_domains_domain_v1.go
+++ b/selectel/resource_selectel_domains_domain_v1.go
@@ -33,7 +33,7 @@ func resourceDomainsDomainV1() *schema.Resource {
 	}
 }
 
-func resourceDomainsDomainV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDomainsDomainV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, err := getDomainsClient(meta)
 	if err != nil {
 		return diag.FromErr(err)
@@ -54,7 +54,7 @@ func resourceDomainsDomainV1Create(ctx context.Context, d *schema.ResourceData, 
 	return resourceDomainsDomainV1Read(ctx, d, meta)
 }
 
-func resourceDomainsDomainV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDomainsDomainV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, err := getDomainsClient(meta)
 	if err != nil {
 		return diag.FromErr(err)
@@ -83,7 +83,7 @@ func resourceDomainsDomainV1Read(ctx context.Context, d *schema.ResourceData, me
 	return nil
 }
 
-func resourceDomainsDomainV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDomainsDomainV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, err := getDomainsClient(meta)
 	if err != nil {
 		return diag.FromErr(err)

--- a/selectel/resource_selectel_domains_record_v1.go
+++ b/selectel/resource_selectel_domains_record_v1.go
@@ -126,7 +126,7 @@ func resourceDomainsRecordV1() *schema.Resource {
 	}
 }
 
-func resourceDomainsRecordV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDomainsRecordV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	domainID := d.Get("domain_id").(int)
 	selMutexKV.Lock(strconv.Itoa(domainID))
 	defer selMutexKV.Unlock(strconv.Itoa(domainID))
@@ -170,7 +170,7 @@ func resourceDomainsRecordV1Create(ctx context.Context, d *schema.ResourceData, 
 	return resourceDomainsRecordV1Read(ctx, d, meta)
 }
 
-func resourceDomainsRecordV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDomainsRecordV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, err := getDomainsClient(meta)
 	if err != nil {
 		return diag.FromErr(err)
@@ -213,7 +213,7 @@ func resourceDomainsRecordV1Read(ctx context.Context, d *schema.ResourceData, me
 	return nil
 }
 
-func resourceDomainsRecordV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDomainsRecordV1Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	domainID, recordID, err := domainsV1ParseDomainRecordIDsPair(d.Id())
 	if err != nil {
 		d.SetId("")
@@ -254,7 +254,7 @@ func resourceDomainsRecordV1Update(ctx context.Context, d *schema.ResourceData, 
 	return resourceDomainsRecordV1Read(ctx, d, meta)
 }
 
-func resourceDomainsRecordV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDomainsRecordV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	domainID, recordID, err := domainsV1ParseDomainRecordIDsPair(d.Id())
 	if err != nil {
 		d.SetId("")

--- a/selectel/resource_selectel_domains_rrset_v2.go
+++ b/selectel/resource_selectel_domains_rrset_v2.go
@@ -77,7 +77,7 @@ func resourceDomainsRRSetV2() *schema.Resource {
 	}
 }
 
-func resourceDomainsRRSetV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDomainsRRSetV2Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	zoneID := d.Get("zone_id").(string)
 
 	client, err := getDomainsV2Client(d, meta)
@@ -116,7 +116,7 @@ func resourceDomainsRRSetV2Create(ctx context.Context, d *schema.ResourceData, m
 	return nil
 }
 
-func resourceDomainsRRSetV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDomainsRRSetV2Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, err := getDomainsV2Client(d, meta)
 	if err != nil {
 		return diag.FromErr(err)
@@ -141,7 +141,7 @@ func resourceDomainsRRSetV2Read(ctx context.Context, d *schema.ResourceData, met
 	return nil
 }
 
-func resourceDomainsRRSetV2ImportState(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceDomainsRRSetV2ImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if config.ProjectID == "" {
 		return nil, errors.New("INFRA_PROJECT_ID must be set for the resource import")
@@ -183,7 +183,7 @@ func resourceDomainsRRSetV2ImportState(ctx context.Context, d *schema.ResourceDa
 	return []*schema.ResourceData{d}, nil
 }
 
-func resourceDomainsRRSetV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDomainsRRSetV2Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	zoneID := d.Get("zone_id").(string)
 
 	client, err := getDomainsV2Client(d, meta)
@@ -215,7 +215,7 @@ func resourceDomainsRRSetV2Update(ctx context.Context, d *schema.ResourceData, m
 	return resourceDomainsRRSetV2Read(ctx, d, meta)
 }
 
-func resourceDomainsRRSetV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDomainsRRSetV2Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	zoneID := d.Get("zone_id").(string)
 
 	client, err := getDomainsV2Client(d, meta)

--- a/selectel/resource_selectel_domains_zone_v2.go
+++ b/selectel/resource_selectel_domains_zone_v2.go
@@ -65,7 +65,7 @@ func resourceDomainsZoneV2() *schema.Resource {
 	}
 }
 
-func resourceDomainsZoneV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDomainsZoneV2Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, err := getDomainsV2Client(d, meta)
 	if err != nil {
 		return diag.FromErr(err)
@@ -109,7 +109,7 @@ func resourceDomainsZoneV2Create(ctx context.Context, d *schema.ResourceData, me
 	return nil
 }
 
-func resourceDomainsZoneV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDomainsZoneV2Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, err := getDomainsV2Client(d, meta)
 	if err != nil {
 		return diag.FromErr(err)
@@ -131,7 +131,7 @@ func resourceDomainsZoneV2Read(ctx context.Context, d *schema.ResourceData, meta
 	return nil
 }
 
-func resourceDomainsZoneV2ImportState(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceDomainsZoneV2ImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if config.ProjectID == "" {
 		return nil, errors.New("INFRA_PROJECT_ID must be set for the resource import")
@@ -162,7 +162,7 @@ func resourceDomainsZoneV2ImportState(ctx context.Context, d *schema.ResourceDat
 	return []*schema.ResourceData{d}, nil
 }
 
-func resourceDomainsZoneV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDomainsZoneV2Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, err := getDomainsV2Client(d, meta)
 	if err != nil {
 		return diag.FromErr(errUpdatingObject(objectZone, d.Id(), err))
@@ -197,7 +197,7 @@ func resourceDomainsZoneV2Update(ctx context.Context, d *schema.ResourceData, me
 	return nil
 }
 
-func resourceDomainsZoneV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDomainsZoneV2Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, err := getDomainsV2Client(d, meta)
 	if err != nil {
 		return diag.FromErr(err)

--- a/selectel/resource_selectel_global_router_dedicated_network_v1.go
+++ b/selectel/resource_selectel_global_router_dedicated_network_v1.go
@@ -96,7 +96,7 @@ func resourceGlobalRouterDedicatedNetworkV1() *schema.Resource {
 	}
 }
 
-func resourceGlobalRouterDedicatedNetworkV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalRouterDedicatedNetworkV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getGlobalRouterClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -139,7 +139,7 @@ func resourceGlobalRouterDedicatedNetworkV1Create(ctx context.Context, d *schema
 	return resourceGlobalRouterDedicatedNetworkV1Read(ctx, d, meta)
 }
 
-func resourceGlobalRouterDedicatedNetworkV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalRouterDedicatedNetworkV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getGlobalRouterClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -170,7 +170,7 @@ func resourceGlobalRouterDedicatedNetworkV1Read(ctx context.Context, d *schema.R
 	return nil
 }
 
-func resourceGlobalRouterDedicatedNetworkV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalRouterDedicatedNetworkV1Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getGlobalRouterClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -215,7 +215,7 @@ func resourceGlobalRouterDedicatedNetworkV1Update(ctx context.Context, d *schema
 	return nil
 }
 
-func resourceGlobalRouterDedicatedNetworkV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalRouterDedicatedNetworkV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getGlobalRouterClient(meta)
 	if diagErr != nil {
 		return diagErr

--- a/selectel/resource_selectel_global_router_dedicated_subnet_v1.go
+++ b/selectel/resource_selectel_global_router_dedicated_subnet_v1.go
@@ -100,7 +100,7 @@ func resourceGlobalRouterDedicatedSubnetV1() *schema.Resource {
 	}
 }
 
-func resourceGlobalRouterDedicatedSubnetV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalRouterDedicatedSubnetV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getGlobalRouterClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -146,7 +146,7 @@ func resourceGlobalRouterDedicatedSubnetV1Create(ctx context.Context, d *schema.
 	return resourceGlobalRouterDedicatedSubnetV1Read(ctx, d, meta)
 }
 
-func resourceGlobalRouterDedicatedSubnetV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalRouterDedicatedSubnetV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getGlobalRouterClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -177,7 +177,7 @@ func resourceGlobalRouterDedicatedSubnetV1Read(ctx context.Context, d *schema.Re
 	return nil
 }
 
-func resourceGlobalRouterDedicatedSubnetV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalRouterDedicatedSubnetV1Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getGlobalRouterClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -222,7 +222,7 @@ func resourceGlobalRouterDedicatedSubnetV1Update(ctx context.Context, d *schema.
 	return nil
 }
 
-func resourceGlobalRouterDedicatedSubnetV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalRouterDedicatedSubnetV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getGlobalRouterClient(meta)
 	if diagErr != nil {
 		return diagErr

--- a/selectel/resource_selectel_global_router_router_v1.go
+++ b/selectel/resource_selectel_global_router_router_v1.go
@@ -92,7 +92,7 @@ func resourceGlobalRouterRouterV1() *schema.Resource {
 	}
 }
 
-func resourceGlobalRouterRouterV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalRouterRouterV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getGlobalRouterClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -123,7 +123,7 @@ func resourceGlobalRouterRouterV1Create(ctx context.Context, d *schema.ResourceD
 	return resourceGlobalRouterRouterV1Read(ctx, d, meta)
 }
 
-func resourceGlobalRouterRouterV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalRouterRouterV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getGlobalRouterClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -154,7 +154,7 @@ func resourceGlobalRouterRouterV1Read(ctx context.Context, d *schema.ResourceDat
 	return nil
 }
 
-func resourceGlobalRouterRouterV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalRouterRouterV1Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getGlobalRouterClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -199,7 +199,7 @@ func resourceGlobalRouterRouterV1Update(ctx context.Context, d *schema.ResourceD
 	return nil
 }
 
-func resourceGlobalRouterRouterV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalRouterRouterV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getGlobalRouterClient(meta)
 	if diagErr != nil {
 		return diagErr

--- a/selectel/resource_selectel_global_router_static_route_v1.go
+++ b/selectel/resource_selectel_global_router_static_route_v1.go
@@ -95,7 +95,7 @@ func resourceGlobalRouterStaticRouteV1() *schema.Resource {
 	}
 }
 
-func resourceGlobalRouterStaticRouteV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalRouterStaticRouteV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getGlobalRouterClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -133,7 +133,7 @@ func resourceGlobalRouterStaticRouteV1Create(ctx context.Context, d *schema.Reso
 	return resourceGlobalRouterStaticRouteV1Read(ctx, d, meta)
 }
 
-func resourceGlobalRouterStaticRouteV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalRouterStaticRouteV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getGlobalRouterClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -164,7 +164,7 @@ func resourceGlobalRouterStaticRouteV1Read(ctx context.Context, d *schema.Resour
 	return nil
 }
 
-func resourceGlobalRouterStaticRouteV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalRouterStaticRouteV1Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getGlobalRouterClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -209,7 +209,7 @@ func resourceGlobalRouterStaticRouteV1Update(ctx context.Context, d *schema.Reso
 	return nil
 }
 
-func resourceGlobalRouterStaticRouteV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalRouterStaticRouteV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getGlobalRouterClient(meta)
 	if diagErr != nil {
 		return diagErr

--- a/selectel/resource_selectel_global_router_vpc_network_v1.go
+++ b/selectel/resource_selectel_global_router_vpc_network_v1.go
@@ -101,7 +101,7 @@ func resourceGlobalRouterVPCNetworkV1() *schema.Resource {
 	}
 }
 
-func resourceGlobalRouterVPCNetworkV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalRouterVPCNetworkV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getGlobalRouterClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -140,7 +140,7 @@ func resourceGlobalRouterVPCNetworkV1Create(ctx context.Context, d *schema.Resou
 	return resourceGlobalRouterVPCNetworkV1Read(ctx, d, meta)
 }
 
-func resourceGlobalRouterVPCNetworkV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalRouterVPCNetworkV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getGlobalRouterClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -172,7 +172,7 @@ func resourceGlobalRouterVPCNetworkV1Read(ctx context.Context, d *schema.Resourc
 	return nil
 }
 
-func resourceGlobalRouterVPCNetworkV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalRouterVPCNetworkV1Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getGlobalRouterClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -217,7 +217,7 @@ func resourceGlobalRouterVPCNetworkV1Update(ctx context.Context, d *schema.Resou
 	return nil
 }
 
-func resourceGlobalRouterVPCNetworkV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalRouterVPCNetworkV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getGlobalRouterClient(meta)
 	if diagErr != nil {
 		return diagErr

--- a/selectel/resource_selectel_global_router_vpc_subnet_v1.go
+++ b/selectel/resource_selectel_global_router_vpc_subnet_v1.go
@@ -111,7 +111,7 @@ func resourceGlobalRouterVPCSubnetV1() *schema.Resource {
 	}
 }
 
-func resourceGlobalRouterVPCSubnetV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalRouterVPCSubnetV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getGlobalRouterClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -159,7 +159,7 @@ func resourceGlobalRouterVPCSubnetV1Create(ctx context.Context, d *schema.Resour
 	return resourceGlobalRouterVPCSubnetV1Read(ctx, d, meta)
 }
 
-func resourceGlobalRouterVPCSubnetV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalRouterVPCSubnetV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getGlobalRouterClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -192,7 +192,7 @@ func resourceGlobalRouterVPCSubnetV1Read(ctx context.Context, d *schema.Resource
 	return nil
 }
 
-func resourceGlobalRouterVPCSubnetV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalRouterVPCSubnetV1Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getGlobalRouterClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -237,7 +237,7 @@ func resourceGlobalRouterVPCSubnetV1Update(ctx context.Context, d *schema.Resour
 	return nil
 }
 
-func resourceGlobalRouterVPCSubnetV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalRouterVPCSubnetV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getGlobalRouterClient(meta)
 	if diagErr != nil {
 		return diagErr

--- a/selectel/resource_selectel_iam_group_membership_v1.go
+++ b/selectel/resource_selectel_iam_group_membership_v1.go
@@ -31,13 +31,13 @@ func resourceIAMGroupMembershipV1() *schema.Resource {
 	}
 }
 
-func resourceIAMGroupMembershipV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIAMGroupMembershipV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	iamClient, diagErr := getIAMClient(meta)
 	if diagErr != nil {
 		return diagErr
 	}
 
-	userIDsInterface := d.Get("user_ids").([]interface{})
+	userIDsInterface := d.Get("user_ids").([]any)
 	userIDs := make([]string, len(userIDsInterface))
 	for i, v := range userIDsInterface {
 		userIDs[i] = v.(string)
@@ -58,7 +58,7 @@ func resourceIAMGroupMembershipV1Create(ctx context.Context, d *schema.ResourceD
 	return resourceIAMGroupMembershipV1Read(ctx, d, meta)
 }
 
-func resourceIAMGroupMembershipV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIAMGroupMembershipV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	iamClient, diagErr := getIAMClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -66,7 +66,7 @@ func resourceIAMGroupMembershipV1Read(ctx context.Context, d *schema.ResourceDat
 
 	groupID := d.Id()
 
-	userIDsInterface := d.Get("user_ids").([]interface{})
+	userIDsInterface := d.Get("user_ids").([]any)
 	userIDs := make([]string, len(userIDsInterface))
 	for i, v := range userIDsInterface {
 		userIDs[i] = v.(string)
@@ -93,7 +93,7 @@ func resourceIAMGroupMembershipV1Read(ctx context.Context, d *schema.ResourceDat
 	return nil
 }
 
-func resourceIAMGroupMembershipV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIAMGroupMembershipV1Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	iamClient, diagErr := getIAMClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -104,12 +104,12 @@ func resourceIAMGroupMembershipV1Update(ctx context.Context, d *schema.ResourceD
 	oldValue, newValue := d.GetChange("user_ids")
 
 	oldUserIDs := make(map[string]struct{})
-	for _, v := range oldValue.([]interface{}) {
+	for _, v := range oldValue.([]any) {
 		oldUserIDs[v.(string)] = struct{}{}
 	}
 
 	newUserIDs := make(map[string]struct{})
-	for _, v := range newValue.([]interface{}) {
+	for _, v := range newValue.([]any) {
 		newUserIDs[v.(string)] = struct{}{}
 	}
 
@@ -134,7 +134,7 @@ func resourceIAMGroupMembershipV1Update(ctx context.Context, d *schema.ResourceD
 	return resourceIAMGroupMembershipV1Read(ctx, d, meta)
 }
 
-func resourceIAMGroupMembershipV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIAMGroupMembershipV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	iamClient, diagErr := getIAMClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -142,7 +142,7 @@ func resourceIAMGroupMembershipV1Delete(ctx context.Context, d *schema.ResourceD
 
 	groupID := d.Id()
 
-	userIDsInterface := d.Get("user_ids").([]interface{})
+	userIDsInterface := d.Get("user_ids").([]any)
 	userIDs := make([]string, len(userIDsInterface))
 	for i, v := range userIDsInterface {
 		userIDs[i] = v.(string)

--- a/selectel/resource_selectel_iam_group_v1.go
+++ b/selectel/resource_selectel_iam_group_v1.go
@@ -60,7 +60,7 @@ func resourceIAMGroupV1() *schema.Resource {
 	}
 }
 
-func resourceIAMGroupV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIAMGroupV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	iamClient, diagErr := getIAMClient(meta)
@@ -101,7 +101,7 @@ func resourceIAMGroupV1Create(ctx context.Context, d *schema.ResourceData, meta 
 	return diags
 }
 
-func resourceIAMGroupV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIAMGroupV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	iamClient, diagErr := getIAMClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -118,7 +118,7 @@ func resourceIAMGroupV1Read(ctx context.Context, d *schema.ResourceData, meta in
 	return nil
 }
 
-func resourceIAMGroupV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIAMGroupV1Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	iamClient, diagErr := getIAMClient(meta)
@@ -170,7 +170,7 @@ func resourceIAMGroupV1Update(ctx context.Context, d *schema.ResourceData, meta 
 	return diags
 }
 
-func resourceIAMGroupV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIAMGroupV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	iamClient, diagErr := getIAMClient(meta)
 	if diagErr != nil {
 		return diagErr

--- a/selectel/resource_selectel_iam_s3_credentials_v1.go
+++ b/selectel/resource_selectel_iam_s3_credentials_v1.go
@@ -57,7 +57,7 @@ func resourceIAMS3CredentialsV1() *schema.Resource {
 	}
 }
 
-func resourceIAMS3CredentialsV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIAMS3CredentialsV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	iamClient, diagErr := getIAMClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -83,7 +83,7 @@ func resourceIAMS3CredentialsV1Create(ctx context.Context, d *schema.ResourceDat
 	return nil
 }
 
-func resourceIAMS3CredentialsV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIAMS3CredentialsV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	iamClient, diagErr := getIAMClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -116,7 +116,7 @@ func resourceIAMS3CredentialsV1Read(ctx context.Context, d *schema.ResourceData,
 	return nil
 }
 
-func resourceIAMS3CredentialsV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIAMS3CredentialsV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	iamClient, diagErr := getIAMClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -131,7 +131,7 @@ func resourceIAMS3CredentialsV1Delete(ctx context.Context, d *schema.ResourceDat
 	return nil
 }
 
-func resourceIAMS3CredentialsV1ImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+func resourceIAMS3CredentialsV1ImportState(_ context.Context, d *schema.ResourceData, _ any) ([]*schema.ResourceData, error) {
 	var v string
 	if v = os.Getenv("OS_S3_CREDENTIALS_USER_ID"); v == "" {
 		return nil, fmt.Errorf("no OS_S3_CREDENTIALS_USER_ID environment variable was found, provide one to use import")

--- a/selectel/resource_selectel_iam_saml_federation_certificate_v1.go
+++ b/selectel/resource_selectel_iam_saml_federation_certificate_v1.go
@@ -71,7 +71,7 @@ func resourceIAMSAMLFederationCertificateV1() *schema.Resource {
 	}
 }
 
-func resourceIAMSAMLFederationCertificateV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIAMSAMLFederationCertificateV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	iamClient, diagErr := getIAMClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -94,7 +94,7 @@ func resourceIAMSAMLFederationCertificateV1Create(ctx context.Context, d *schema
 	return resourceIAMSAMLFederationCertificateV1Read(ctx, d, meta)
 }
 
-func resourceIAMSAMLFederationCertificateV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIAMSAMLFederationCertificateV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	iamClient, diagErr := getIAMClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -117,7 +117,7 @@ func resourceIAMSAMLFederationCertificateV1Read(ctx context.Context, d *schema.R
 	return nil
 }
 
-func resourceIAMSAMLFederationCertificateV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIAMSAMLFederationCertificateV1Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	iamClient, diagErr := getIAMClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -139,7 +139,7 @@ func resourceIAMSAMLFederationCertificateV1Update(ctx context.Context, d *schema
 	return resourceIAMSAMLFederationCertificateV1Read(ctx, d, meta)
 }
 
-func resourceIAMSAMLFederationCertificateV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIAMSAMLFederationCertificateV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	iamClient, diagErr := getIAMClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -154,7 +154,7 @@ func resourceIAMSAMLFederationCertificateV1Delete(ctx context.Context, d *schema
 	return nil
 }
 
-func resourceIAMS3SAMLFederationCertificateV1ImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+func resourceIAMS3SAMLFederationCertificateV1ImportState(_ context.Context, d *schema.ResourceData, _ any) ([]*schema.ResourceData, error) {
 	var v string
 	if v = os.Getenv("OS_SAML_FEDERATION_ID"); v == "" {
 		return nil, fmt.Errorf("no OS_SAML_FEDERATION_ID environment variable was found, provide one to use import")

--- a/selectel/resource_selectel_iam_saml_federation_v1.go
+++ b/selectel/resource_selectel_iam_saml_federation_v1.go
@@ -69,7 +69,7 @@ func resourceIAMSAMLFederationV1() *schema.Resource {
 	}
 }
 
-func resourceIAMSAMLFederationV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIAMSAMLFederationV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	iamClient, diagErr := getIAMClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -96,7 +96,7 @@ func resourceIAMSAMLFederationV1Create(ctx context.Context, d *schema.ResourceDa
 	return resourceIAMSAMLFederationV1Read(ctx, d, meta)
 }
 
-func resourceIAMSAMLFederationV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIAMSAMLFederationV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	iamClient, diagErr := getIAMClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -120,7 +120,7 @@ func resourceIAMSAMLFederationV1Read(ctx context.Context, d *schema.ResourceData
 	return nil
 }
 
-func resourceIAMSAMLFederationV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIAMSAMLFederationV1Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	iamClient, diagErr := getIAMClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -149,7 +149,7 @@ func resourceIAMSAMLFederationV1Update(ctx context.Context, d *schema.ResourceDa
 	return resourceIAMSAMLFederationV1Read(ctx, d, meta)
 }
 
-func resourceIAMSAMLFederationV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIAMSAMLFederationV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	iamClient, diagErr := getIAMClient(meta)
 	if diagErr != nil {
 		return diagErr

--- a/selectel/resource_selectel_iam_serviceuser_v1.go
+++ b/selectel/resource_selectel_iam_serviceuser_v1.go
@@ -67,7 +67,7 @@ func resourceIAMServiceUserV1() *schema.Resource {
 	}
 }
 
-func resourceIAMServiceUserV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIAMServiceUserV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	iamClient, diagErr := getIAMClient(meta)
@@ -102,7 +102,7 @@ func resourceIAMServiceUserV1Create(ctx context.Context, d *schema.ResourceData,
 	return diags
 }
 
-func resourceIAMServiceUserV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIAMServiceUserV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	iamClient, diagErr := getIAMClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -124,7 +124,7 @@ func resourceIAMServiceUserV1Read(ctx context.Context, d *schema.ResourceData, m
 	return nil
 }
 
-func resourceIAMServiceUserV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIAMServiceUserV1Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	iamClient, diagErr := getIAMClient(meta)
@@ -180,7 +180,7 @@ func resourceIAMServiceUserV1Update(ctx context.Context, d *schema.ResourceData,
 	return diags
 }
 
-func resourceIAMServiceUserV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIAMServiceUserV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	iamClient, diagErr := getIAMClient(meta)
 	if diagErr != nil {
 		return diagErr

--- a/selectel/resource_selectel_iam_user_v1.go
+++ b/selectel/resource_selectel_iam_user_v1.go
@@ -81,7 +81,7 @@ func resourceIAMUserV1() *schema.Resource {
 	}
 }
 
-func resourceIAMUserV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIAMUserV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	iamClient, diagErr := getIAMClient(meta)
@@ -96,7 +96,7 @@ func resourceIAMUserV1Create(ctx context.Context, d *schema.ResourceData, meta i
 
 	diags = checkDeprecatedRoles(ctx, meta, roles)
 
-	federation, err := convertIAMListToUserFederation(d.Get("federation").([]interface{}))
+	federation, err := convertIAMListToUserFederation(d.Get("federation").([]any))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -125,7 +125,7 @@ func resourceIAMUserV1Create(ctx context.Context, d *schema.ResourceData, meta i
 	return diags
 }
 
-func resourceIAMUserV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIAMUserV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	iamClient, diagErr := getIAMClient(meta)
 	if diagErr != nil {
 		return diagErr
@@ -149,7 +149,7 @@ func resourceIAMUserV1Read(ctx context.Context, d *schema.ResourceData, meta int
 	return nil
 }
 
-func resourceIAMUserV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIAMUserV1Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	iamClient, diagErr := getIAMClient(meta)
@@ -188,7 +188,7 @@ func resourceIAMUserV1Update(ctx context.Context, d *schema.ResourceData, meta i
 	return diags
 }
 
-func resourceIAMUserV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIAMUserV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	iamClient, diagErr := getIAMClient(meta)
 	if diagErr != nil {
 		return diagErr

--- a/selectel/resource_selectel_mks_cluster_v1.go
+++ b/selectel/resource_selectel_mks_cluster_v1.go
@@ -40,7 +40,7 @@ func resourceMKSClusterV1() *schema.Resource {
 			},
 			customdiff.ComputedIf(
 				"maintenance_window_end",
-				func(_ context.Context, d *schema.ResourceDiff, _ interface{}) bool {
+				func(_ context.Context, d *schema.ResourceDiff, _ any) bool {
 					return d.HasChange("maintenance_window_start")
 				}),
 		),
@@ -74,7 +74,7 @@ func resourceMKSClusterV1() *schema.Resource {
 				Required:         true,
 				ForceNew:         false,
 				DiffSuppressFunc: mksClusterV1KubeVersionDiffSuppressFunc,
-				StateFunc: func(v interface{}) string {
+				StateFunc: func(v any) string {
 					return strings.TrimPrefix(v.(string), "v")
 				},
 			},
@@ -159,7 +159,7 @@ func resourceMKSClusterV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
-				StateFunc: func(v interface{}) string {
+				StateFunc: func(v any) string {
 					return strings.ToUpper(v.(string))
 				},
 				ValidateFunc: validation.StringInSlice([]string{
@@ -259,7 +259,7 @@ func resourceMKSClusterV1() *schema.Resource {
 	}
 }
 
-func resourceMKSClusterV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceMKSClusterV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	mksClient, diagErr := getMKSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -374,7 +374,7 @@ func resourceMKSClusterV1Create(ctx context.Context, d *schema.ResourceData, met
 	return resourceMKSClusterV1Read(ctx, d, meta)
 }
 
-func resourceMKSClusterV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceMKSClusterV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	mksClient, diagErr := getMKSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -416,7 +416,7 @@ func resourceMKSClusterV1Read(ctx context.Context, d *schema.ResourceData, meta 
 	return nil
 }
 
-func resourceMKSClusterV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceMKSClusterV1Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	mksClient, diagErr := getMKSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -492,7 +492,7 @@ func resourceMKSClusterV1Update(ctx context.Context, d *schema.ResourceData, met
 	return resourceMKSClusterV1Read(ctx, d, meta)
 }
 
-func resourceMKSClusterV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceMKSClusterV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	mksClient, diagErr := getMKSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -507,7 +507,7 @@ func resourceMKSClusterV1Delete(ctx context.Context, d *schema.ResourceData, met
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{strconv.Itoa(http.StatusOK)},
 		Target:  []string{strconv.Itoa(http.StatusNotFound)},
-		Refresh: func() (result interface{}, state string, err error) {
+		Refresh: func() (result any, state string, err error) {
 			result, response, err := cluster.Get(ctx, mksClient, d.Id())
 			if err != nil {
 				if response != nil {
@@ -533,7 +533,7 @@ func resourceMKSClusterV1Delete(ctx context.Context, d *schema.ResourceData, met
 	return nil
 }
 
-func resourceMKSClusterV1ImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceMKSClusterV1ImportState(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if config.ProjectID == "" {
 		return nil, errors.New("INFRA_PROJECT_ID must be set for the resource import")

--- a/selectel/resource_selectel_mks_nodegroup_v1.go
+++ b/selectel/resource_selectel_mks_nodegroup_v1.go
@@ -200,17 +200,17 @@ func resourceMKSNodegroupV1() *schema.Resource {
 		},
 		CustomizeDiff: customdiff.All(
 			// We need to recreate nodegroup if flavor changed.
-			customdiff.ForceNewIfChange("flavor_id", func(_ context.Context, oldVersion, newVersion, _ interface{}) bool {
+			customdiff.ForceNewIfChange("flavor_id", func(_ context.Context, oldVersion, newVersion, _ any) bool {
 				return oldVersion.(string) != newVersion.(string)
 			}),
-			customdiff.ForceNewIfChange("local_volume", func(_ context.Context, oldVersion, newVersion, _ interface{}) bool {
+			customdiff.ForceNewIfChange("local_volume", func(_ context.Context, oldVersion, newVersion, _ any) bool {
 				return oldVersion.(bool) != newVersion.(bool)
 			}),
 		),
 	}
 }
 
-func resourceMKSNodegroupV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceMKSNodegroupV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	clusterID := d.Get("cluster_id").(string)
 	selMutexKV.Lock(clusterID)
 	defer selMutexKV.Unlock(clusterID)
@@ -320,10 +320,10 @@ func resourceMKSNodegroupV1Create(ctx context.Context, d *schema.ResourceData, m
 		}
 	}
 
-	labels := d.Get("labels").(map[string]interface{})
+	labels := d.Get("labels").(map[string]any)
 	createOpts.Labels = expandMKSNodegroupV1Labels(labels)
 
-	taints := d.Get("taints").([]interface{})
+	taints := d.Get("taints").([]any)
 	createOpts.Taints = expandMKSNodegroupV1Taints(taints)
 
 	log.Print(msgCreate(objectNodegroup, createOpts))
@@ -347,7 +347,7 @@ func resourceMKSNodegroupV1Create(ctx context.Context, d *schema.ResourceData, m
 	return resourceMKSNodegroupV1Read(ctx, d, meta)
 }
 
-func resourceMKSNodegroupV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceMKSNodegroupV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	clusterID, nodegroupID, err := mksNodegroupV1ParseID(d.Id())
 	if err != nil {
 		d.SetId("")
@@ -405,7 +405,7 @@ func resourceMKSNodegroupV1Read(ctx context.Context, d *schema.ResourceData, met
 	return nil
 }
 
-func resourceMKSNodegroupV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceMKSNodegroupV1Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	clusterID, nodegroupID, err := mksNodegroupV1ParseID(d.Id())
 	if err != nil {
 		d.SetId("")
@@ -440,13 +440,13 @@ func resourceMKSNodegroupV1Update(ctx context.Context, d *schema.ResourceData, m
 	)
 
 	if d.HasChange("labels") {
-		labels := d.Get("labels").(map[string]interface{})
+		labels := d.Get("labels").(map[string]any)
 		updateOpts.Labels = expandMKSNodegroupV1Labels(labels)
 		hasChanged = true
 	}
 
 	if d.HasChange("taints") {
-		taints := d.Get("taints").([]interface{})
+		taints := d.Get("taints").([]any)
 		updateOpts.Taints = expandMKSNodegroupV1Taints(taints)
 		hasChanged = true
 	}
@@ -540,7 +540,7 @@ func resourceMKSNodegroupV1Update(ctx context.Context, d *schema.ResourceData, m
 	return resourceMKSNodegroupV1Read(ctx, d, meta)
 }
 
-func resourceMKSNodegroupV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceMKSNodegroupV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	clusterID, nodegroupID, err := mksNodegroupV1ParseID(d.Id())
 	if err != nil {
 		d.SetId("")
@@ -564,7 +564,7 @@ func resourceMKSNodegroupV1Delete(ctx context.Context, d *schema.ResourceData, m
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{strconv.Itoa(http.StatusOK)},
 		Target:  []string{strconv.Itoa(http.StatusNotFound)},
-		Refresh: func() (result interface{}, state string, err error) {
+		Refresh: func() (result any, state string, err error) {
 			result, response, err := nodegroup.Get(ctx, mksClient, clusterID, nodegroupID)
 			if err != nil {
 				if response != nil {
@@ -590,7 +590,7 @@ func resourceMKSNodegroupV1Delete(ctx context.Context, d *schema.ResourceData, m
 	return nil
 }
 
-func resourceMKSNodegroupV1ImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceMKSNodegroupV1ImportState(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if config.ProjectID == "" {
 		return nil, errors.New("INFRA_PROJECT_ID must be set for the resource import")

--- a/selectel/resource_selectel_private_dns_service_v1.go
+++ b/selectel/resource_selectel_private_dns_service_v1.go
@@ -58,7 +58,7 @@ func resourcePrivateDNSServiceV1() *schema.Resource {
 	}
 }
 
-func resourcePrivateDNSServiceV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePrivateDNSServiceV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getPrivateDNSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -78,7 +78,7 @@ func resourcePrivateDNSServiceV1Create(ctx context.Context, d *schema.ResourceDa
 	return nil
 }
 
-func resourcePrivateDNSServiceV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePrivateDNSServiceV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getPrivateDNSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -96,7 +96,7 @@ func resourcePrivateDNSServiceV1Read(ctx context.Context, d *schema.ResourceData
 	return nil
 }
 
-func resourcePrivateDNSServiceV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePrivateDNSServiceV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getPrivateDNSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -110,7 +110,7 @@ func resourcePrivateDNSServiceV1Delete(ctx context.Context, d *schema.ResourceDa
 	return nil
 }
 
-func resourcePrivateDNSServiceV1ImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourcePrivateDNSServiceV1ImportState(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if config.ProjectID == "" {
 		return nil, fmt.Errorf("INFRA_PROJECT_ID must be set for the resource import")

--- a/selectel/resource_selectel_private_dns_zone_v1.go
+++ b/selectel/resource_selectel_private_dns_zone_v1.go
@@ -103,7 +103,7 @@ func resourcePrivateDNSZoneV1() *schema.Resource {
 	}
 }
 
-func resourcePrivateDNSZoneV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePrivateDNSZoneV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getPrivateDNSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -140,7 +140,7 @@ func resourcePrivateDNSZoneV1Create(ctx context.Context, d *schema.ResourceData,
 	return nil
 }
 
-func resourcePrivateDNSZoneV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePrivateDNSZoneV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getPrivateDNSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -158,7 +158,7 @@ func resourcePrivateDNSZoneV1Read(ctx context.Context, d *schema.ResourceData, m
 	return nil
 }
 
-func resourcePrivateDNSZoneV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePrivateDNSZoneV1Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getPrivateDNSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -189,7 +189,7 @@ func resourcePrivateDNSZoneV1Update(ctx context.Context, d *schema.ResourceData,
 	return resourcePrivateDNSZoneV1Read(ctx, d, meta)
 }
 
-func resourcePrivateDNSZoneV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePrivateDNSZoneV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, diagErr := getPrivateDNSClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -203,7 +203,7 @@ func resourcePrivateDNSZoneV1Delete(ctx context.Context, d *schema.ResourceData,
 	return nil
 }
 
-func resourcePrivateDNSZoneV1ImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourcePrivateDNSZoneV1ImportState(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if config.ProjectID == "" {
 		return nil, fmt.Errorf("INFRA_PROJECT_ID must be set for the resource import")
@@ -219,8 +219,8 @@ func resourcePrivateDNSZoneV1ImportState(_ context.Context, d *schema.ResourceDa
 	return []*schema.ResourceData{d}, nil
 }
 
-func privateDNSRecordKey(v interface{}) string {
-	m := v.(map[string]interface{})
+func privateDNSRecordKey(v any) string {
+	m := v.(map[string]any)
 	return m["type"].(string) + " " + m["domain"].(string)
 }
 

--- a/selectel/resource_selectel_vpc_floatingip_v2.go
+++ b/selectel/resource_selectel_vpc_floatingip_v2.go
@@ -72,7 +72,7 @@ func resourceVPCFloatingIPV2() *schema.Resource {
 	}
 }
 
-func resourceVPCFloatingIPV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCFloatingIPV2Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	config := meta.(*Config)
 	projectID := d.Get("project_id").(string)
 	selvpcClient, err := config.GetSelVPCClientWithProjectScope(projectID)
@@ -109,7 +109,7 @@ func resourceVPCFloatingIPV2Create(ctx context.Context, d *schema.ResourceData, 
 	return resourceVPCFloatingIPV2Read(ctx, d, meta)
 }
 
-func resourceVPCFloatingIPV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCFloatingIPV2Read(_ context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	config := meta.(*Config)
 	projectID := d.Get("project_id").(string)
 	selvpcClient, err := config.GetSelVPCClientWithProjectScope(projectID)
@@ -145,7 +145,7 @@ func resourceVPCFloatingIPV2Read(_ context.Context, d *schema.ResourceData, meta
 	return nil
 }
 
-func resourceVPCFloatingIPV2Delete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCFloatingIPV2Delete(_ context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	config := meta.(*Config)
 	projectID := d.Get("project_id").(string)
 	selvpcClient, err := config.GetSelVPCClientWithProjectScope(projectID)
@@ -169,7 +169,7 @@ func resourceVPCFloatingIPV2Delete(_ context.Context, d *schema.ResourceData, me
 	return nil
 }
 
-func resourceVPCFloatingIPV2ImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceVPCFloatingIPV2ImportState(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if config.ProjectID == "" {
 		return nil, fmt.Errorf("INFRA_PROJECT_ID must be set for the resource import")

--- a/selectel/resource_selectel_vpc_keypair_v2.go
+++ b/selectel/resource_selectel_vpc_keypair_v2.go
@@ -46,7 +46,7 @@ func resourceVPCKeypairV2() *schema.Resource {
 	}
 }
 
-func resourceVPCKeypairV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCKeypairV2Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	config := meta.(*Config)
 	selvpcClient, err := config.GetSelVPCClient()
 	if err != nil {
@@ -80,7 +80,7 @@ func resourceVPCKeypairV2Create(ctx context.Context, d *schema.ResourceData, met
 	return resourceVPCKeypairV2Read(ctx, d, meta)
 }
 
-func resourceVPCKeypairV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCKeypairV2Read(_ context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	config := meta.(*Config)
 	selvpcClient, err := config.GetSelVPCClient()
 	if err != nil {
@@ -114,7 +114,7 @@ func resourceVPCKeypairV2Read(_ context.Context, d *schema.ResourceData, meta in
 	return nil
 }
 
-func resourceVPCKeypairV2Delete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCKeypairV2Delete(_ context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	config := meta.(*Config)
 	selvpcClient, err := config.GetSelVPCClient()
 	if err != nil {

--- a/selectel/resource_selectel_vpc_license_v2.go
+++ b/selectel/resource_selectel_vpc_license_v2.go
@@ -78,7 +78,7 @@ func resourceVPCLicenseV2() *schema.Resource {
 	}
 }
 
-func resourceVPCLicenseV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCLicenseV2Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	config := meta.(*Config)
 	projectID := d.Get("project_id").(string)
 	selvpcClient, err := config.GetSelVPCClientWithProjectScope(projectID)
@@ -118,7 +118,7 @@ func resourceVPCLicenseV2Create(ctx context.Context, d *schema.ResourceData, met
 	return resourceVPCLicenseV2Read(ctx, d, meta)
 }
 
-func resourceVPCLicenseV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCLicenseV2Read(_ context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	config := meta.(*Config)
 	projectID := d.Get("project_id").(string)
 	selvpcClient, err := config.GetSelVPCClientWithProjectScope(projectID)
@@ -154,7 +154,7 @@ func resourceVPCLicenseV2Read(_ context.Context, d *schema.ResourceData, meta in
 	return nil
 }
 
-func resourceVPCLicenseV2Delete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCLicenseV2Delete(_ context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	config := meta.(*Config)
 	projectID := d.Get("project_id").(string)
 	selvpcClient, err := config.GetSelVPCClientWithProjectScope(projectID)
@@ -178,7 +178,7 @@ func resourceVPCLicenseV2Delete(_ context.Context, d *schema.ResourceData, meta 
 	return nil
 }
 
-func resourceVPCLicenseV2ImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceVPCLicenseV2ImportState(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if config.ProjectID == "" {
 		return nil, fmt.Errorf("INFRA_PROJECT_ID must be set for the resource import")

--- a/selectel/resource_selectel_vpc_project_v2.go
+++ b/selectel/resource_selectel_vpc_project_v2.go
@@ -126,7 +126,7 @@ func resourceVPCProjectV2() *schema.Resource {
 	}
 }
 
-func resourceVPCProjectV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCProjectV2Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	config := meta.(*Config)
 
 	selvpcClient, err := config.GetSelVPCClient()
@@ -169,7 +169,7 @@ func resourceVPCProjectV2Create(ctx context.Context, d *schema.ResourceData, met
 	return resourceVPCProjectV2Read(ctx, d, meta)
 }
 
-func resourceVPCProjectV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCProjectV2Read(_ context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	config := meta.(*Config)
 	selvpcClient, err := config.GetSelVPCClient()
 	if err != nil {
@@ -211,7 +211,7 @@ func resourceVPCProjectV2Read(_ context.Context, d *schema.ResourceData, meta in
 	return nil
 }
 
-func resourceVPCProjectV2Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCProjectV2Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	config := meta.(*Config)
 	selvpcClient, err := config.GetSelVPCClient()
 	if err != nil {
@@ -232,7 +232,7 @@ func resourceVPCProjectV2Update(ctx context.Context, d *schema.ResourceData, met
 	}
 	if d.HasChange("theme") {
 		hasChange, projectChange = true, true
-		themeMap := d.Get("theme").(map[string]interface{})
+		themeMap := d.Get("theme").(map[string]any)
 		updateThemeOpts := resourceProjectV2UpdateThemeOptsFromMap(themeMap)
 		projectOpts.Theme = updateThemeOpts
 	}
@@ -271,7 +271,7 @@ func resourceVPCProjectV2Update(ctx context.Context, d *schema.ResourceData, met
 	return resourceVPCProjectV2Read(ctx, d, meta)
 }
 
-func resourceVPCProjectV2Delete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCProjectV2Delete(_ context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	config := meta.(*Config)
 	selvpcClient, err := config.GetSelVPCClient()
 	if err != nil {

--- a/selectel/resource_selectel_vpc_project_v2_test.go
+++ b/selectel/resource_selectel_vpc_project_v2_test.go
@@ -240,12 +240,12 @@ func TestResourceVPCProjectV2QuotasOptsFromSet(t *testing.T) {
 	resourceQuotas := &schema.Set{
 		F: resourceQuotasHashSetFunc(),
 	}
-	resourceQuotas.Add(map[string]interface{}{
+	resourceQuotas.Add(map[string]any{
 		"region": region,
 		"zone":   zone,
 		"value":  100,
 	})
-	quotaSet.Add(map[string]interface{}{
+	quotaSet.Add(map[string]any{
 		"resource_name":   "volume_gigabytes_fast",
 		"resource_quotas": resourceQuotas,
 	})
@@ -280,12 +280,12 @@ func TestResourceVPCProjectV2QuotasOptsFromListNoName(t *testing.T) {
 	resourceQuotas := &schema.Set{
 		F: resourceQuotasHashSetFunc(),
 	}
-	resourceQuotas.Add(map[string]interface{}{
+	resourceQuotas.Add(map[string]any{
 		"region": "ru-3",
 		"zone":   "ru-3a",
 		"value":  100,
 	})
-	quotaSet.Add(map[string]interface{}{
+	quotaSet.Add(map[string]any{
 		"resource_quotas": resourceQuotas,
 	})
 
@@ -298,8 +298,8 @@ func TestResourceVPCProjectV2QuotasOptsFromListNoName(t *testing.T) {
 func TestResourceVPCProjectV2QuotasOptsFromListNoQuotas(t *testing.T) {
 	quotaSet := schema.NewSet(
 		schema.HashResource(resourceVPCProjectV2().Schema["quotas"].Elem.(*schema.Resource)),
-		[]interface{}{
-			map[string]interface{}{
+		[]any{
+			map[string]any{
 				"resource_name": "volume_gigabytes_fast",
 			},
 		})
@@ -311,7 +311,7 @@ func TestResourceVPCProjectV2QuotasOptsFromListNoQuotas(t *testing.T) {
 }
 
 func TestResourceProjectV2UpdateThemeOptsFromMap(t *testing.T) {
-	themeOptsMap := map[string]interface{}{
+	themeOptsMap := map[string]any{
 		"color": "FF0000",
 		"logo":  "fake.png",
 	}

--- a/selectel/resource_selectel_vpc_subnet_v2.go
+++ b/selectel/resource_selectel_vpc_subnet_v2.go
@@ -92,7 +92,7 @@ func resourceVPCSubnetV2() *schema.Resource {
 	}
 }
 
-func resourceVPCSubnetV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCSubnetV2Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	config := meta.(*Config)
 	projectID := d.Get("project_id").(string)
 	selvpcClient, err := config.GetSelVPCClientWithProjectScope(projectID)
@@ -131,7 +131,7 @@ func resourceVPCSubnetV2Create(ctx context.Context, d *schema.ResourceData, meta
 	return resourceVPCSubnetV2Read(ctx, d, meta)
 }
 
-func resourceVPCSubnetV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCSubnetV2Read(_ context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	config := meta.(*Config)
 	projectID := d.Get("project_id").(string)
 	selvpcClient, err := config.GetSelVPCClientWithProjectScope(projectID)
@@ -176,7 +176,7 @@ func resourceVPCSubnetV2Read(_ context.Context, d *schema.ResourceData, meta int
 	return nil
 }
 
-func resourceVPCSubnetV2Delete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCSubnetV2Delete(_ context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	config := meta.(*Config)
 	projectID := d.Get("project_id").(string)
 	selvpcClient, err := config.GetSelVPCClientWithProjectScope(projectID)
@@ -200,7 +200,7 @@ func resourceVPCSubnetV2Delete(_ context.Context, d *schema.ResourceData, meta i
 	return nil
 }
 
-func resourceVPCSubnetV2ImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceVPCSubnetV2ImportState(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if config.ProjectID == "" {
 		return nil, fmt.Errorf("INFRA_PROJECT_ID must be set for the resource import")

--- a/selectel/resourse_selectel_secretsmanager_certificate_v1.go
+++ b/selectel/resourse_selectel_secretsmanager_certificate_v1.go
@@ -131,14 +131,14 @@ func resourceSecretsManagerCertificateV1() *schema.Resource {
 	}
 }
 
-func resourceSecretsManagerCertificateV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSecretsManagerCertificateV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	cl, diagErr := getSecretsManagerClient(d, meta)
 	if diagErr != nil {
 		return diagErr
 	}
 
 	name := d.Get("name").(string)
-	rawCertificates := d.Get("certificates").([]interface{})
+	rawCertificates := d.Get("certificates").([]any)
 	certificates := convertToStringSlice(rawCertificates)
 
 	privateKey := d.Get("private_key").(string)
@@ -163,7 +163,7 @@ func resourceSecretsManagerCertificateV1Create(ctx context.Context, d *schema.Re
 	return resourceSecretsManagerCertificateV1Read(ctx, d, meta)
 }
 
-func resourceSecretsManagerCertificateV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSecretsManagerCertificateV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	cl, diagErr := getSecretsManagerClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -187,7 +187,7 @@ func resourceSecretsManagerCertificateV1Read(ctx context.Context, d *schema.Reso
 	return nil
 }
 
-func resourceSecretsManagerCertificateV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSecretsManagerCertificateV1Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	cl, diagErr := getSecretsManagerClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -205,7 +205,7 @@ func resourceSecretsManagerCertificateV1Update(ctx context.Context, d *schema.Re
 	}
 
 	if d.HasChange("certificates") || d.HasChange("private_key") {
-		rawCertificates := d.Get("certificates").([]interface{})
+		rawCertificates := d.Get("certificates").([]any)
 		certificates := convertToStringSlice(rawCertificates)
 
 		upd := certs.UpdateCertificateVersionRequest{
@@ -226,7 +226,7 @@ func resourceSecretsManagerCertificateV1Update(ctx context.Context, d *schema.Re
 	return resourceSecretsManagerCertificateV1Read(ctx, d, meta)
 }
 
-func resourceSecretsManagerCertificateV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSecretsManagerCertificateV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	cl, diagErr := getSecretsManagerClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -245,7 +245,7 @@ func resourceSecretsManagerCertificateV1Delete(ctx context.Context, d *schema.Re
 // resourceSecretsManagerCertificateV1ImportState —  helper used in Importer: &schema.ResourceImporter
 // to avoid difficulties occurred with required INFRA_PROJECT_ID env in
 // resourceSecretsManagerCertificateV1Read when uising schema.ImportStatePassthroughContext.
-func resourceSecretsManagerCertificateV1ImportState(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceSecretsManagerCertificateV1ImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if config.ProjectID == "" {
 		return nil, errors.New("INFRA_PROJECT_ID must be set for the resource import")
@@ -260,9 +260,9 @@ func resourceSecretsManagerCertificateV1ImportState(ctx context.Context, d *sche
 }
 
 // convertSMIssuedByToList — helper for setting "issued_by" attribute with nested structure.
-func convertSMIssuedByToList(ib certs.IssuedBy) []interface{} {
-	return []interface{}{
-		map[string]interface{}{
+func convertSMIssuedByToList(ib certs.IssuedBy) []any {
+	return []any{
+		map[string]any{
 			"country":        convertToInterfaceSlice(ib.Country),
 			"locality":       convertToInterfaceSlice(ib.Locality),
 			"serial_number":  ib.SerialNumber,
@@ -272,9 +272,9 @@ func convertSMIssuedByToList(ib certs.IssuedBy) []interface{} {
 }
 
 // convertValidityToList — helper for setting "validity" attribute with nested structure.
-func convertSMValidityToList(validity certs.Validity) []interface{} {
-	return []interface{}{
-		map[string]interface{}{
+func convertSMValidityToList(validity certs.Validity) []any {
+	return []any{
+		map[string]any{
 			"basic_constraints": validity.BasicConstraints,
 			"not_after":         validity.NotAfter,
 			"not_before":        validity.NotBefore,

--- a/selectel/resourse_selectel_secretsmanager_secret_v1.go
+++ b/selectel/resourse_selectel_secretsmanager_secret_v1.go
@@ -65,7 +65,7 @@ func resourceSecretsManagerSecretV1() *schema.Resource {
 	}
 }
 
-func resourceSecretsManagerSecretV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSecretsManagerSecretV1Create(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	cl, diagErr := getSecretsManagerClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -94,7 +94,7 @@ func resourceSecretsManagerSecretV1Create(ctx context.Context, d *schema.Resourc
 	return resourceSecretsManagerSecretV1Read(ctx, d, meta)
 }
 
-func resourceSecretsManagerSecretV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSecretsManagerSecretV1Read(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	cl, diagErr := getSecretsManagerClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -123,7 +123,7 @@ func resourceSecretsManagerSecretV1Read(ctx context.Context, d *schema.ResourceD
 	return nil
 }
 
-func resourceSecretsManagerSecretV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSecretsManagerSecretV1Delete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	cl, diagErr := getSecretsManagerClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -141,7 +141,7 @@ func resourceSecretsManagerSecretV1Delete(ctx context.Context, d *schema.Resourc
 	return nil
 }
 
-func resourceSecretsManagerSecretV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSecretsManagerSecretV1Update(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	cl, diagErr := getSecretsManagerClient(d, meta)
 	if diagErr != nil {
 		return diagErr
@@ -168,7 +168,7 @@ func resourceSecretsManagerSecretV1Update(ctx context.Context, d *schema.Resourc
 // resourceSecretsManagerSecretV1ImportState —  helper used in Importer: &schema.ResourceImporter
 // to avoid difficulties occurred with required INFRA_PROJECT_ID env in
 // resourceSecretsManagerSecretV1Read when uising schema.ImportStatePassthroughContext.
-func resourceSecretsManagerSecretV1ImportState(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceSecretsManagerSecretV1ImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 	if config.ProjectID == "" {
 		return nil, errors.New("INFRA_PROJECT_ID must be set for the resource import")

--- a/selectel/secretsmanager.go
+++ b/selectel/secretsmanager.go
@@ -8,7 +8,7 @@ import (
 	"github.com/selectel/secretsmanager-go"
 )
 
-func getSecretsManagerClient(d *schema.ResourceData, meta interface{}) (*secretsmanager.Client, diag.Diagnostics) {
+func getSecretsManagerClient(d *schema.ResourceData, meta any) (*secretsmanager.Client, diag.Diagnostics) {
 	config := meta.(*Config)
 
 	selvpcClient, err := config.GetSelVPCClientWithProjectScope(d.Get("project_id").(string))
@@ -41,7 +41,7 @@ func getSecretsManagerClient(d *schema.ResourceData, meta interface{}) (*secrets
 	return cl, nil
 }
 
-func getSecretsManagerClientForAccImportTests(meta interface{}) (*secretsmanager.Client, diag.Diagnostics) {
+func getSecretsManagerClientForAccImportTests(meta any) (*secretsmanager.Client, diag.Diagnostics) {
 	config := meta.(*Config)
 
 	selvpcClient, err := config.GetSelVPCClientWithProjectScope(config.ProjectID)
@@ -61,7 +61,7 @@ func getSecretsManagerClientForAccImportTests(meta interface{}) (*secretsmanager
 	return cl, nil
 }
 
-func convertToStringSlice(sl []interface{}) []string {
+func convertToStringSlice(sl []any) []string {
 	result := make([]string, len(sl))
 	for i := range sl {
 		result[i] = sl[i].(string)
@@ -70,8 +70,8 @@ func convertToStringSlice(sl []interface{}) []string {
 	return result
 }
 
-func convertToInterfaceSlice(sl []string) []interface{} {
-	result := make([]interface{}, len(sl))
+func convertToInterfaceSlice(sl []string) []any {
+	result := make([]any, len(sl))
 	for i := range sl {
 		result[i] = sl[i]
 	}

--- a/selectel/waiters/cloudbackup/plan.go
+++ b/selectel/waiters/cloudbackup/plan.go
@@ -38,7 +38,7 @@ func WaitForPlanV2StartedState(
 }
 
 func planV2RefreshFunc(ctx context.Context, client *cloudbackup.ServiceClient, id string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		p, _, err := client.Plan(ctx, id)
 		if err != nil {
 			return nil, "", err
@@ -74,7 +74,7 @@ func WaitForPlanV2Deleted(
 }
 
 func planV2DeleteRefreshFunc(ctx context.Context, client *cloudbackup.ServiceClient, id string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		p, resp, err := client.Plan(ctx, id)
 		switch {
 		case resp != nil && resp.StatusCode == http.StatusNotFound:

--- a/selectel/waiters/dbaas/acl.go
+++ b/selectel/waiters/dbaas/acl.go
@@ -43,7 +43,7 @@ func WaitForDBaaSACLV1ActiveState(
 }
 
 func DBaaSACLV1DeleteStateRefreshFunc(ctx context.Context, client *dbaas.API, aclID string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		d, err := client.ACL(ctx, aclID)
 		if err != nil {
 			var dbaasError *dbaas.DBaaSAPIError
@@ -59,7 +59,7 @@ func DBaaSACLV1DeleteStateRefreshFunc(ctx context.Context, client *dbaas.API, ac
 }
 
 func dbaasACLV1StateRefreshFunc(ctx context.Context, client *dbaas.API, aclID string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		d, err := client.ACL(ctx, aclID)
 		if err != nil {
 			return nil, "", err

--- a/selectel/waiters/dbaas/database.go
+++ b/selectel/waiters/dbaas/database.go
@@ -43,7 +43,7 @@ func WaitForDBaaSDatabaseV1ActiveState(
 }
 
 func DBaaSDatabaseV1DeleteStateRefreshFunc(ctx context.Context, client *dbaas.API, datastoreID string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		d, err := client.Database(ctx, datastoreID)
 		if err != nil {
 			var dbaasError *dbaas.DBaaSAPIError
@@ -59,7 +59,7 @@ func DBaaSDatabaseV1DeleteStateRefreshFunc(ctx context.Context, client *dbaas.AP
 }
 
 func dbaasDatabaseV1StateRefreshFunc(ctx context.Context, client *dbaas.API, databaseID string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		d, err := client.Database(ctx, databaseID)
 		if err != nil {
 			return nil, "", err

--- a/selectel/waiters/dbaas/datastore.go
+++ b/selectel/waiters/dbaas/datastore.go
@@ -44,7 +44,7 @@ func WaitForDBaaSDatastoreV1ActiveState(
 }
 
 func DBaaSDatastoreV1DeleteStateRefreshFunc(ctx context.Context, client *dbaas.API, datastoreID string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		d, err := client.Datastore(ctx, datastoreID)
 		if err != nil {
 			var dbaasError *dbaas.DBaaSAPIError
@@ -60,7 +60,7 @@ func DBaaSDatastoreV1DeleteStateRefreshFunc(ctx context.Context, client *dbaas.A
 }
 
 func dbaasDatastoreV1StateRefreshFunc(ctx context.Context, client *dbaas.API, datastoreID string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		d, err := client.Datastore(ctx, datastoreID)
 		if err != nil {
 			return nil, "", err

--- a/selectel/waiters/dbaas/extension.go
+++ b/selectel/waiters/dbaas/extension.go
@@ -42,7 +42,7 @@ func WaitForDBaaSExtensionV1ActiveState(
 }
 
 func DBaaSExtensionV1DeleteStateRefreshFunc(ctx context.Context, client *dbaas.API, extensionID string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		d, err := client.Extension(ctx, extensionID)
 		if err != nil {
 			var dbaasError *dbaas.DBaaSAPIError
@@ -58,7 +58,7 @@ func DBaaSExtensionV1DeleteStateRefreshFunc(ctx context.Context, client *dbaas.A
 }
 
 func dbaasExtensionV1StateRefreshFunc(ctx context.Context, client *dbaas.API, extensionID string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		d, err := client.Extension(ctx, extensionID)
 		if err != nil {
 			return nil, "", err

--- a/selectel/waiters/dbaas/grant.go
+++ b/selectel/waiters/dbaas/grant.go
@@ -42,7 +42,7 @@ func WaitForDBaaSGrantV1ActiveState(
 }
 
 func DBaaSGrantV1DeleteStateRefreshFunc(ctx context.Context, client *dbaas.API, grantID string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		d, err := client.Grant(ctx, grantID)
 		if err != nil {
 			var dbaasError *dbaas.DBaaSAPIError
@@ -58,7 +58,7 @@ func DBaaSGrantV1DeleteStateRefreshFunc(ctx context.Context, client *dbaas.API, 
 }
 
 func dbaasGrantV1StateRefreshFunc(ctx context.Context, client *dbaas.API, grantID string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		d, err := client.Grant(ctx, grantID)
 		if err != nil {
 			return nil, "", err

--- a/selectel/waiters/dbaas/logical_replication_slot.go
+++ b/selectel/waiters/dbaas/logical_replication_slot.go
@@ -43,7 +43,7 @@ func WaitForDBaaSLogicalReplicationSlotV1ActiveState(
 }
 
 func DBaaSLogicalReplicationSlotV1DeleteStateRefreshFunc(ctx context.Context, client *dbaas.API, slotID string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		d, err := client.LogicalReplicationSlot(ctx, slotID)
 		if err != nil {
 			var dbaasError *dbaas.DBaaSAPIError
@@ -59,7 +59,7 @@ func DBaaSLogicalReplicationSlotV1DeleteStateRefreshFunc(ctx context.Context, cl
 }
 
 func dbaasLogicalReplicationSlotV1StateRefreshFunc(ctx context.Context, client *dbaas.API, slotID string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		d, err := client.LogicalReplicationSlot(ctx, slotID)
 		if err != nil {
 			return nil, "", err

--- a/selectel/waiters/dbaas/topic.go
+++ b/selectel/waiters/dbaas/topic.go
@@ -43,7 +43,7 @@ func WaitForDBaaSTopicV1ActiveState(
 }
 
 func DBaaSTopicV1DeleteStateRefreshFunc(ctx context.Context, client *dbaas.API, topicID string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		d, err := client.Topic(ctx, topicID)
 		if err != nil {
 			var dbaasError *dbaas.DBaaSAPIError
@@ -59,7 +59,7 @@ func DBaaSTopicV1DeleteStateRefreshFunc(ctx context.Context, client *dbaas.API, 
 }
 
 func dbaasTopicV1StateRefreshFunc(ctx context.Context, client *dbaas.API, topicID string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		d, err := client.Topic(ctx, topicID)
 		if err != nil {
 			return nil, "", err

--- a/selectel/waiters/dbaas/user.go
+++ b/selectel/waiters/dbaas/user.go
@@ -43,7 +43,7 @@ func WaitForDBaaSUserV1ActiveState(
 }
 
 func DBaaSUserV1DeleteStateRefreshFunc(ctx context.Context, client *dbaas.API, userID string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		d, err := client.User(ctx, userID)
 		if err != nil {
 			var dbaasError *dbaas.DBaaSAPIError
@@ -59,7 +59,7 @@ func DBaaSUserV1DeleteStateRefreshFunc(ctx context.Context, client *dbaas.API, u
 }
 
 func dbaasUserV1StateRefreshFunc(ctx context.Context, client *dbaas.API, userID string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		d, err := client.User(ctx, userID)
 		if err != nil {
 			return nil, "", err

--- a/selectel/waiters/dedicated/boot.go
+++ b/selectel/waiters/dedicated/boot.go
@@ -39,7 +39,7 @@ func WaitForServersServerInstallNewOSV1ActiveState(
 func serversServerInstallNewOSV1StateRefreshFunc(
 	ctx context.Context, client *dedicated.ServiceClient, resourceID string, timer *time.Timer,
 ) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		select {
 		case <-timer.C:
 			log.Printf("[WARN] reinstalling the OS is taking more than 30 minutes, contact support")

--- a/selectel/waiters/dedicated/server.go
+++ b/selectel/waiters/dedicated/server.go
@@ -39,7 +39,7 @@ func WaitForServersServerV1ActiveState(
 }
 
 func serversServerV1StateRefreshFunc(ctx context.Context, client *dedicated.ServiceClient, id string, timer *time.Timer) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		select {
 		case <-timer.C:
 			log.Printf("[WARN] operation is taking more than 30 minutes, contact support")

--- a/selectel/waiters/globalrouter/globalrouter.go
+++ b/selectel/waiters/globalrouter/globalrouter.go
@@ -200,7 +200,7 @@ func WaitForStaticRouteV1Deleted(
 }
 
 func routerV1RefreshFunc(ctx context.Context, client *globalrouter.ServiceClient, id string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		p, _, err := client.Router(ctx, id)
 		if err != nil {
 			return nil, "", err
@@ -215,7 +215,7 @@ func routerV1RefreshFunc(ctx context.Context, client *globalrouter.ServiceClient
 }
 
 func routerV1DeleteRefreshFunc(ctx context.Context, client *globalrouter.ServiceClient, id string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		p, resp, err := client.Router(ctx, id)
 		switch {
 		case resp != nil && resp.StatusCode == http.StatusNotFound:
@@ -229,7 +229,7 @@ func routerV1DeleteRefreshFunc(ctx context.Context, client *globalrouter.Service
 }
 
 func networkV1RefreshFunc(ctx context.Context, client *globalrouter.ServiceClient, id string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		p, _, err := client.Network(ctx, id)
 		if err != nil {
 			return nil, "", err
@@ -244,7 +244,7 @@ func networkV1RefreshFunc(ctx context.Context, client *globalrouter.ServiceClien
 }
 
 func networkV1DeleteRefreshFunc(ctx context.Context, client *globalrouter.ServiceClient, id string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		p, resp, err := client.Network(ctx, id)
 		switch {
 		case resp != nil && resp.StatusCode == http.StatusNotFound:
@@ -258,7 +258,7 @@ func networkV1DeleteRefreshFunc(ctx context.Context, client *globalrouter.Servic
 }
 
 func subnetV1RefreshFunc(ctx context.Context, client *globalrouter.ServiceClient, id string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		p, _, err := client.Subnet(ctx, id)
 		if err != nil {
 			return nil, "", err
@@ -273,7 +273,7 @@ func subnetV1RefreshFunc(ctx context.Context, client *globalrouter.ServiceClient
 }
 
 func subnetV1DeleteRefreshFunc(ctx context.Context, client *globalrouter.ServiceClient, id string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		p, resp, err := client.Subnet(ctx, id)
 		switch {
 		case resp != nil && resp.StatusCode == http.StatusNotFound:
@@ -287,7 +287,7 @@ func subnetV1DeleteRefreshFunc(ctx context.Context, client *globalrouter.Service
 }
 
 func staticRouteV1RefreshFunc(ctx context.Context, client *globalrouter.ServiceClient, id string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		p, _, err := client.StaticRoute(ctx, id)
 		if err != nil {
 			return nil, "", err
@@ -302,7 +302,7 @@ func staticRouteV1RefreshFunc(ctx context.Context, client *globalrouter.ServiceC
 }
 
 func staticRouteV1DeleteRefreshFunc(ctx context.Context, client *globalrouter.ServiceClient, id string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		p, resp, err := client.StaticRoute(ctx, id)
 		switch {
 		case resp != nil && resp.StatusCode == http.StatusNotFound:


### PR DESCRIPTION
1. bump golang to 1.26
2. run go fix ./...
3. add go fix to github workflow (CI)
4. bump golangci-lint to v2.11.3 (due to golang version update) 