### PR TITLE
feat(iam): add OIDC federations resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/selectel/domains-go v1.0.2
 	github.com/selectel/globalrouter-go v1.2.0
 	github.com/selectel/go-selvpcclient/v4 v4.2.0
-	github.com/selectel/iam-go v0.8.1
+	github.com/selectel/iam-go v0.8.2-0.20260402132528-00c244ccdefb
 	github.com/selectel/mks-go v1.0.0
 	github.com/selectel/private-dns-go v1.0.0
 	github.com/selectel/secretsmanager-go v0.2.1

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/selectel/domains-go v1.0.2
 	github.com/selectel/globalrouter-go v1.2.0
 	github.com/selectel/go-selvpcclient/v4 v4.2.0
-	github.com/selectel/iam-go v0.8.2-0.20260402132528-00c244ccdefb
+	github.com/selectel/iam-go v0.9.0
 	github.com/selectel/mks-go v1.0.0
 	github.com/selectel/private-dns-go v1.0.0
 	github.com/selectel/secretsmanager-go v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -202,8 +202,8 @@ github.com/selectel/globalrouter-go v1.2.0 h1:hNwxN9YAEaGSsveZ35u1m3CqTWjKIyIfvi
 github.com/selectel/globalrouter-go v1.2.0/go.mod h1:3FlK0iJBZx8Lil3KOkOsU72yv7EcetdV7xNOvfX2+/U=
 github.com/selectel/go-selvpcclient/v4 v4.2.0 h1:tVqSAdmNcdshv3AgfaIwGHs1oLk4jX8Tm+ccMg1rBmc=
 github.com/selectel/go-selvpcclient/v4 v4.2.0/go.mod h1:eFhL1KUW159KOJVeGO7k/Uxl0TYd/sBkWXjuF5WxmYk=
-github.com/selectel/iam-go v0.8.1 h1:bImeUgoDu/2JAH5AFwcnrDz4Kjf3tk855llYhH0qJM8=
-github.com/selectel/iam-go v0.8.1/go.mod h1:OIAkW7MZK97YUm+uvUgYbgDhkI9SdzTCxwd4yZoOR1o=
+github.com/selectel/iam-go v0.8.2-0.20260402132528-00c244ccdefb h1:jENlCFxQa1ycDe2aVudGS/InR0/lNdVlX5NHXDuksh0=
+github.com/selectel/iam-go v0.8.2-0.20260402132528-00c244ccdefb/go.mod h1:OIAkW7MZK97YUm+uvUgYbgDhkI9SdzTCxwd4yZoOR1o=
 github.com/selectel/mks-go v1.0.0 h1:futO/vA+bLM2RyCi0+8u3Xmdvg8HqJouRaOVTmD3Msc=
 github.com/selectel/mks-go v1.0.0/go.mod h1:VxtV3dzwgOEzZc+9VMQb9DvxfSlej2ZQ8jnT8kqIGgU=
 github.com/selectel/private-dns-go v1.0.0 h1:gCi1fAxJ5aRiaSLR6xsIdYTFHGkG29vCZVmaXSWYbKw=

--- a/go.sum
+++ b/go.sum
@@ -202,8 +202,8 @@ github.com/selectel/globalrouter-go v1.2.0 h1:hNwxN9YAEaGSsveZ35u1m3CqTWjKIyIfvi
 github.com/selectel/globalrouter-go v1.2.0/go.mod h1:3FlK0iJBZx8Lil3KOkOsU72yv7EcetdV7xNOvfX2+/U=
 github.com/selectel/go-selvpcclient/v4 v4.2.0 h1:tVqSAdmNcdshv3AgfaIwGHs1oLk4jX8Tm+ccMg1rBmc=
 github.com/selectel/go-selvpcclient/v4 v4.2.0/go.mod h1:eFhL1KUW159KOJVeGO7k/Uxl0TYd/sBkWXjuF5WxmYk=
-github.com/selectel/iam-go v0.8.2-0.20260402132528-00c244ccdefb h1:jENlCFxQa1ycDe2aVudGS/InR0/lNdVlX5NHXDuksh0=
-github.com/selectel/iam-go v0.8.2-0.20260402132528-00c244ccdefb/go.mod h1:OIAkW7MZK97YUm+uvUgYbgDhkI9SdzTCxwd4yZoOR1o=
+github.com/selectel/iam-go v0.9.0 h1:iivGpZR4jHC3sSLWEY+vGPLjgM4kmSjPf1n4xa81yP8=
+github.com/selectel/iam-go v0.9.0/go.mod h1:OIAkW7MZK97YUm+uvUgYbgDhkI9SdzTCxwd4yZoOR1o=
 github.com/selectel/mks-go v1.0.0 h1:futO/vA+bLM2RyCi0+8u3Xmdvg8HqJouRaOVTmD3Msc=
 github.com/selectel/mks-go v1.0.0/go.mod h1:VxtV3dzwgOEzZc+9VMQb9DvxfSlej2ZQ8jnT8kqIGgU=
 github.com/selectel/private-dns-go v1.0.0 h1:gCi1fAxJ5aRiaSLR6xsIdYTFHGkG29vCZVmaXSWYbKw=

--- a/selectel/provider.go
+++ b/selectel/provider.go
@@ -26,6 +26,8 @@ const (
 	objectSAMLFederation               = "saml federation"
 	objectSAMLFederationCertificate    = "saml federation certificate"
 	objectSAMLFederationGroupMappings  = "saml federation group mappings"
+	objectOIDCFederation               = "oidc federation"
+	objectOIDCFederationGroupMappings  = "oidc federation group mappings"
 	objectGroup                        = "group"
 	objectGroupMembership              = "group-membership"
 	objectCluster                      = "cluster"
@@ -163,6 +165,8 @@ func Provider(providerVersion string) *schema.Provider {
 			"selectel_iam_saml_federation_v1":                       resourceIAMSAMLFederationV1(),
 			"selectel_iam_saml_federation_certificate_v1":           resourceIAMSAMLFederationCertificateV1(),
 			"selectel_iam_saml_federation_group_mappings_v1":        resourceIAMSAMLFederationGroupMappingsV1(),
+			"selectel_iam_oidc_federation_v1":                       resourceIAMOIDCFederationV1(),
+			"selectel_iam_oidc_federation_group_mappings_v1":        resourceIAMOIDCFederationGroupMappingsV1(),
 			"selectel_iam_group_v1":                                 resourceIAMGroupV1(),
 			"selectel_iam_group_membership_v1":                      resourceIAMGroupMembershipV1(),
 			"selectel_mks_cluster_v1":                               resourceMKSClusterV1(),

--- a/selectel/resource_selectel_iam_oidc_federation_group_mappings_v1.go
+++ b/selectel/resource_selectel_iam_oidc_federation_group_mappings_v1.go
@@ -1,0 +1,191 @@
+package selectel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/selectel/iam-go/iamerrors"
+	"github.com/selectel/iam-go/service/federations/oidc/groupmappings"
+)
+
+func resourceIAMOIDCFederationGroupMappingsV1() *schema.Resource {
+	return &schema.Resource{
+		Description:   "Represents OIDC Federation group mappings in IAM API",
+		CreateContext: resourceIAMOIDCFederationGroupMappingsV1Create,
+		ReadContext:   resourceIAMOIDCFederationGroupMappingsV1Read,
+		UpdateContext: resourceIAMOIDCFederationGroupMappingsV1Update,
+		DeleteContext: resourceIAMOIDCFederationGroupMappingsV1Delete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"federation_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Federation ID to manage group mappings for.",
+			},
+			"group_mapping": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Description: "List of mappings between internal and external groups.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"internal_group_id": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Internal IAM group ID.",
+						},
+						"external_group_id": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "External identity provider group ID.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceIAMOIDCFederationGroupMappingsV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	iamClient, diagErr := getIAMClient(meta)
+	if diagErr != nil {
+		return diagErr
+	}
+
+	federationID := d.Get("federation_id").(string)
+	request := expandOIDCFederationGroupMappings(d)
+
+	log.Print(msgCreate(objectOIDCFederationGroupMappings, fmt.Sprintf("federation_id: %s, group_mappings: %+v", federationID, request.GroupMappings)))
+
+	err := iamClient.OIDCFederations.GroupMappings.Update(ctx, federationID, request)
+	if err != nil {
+		return diag.FromErr(errCreatingObject(objectOIDCFederationGroupMappings, err))
+	}
+
+	d.SetId(federationID)
+
+	return resourceIAMOIDCFederationGroupMappingsV1Read(ctx, d, meta)
+}
+
+func resourceIAMOIDCFederationGroupMappingsV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	iamClient, diagErr := getIAMClient(meta)
+	if diagErr != nil {
+		return diagErr
+	}
+
+	federationID := d.Id()
+	if federationID == "" {
+		if v, ok := d.GetOk("federation_id"); ok {
+			federationID = v.(string)
+		}
+	}
+
+	log.Print(msgGet(objectOIDCFederationGroupMappings, federationID))
+
+	mappings, err := iamClient.OIDCFederations.GroupMappings.List(ctx, federationID)
+	if err != nil {
+		if errors.Is(err, iamerrors.ErrFederationNotFound) {
+			d.SetId("")
+			return nil
+		}
+
+		return diag.FromErr(errGettingObject(objectOIDCFederationGroupMappings, federationID, err))
+	}
+
+	d.Set("federation_id", federationID)
+	d.Set("group_mapping", flattenOIDCFederationGroupMappings(mappings.GroupMappings))
+
+	return nil
+}
+
+func resourceIAMOIDCFederationGroupMappingsV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	iamClient, diagErr := getIAMClient(meta)
+	if diagErr != nil {
+		return diagErr
+	}
+
+	federationID := d.Get("federation_id").(string)
+	if federationID == "" {
+		federationID = d.Id()
+	}
+
+	request := expandOIDCFederationGroupMappings(d)
+
+	log.Print(msgUpdate(objectOIDCFederationGroupMappings, federationID, fmt.Sprintf("group_mappings: %+v", request.GroupMappings)))
+
+	err := iamClient.OIDCFederations.GroupMappings.Update(ctx, federationID, request)
+	if err != nil {
+		return diag.FromErr(errUpdatingObject(objectOIDCFederationGroupMappings, federationID, err))
+	}
+
+	d.SetId(federationID)
+
+	return resourceIAMOIDCFederationGroupMappingsV1Read(ctx, d, meta)
+}
+
+func resourceIAMOIDCFederationGroupMappingsV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	iamClient, diagErr := getIAMClient(meta)
+	if diagErr != nil {
+		return diagErr
+	}
+
+	federationID := d.Id()
+	if federationID == "" {
+		if v, ok := d.GetOk("federation_id"); ok {
+			federationID = v.(string)
+		}
+	}
+
+	log.Print(msgDelete(objectOIDCFederationGroupMappings, federationID))
+
+	emptyRequest := groupmappings.GroupMappingsRequest{
+		GroupMappings: []groupmappings.GroupMapping{},
+	}
+
+	err := iamClient.OIDCFederations.GroupMappings.Update(ctx, federationID, emptyRequest)
+	if err != nil && !errors.Is(err, iamerrors.ErrFederationNotFound) {
+		return diag.FromErr(errDeletingObject(objectOIDCFederationGroupMappings, federationID, err))
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func expandOIDCFederationGroupMappings(d *schema.ResourceData) groupmappings.GroupMappingsRequest {
+	rawMappings := d.Get("group_mapping").([]interface{})
+
+	mappings := make([]groupmappings.GroupMapping, 0, len(rawMappings))
+
+	for _, raw := range rawMappings {
+		mappingData := raw.(map[string]interface{})
+
+		mappings = append(mappings, groupmappings.GroupMapping{
+			InternalGroupID: mappingData["internal_group_id"].(string),
+			ExternalGroupID: mappingData["external_group_id"].(string),
+		})
+	}
+
+	return groupmappings.GroupMappingsRequest{
+		GroupMappings: mappings,
+	}
+}
+
+func flattenOIDCFederationGroupMappings(mappings []groupmappings.GroupMapping) []interface{} {
+	result := make([]interface{}, 0, len(mappings))
+
+	for _, mapping := range mappings {
+		result = append(result, map[string]interface{}{
+			"internal_group_id": mapping.InternalGroupID,
+			"external_group_id": mapping.ExternalGroupID,
+		})
+	}
+
+	return result
+}

--- a/selectel/resource_selectel_iam_oidc_federation_group_mappings_v1_test.go
+++ b/selectel/resource_selectel_iam_oidc_federation_group_mappings_v1_test.go
@@ -1,0 +1,146 @@
+package selectel
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIAMV1OIDCFederationGroupMappingsBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccSelectelPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIAMV1OIDCFederationGroupMappingsBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("selectel_iam_oidc_federation_group_mappings_v1.group_mappings_tf_acc_test_1", "id"),
+					resource.TestCheckResourceAttrSet("selectel_iam_oidc_federation_group_mappings_v1.group_mappings_tf_acc_test_1", "federation_id"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_group_mappings_v1.group_mappings_tf_acc_test_1", "group_mapping.0.external_group_id", "external-group-1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIAMV1OIDCFederationGroupMappingsUpdate(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccSelectelPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIAMV1OIDCFederationGroupMappingsBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("selectel_iam_oidc_federation_group_mappings_v1.group_mappings_tf_acc_test_1", "id"),
+					resource.TestCheckResourceAttrSet("selectel_iam_oidc_federation_group_mappings_v1.group_mappings_tf_acc_test_1", "federation_id"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_group_mappings_v1.group_mappings_tf_acc_test_1", "group_mapping.#", "1"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_group_mappings_v1.group_mappings_tf_acc_test_1", "group_mapping.0.external_group_id", "external-group-1"),
+				),
+			},
+			{
+				Config: testAccIAMV1OIDCFederationGroupMappingsUpdate(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("selectel_iam_oidc_federation_group_mappings_v1.group_mappings_tf_acc_test_1", "id"),
+					resource.TestCheckResourceAttrSet("selectel_iam_oidc_federation_group_mappings_v1.group_mappings_tf_acc_test_1", "federation_id"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_group_mappings_v1.group_mappings_tf_acc_test_1", "group_mapping.#", "2"),
+				),
+			},
+			{
+				Config: testAccIAMV1OIDCFederationGroupMappingsBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("selectel_iam_oidc_federation_group_mappings_v1.group_mappings_tf_acc_test_1", "id"),
+					resource.TestCheckResourceAttrSet("selectel_iam_oidc_federation_group_mappings_v1.group_mappings_tf_acc_test_1", "federation_id"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_group_mappings_v1.group_mappings_tf_acc_test_1", "group_mapping.#", "1"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_group_mappings_v1.group_mappings_tf_acc_test_1", "group_mapping.0.external_group_id", "external-group-1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccIAMV1OIDCFederationGroupMappingsBasic() string {
+	return `
+resource "selectel_iam_group_v1" "group_tf_acc_test_1" {
+  name = "test-group-mapping-1"
+  role {
+    role_name = "reader"
+    scope     = "account"
+  }
+}
+
+resource "selectel_iam_group_v1" "group_tf_acc_test_2" {
+  name = "test-group-mapping-2"
+  role {
+    role_name = "reader"
+    scope     = "account"
+  }
+}
+
+resource "selectel_iam_oidc_federation_v1" "federation_tf_acc_test_1" {
+  name                  = "federation name"
+  description           = "simple description"
+  issuer                = "http://localhost:8080/realms/master"
+  client_id             = "my-client-id"
+  client_secret         = "my-client-secret"
+  auth_url              = "http://localhost:8080/realms/master/protocol/openid-connect/auth"
+  token_url             = "http://localhost:8080/realms/master/protocol/openid-connect/token"
+  jwks_url              = "http://localhost:8080/realms/master/protocol/openid-connect/certs"
+  session_max_age_hours = 24
+}
+
+resource "selectel_iam_oidc_federation_group_mappings_v1" "group_mappings_tf_acc_test_1" {
+  federation_id = selectel_iam_oidc_federation_v1.federation_tf_acc_test_1.id
+
+  group_mapping {
+    internal_group_id = selectel_iam_group_v1.group_tf_acc_test_1.id
+    external_group_id = "external-group-1"
+  }
+}
+`
+}
+
+func testAccIAMV1OIDCFederationGroupMappingsUpdate() string {
+	return `
+resource "selectel_iam_group_v1" "group_tf_acc_test_1" {
+  name = "test-group-mapping-1"
+  role {
+    role_name = "reader"
+    scope     = "account"
+  }
+}
+
+resource "selectel_iam_group_v1" "group_tf_acc_test_2" {
+  name = "test-group-mapping-2"
+  role {
+    role_name = "reader"
+    scope     = "account"
+  }
+}
+
+resource "selectel_iam_oidc_federation_v1" "federation_tf_acc_test_1" {
+  name                  = "federation name"
+  description           = "simple description"
+  issuer                = "http://localhost:8080/realms/master"
+  client_id             = "my-client-id"
+  client_secret         = "my-client-secret"
+  auth_url              = "http://localhost:8080/realms/master/protocol/openid-connect/auth"
+  token_url             = "http://localhost:8080/realms/master/protocol/openid-connect/token"
+  jwks_url              = "http://localhost:8080/realms/master/protocol/openid-connect/certs"
+  session_max_age_hours = 24
+}
+
+resource "selectel_iam_oidc_federation_group_mappings_v1" "group_mappings_tf_acc_test_1" {
+  federation_id = selectel_iam_oidc_federation_v1.federation_tf_acc_test_1.id
+
+  group_mapping {
+    internal_group_id = selectel_iam_group_v1.group_tf_acc_test_1.id
+    external_group_id = "external-group-1"
+  }
+
+  group_mapping {
+    internal_group_id = selectel_iam_group_v1.group_tf_acc_test_2.id
+    external_group_id = "external-group-2"
+  }
+}
+`
+}

--- a/selectel/resource_selectel_iam_oidc_federation_v1.go
+++ b/selectel/resource_selectel_iam_oidc_federation_v1.go
@@ -8,16 +8,16 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/selectel/iam-go/iamerrors"
-	"github.com/selectel/iam-go/service/federations/saml"
+	"github.com/selectel/iam-go/service/federations/oidc"
 )
 
-func resourceIAMSAMLFederationV1() *schema.Resource {
+func resourceIAMOIDCFederationV1() *schema.Resource {
 	return &schema.Resource{
-		Description:   "Represents a SAML Federation in IAM API",
-		CreateContext: resourceIAMSAMLFederationV1Create,
-		ReadContext:   resourceIAMSAMLFederationV1Read,
-		UpdateContext: resourceIAMSAMLFederationV1Update,
-		DeleteContext: resourceIAMSAMLFederationV1Delete,
+		Description:   "Represents an OIDC Federation in IAM API",
+		CreateContext: resourceIAMOIDCFederationV1Create,
+		ReadContext:   resourceIAMOIDCFederationV1Read,
+		UpdateContext: resourceIAMOIDCFederationV1Update,
+		DeleteContext: resourceIAMOIDCFederationV1Delete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -43,16 +43,31 @@ func resourceIAMSAMLFederationV1() *schema.Resource {
 				Required:    true,
 				Description: "ID of the credential provider.",
 			},
-			"sso_url": {
+			"client_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "Single sign-on endpoint URL.",
+				Description: "Client ID for OIDC authentication.",
 			},
-			"sign_authn_requests": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     false,
-				Description: "Should sign authentication requests.",
+			"client_secret": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Sensitive:   true,
+				Description: "Client secret for OIDC authentication.",
+			},
+			"auth_url": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Authorization endpoint URL.",
+			},
+			"token_url": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Token endpoint URL.",
+			},
+			"jwks_url": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "JWKS endpoint URL.",
 			},
 			"auto_users_creation": {
 				Type:        schema.TypeBool,
@@ -71,12 +86,6 @@ func resourceIAMSAMLFederationV1() *schema.Resource {
 				Required:    true,
 				Description: "Session lifetime.",
 			},
-			"force_authn": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     false,
-				Description: "Enable forced authentication at every login.",
-			},
 			"account_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -86,46 +95,48 @@ func resourceIAMSAMLFederationV1() *schema.Resource {
 	}
 }
 
-func resourceIAMSAMLFederationV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIAMOIDCFederationV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamClient, diagErr := getIAMClient(meta)
 	if diagErr != nil {
 		return diagErr
 	}
 
-	opts := saml.CreateRequest{
+	opts := oidc.CreateRequest{
 		Name:               d.Get("name").(string),
 		Description:        d.Get("description").(string),
 		Alias:              d.Get("alias").(string),
 		Issuer:             d.Get("issuer").(string),
-		SSOUrl:             d.Get("sso_url").(string),
-		SignAuthnRequests:  d.Get("sign_authn_requests").(bool),
-		ForceAuthn:         d.Get("force_authn").(bool),
+		ClientID:           d.Get("client_id").(string),
+		ClientSecret:       d.Get("client_secret").(string),
+		AuthURL:            d.Get("auth_url").(string),
+		TokenURL:           d.Get("token_url").(string),
+		JWKSURL:            d.Get("jwks_url").(string),
 		SessionMaxAgeHours: d.Get("session_max_age_hours").(int),
 		AutoUsersCreation:  d.Get("auto_users_creation").(bool),
 		EnableGroupMapping: d.Get("enable_group_mappings").(bool),
 	}
-	log.Print(msgCreate(objectSAMLFederation, opts))
+	log.Print(msgCreate(objectOIDCFederation, opts))
 
-	federation, err := iamClient.SAMLFederations.Create(ctx, opts)
+	federation, err := iamClient.OIDCFederations.Create(ctx, opts)
 	if err != nil {
-		return diag.FromErr(errCreatingObject(objectSAMLFederation, err))
+		return diag.FromErr(errCreatingObject(objectOIDCFederation, err))
 	}
 
 	d.SetId(federation.ID)
 
-	return resourceIAMSAMLFederationV1Read(ctx, d, meta)
+	return resourceIAMOIDCFederationV1Read(ctx, d, meta)
 }
 
-func resourceIAMSAMLFederationV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIAMOIDCFederationV1Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamClient, diagErr := getIAMClient(meta)
 	if diagErr != nil {
 		return diagErr
 	}
 
-	log.Print(msgGet(objectSAMLFederation, d.Id()))
-	federation, err := iamClient.SAMLFederations.Get(ctx, d.Id())
+	log.Print(msgGet(objectOIDCFederation, d.Id()))
+	federation, err := iamClient.OIDCFederations.Get(ctx, d.Id())
 	if err != nil {
-		return diag.FromErr(errGettingObject(objectSAMLFederation, d.Id(), err))
+		return diag.FromErr(errGettingObject(objectOIDCFederation, d.Id(), err))
 	}
 
 	d.Set("account_id", federation.AccountID)
@@ -133,9 +144,11 @@ func resourceIAMSAMLFederationV1Read(ctx context.Context, d *schema.ResourceData
 	d.Set("alias", federation.Alias)
 	d.Set("description", federation.Description)
 	d.Set("issuer", federation.Issuer)
-	d.Set("sso_url", federation.SSOURL)
-	d.Set("sign_authn_requests", federation.SignAuthnRequests)
-	d.Set("force_authn", federation.ForceAuthn)
+	d.Set("client_id", federation.ClientID)
+	d.Set("client_secret", federation.ClientSecret)
+	d.Set("auth_url", federation.AuthURL)
+	d.Set("token_url", federation.TokenURL)
+	d.Set("jwks_url", federation.JWKSURL)
 	d.Set("auto_users_creation", federation.AutoUsersCreation)
 	d.Set("enable_group_mappings", federation.EnableGroupMapping)
 	d.Set("session_max_age_hours", federation.SessionMaxAgeHours)
@@ -143,50 +156,50 @@ func resourceIAMSAMLFederationV1Read(ctx context.Context, d *schema.ResourceData
 	return nil
 }
 
-func resourceIAMSAMLFederationV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIAMOIDCFederationV1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamClient, diagErr := getIAMClient(meta)
 	if diagErr != nil {
 		return diagErr
 	}
 
-	signAuthnRequests := d.Get("sign_authn_requests").(bool)
-	forceAuthn := d.Get("force_authn").(bool)
 	description := d.Get("description").(string)
 	autoUsersCreation := d.Get("auto_users_creation").(bool)
 	enableGroupMappings := d.Get("enable_group_mappings").(bool)
 
-	opts := saml.UpdateRequest{
+	opts := oidc.UpdateRequest{
 		Name:               d.Get("name").(string),
 		Description:        &description,
 		Alias:              d.Get("alias").(string),
 		Issuer:             d.Get("issuer").(string),
-		SSOUrl:             d.Get("sso_url").(string),
-		SignAuthnRequests:  &signAuthnRequests,
-		ForceAuthn:         &forceAuthn,
+		ClientID:           d.Get("client_id").(string),
+		ClientSecret:       d.Get("client_secret").(string),
+		AuthURL:            d.Get("auth_url").(string),
+		TokenURL:           d.Get("token_url").(string),
+		JWKSURL:            d.Get("jwks_url").(string),
 		SessionMaxAgeHours: d.Get("session_max_age_hours").(int),
 		AutoUsersCreation:  &autoUsersCreation,
 		EnableGroupMapping: &enableGroupMappings,
 	}
 
-	log.Print(msgUpdate(objectSAMLFederation, d.Id(), opts))
-	err := iamClient.SAMLFederations.Update(ctx, d.Id(), opts)
+	log.Print(msgUpdate(objectOIDCFederation, d.Id(), opts))
+	err := iamClient.OIDCFederations.Update(ctx, d.Id(), opts)
 	if err != nil {
-		return diag.FromErr(errUpdatingObject(objectSAMLFederation, d.Id(), err))
+		return diag.FromErr(errUpdatingObject(objectOIDCFederation, d.Id(), err))
 	}
 
-	return resourceIAMSAMLFederationV1Read(ctx, d, meta)
+	return resourceIAMOIDCFederationV1Read(ctx, d, meta)
 }
 
-func resourceIAMSAMLFederationV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIAMOIDCFederationV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	iamClient, diagErr := getIAMClient(meta)
 	if diagErr != nil {
 		return diagErr
 	}
 
-	log.Print(msgDelete(objectSAMLFederation, d.Id()))
-	err := iamClient.SAMLFederations.Delete(ctx, d.Id())
+	log.Print(msgDelete(objectOIDCFederation, d.Id()))
+	err := iamClient.OIDCFederations.Delete(ctx, d.Id())
 	if err != nil && !errors.Is(err, iamerrors.ErrFederationNotFound) {
-		return diag.FromErr(errDeletingObject(objectSAMLFederation, d.Id(), err))
+		return diag.FromErr(errDeletingObject(objectOIDCFederation, d.Id(), err))
 	}
 
 	return nil

--- a/selectel/resource_selectel_iam_oidc_federation_v1_test.go
+++ b/selectel/resource_selectel_iam_oidc_federation_v1_test.go
@@ -1,0 +1,117 @@
+package selectel
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIAMV1OIDCFederationBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccSelectelPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIAMV1OIDCFederationBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "id"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "name", "federation name"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "alias", "federation-alias"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "description", "simple description"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "issuer", "http://localhost:8080/realms/master"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "client_id", "my-client-id"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "client_secret", "my-client-secret"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "auth_url", "http://localhost:8080/realms/master/protocol/openid-connect/auth"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "token_url", "http://localhost:8080/realms/master/protocol/openid-connect/token"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "jwks_url", "http://localhost:8080/realms/master/protocol/openid-connect/certs"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "auto_users_creation", "true"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "enable_group_mappings", "true"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "session_max_age_hours", "24"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIAMV1OIDCFederationUpdate(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccSelectelPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIAMV1OIDCFederationBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "id"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "name", "federation name"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "alias", "federation-alias"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "description", "simple description"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "issuer", "http://localhost:8080/realms/master"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "client_id", "my-client-id"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "client_secret", "my-client-secret"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "auth_url", "http://localhost:8080/realms/master/protocol/openid-connect/auth"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "token_url", "http://localhost:8080/realms/master/protocol/openid-connect/token"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "jwks_url", "http://localhost:8080/realms/master/protocol/openid-connect/certs"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "auto_users_creation", "true"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "enable_group_mappings", "true"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "session_max_age_hours", "24"),
+				),
+			},
+			{
+				Config: testAccIAMV1OIDCFederationUpdate(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "id"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "name", "federation name 2"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "alias", "federation-alias-2"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "description", "simple description 2"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "issuer", "http://localhost:8080/realms/master"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "client_id", "my-client-id"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "client_secret", "my-client-secret"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "auth_url", "http://localhost:8080/realms/master/protocol/openid-connect/auth"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "token_url", "http://localhost:8080/realms/master/protocol/openid-connect/token"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "jwks_url", "http://localhost:8080/realms/master/protocol/openid-connect/certs"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "auto_users_creation", "false"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "enable_group_mappings", "false"),
+					resource.TestCheckResourceAttr("selectel_iam_oidc_federation_v1.federation_tf_acc_test_1", "session_max_age_hours", "24"),
+				),
+			},
+		},
+	})
+}
+
+func testAccIAMV1OIDCFederationBasic() string {
+	return `
+resource "selectel_iam_oidc_federation_v1" "federation_tf_acc_test_1" {
+  name                  = "federation name"
+  alias                 = "federation-alias"
+  description           = "simple description"
+  issuer                = "http://localhost:8080/realms/master"
+  client_id             = "my-client-id"
+  client_secret         = "my-client-secret"
+  auth_url              = "http://localhost:8080/realms/master/protocol/openid-connect/auth"
+  token_url             = "http://localhost:8080/realms/master/protocol/openid-connect/token"
+  jwks_url              = "http://localhost:8080/realms/master/protocol/openid-connect/certs"
+  auto_users_creation   = true
+  enable_group_mappings = true
+  session_max_age_hours = 24
+}
+`
+}
+
+func testAccIAMV1OIDCFederationUpdate() string {
+	return `
+resource "selectel_iam_oidc_federation_v1" "federation_tf_acc_test_1" {
+  name                  = "federation name 2"
+  alias                 = "federation-alias-2"
+  description           = "simple description 2"
+  issuer                = "http://localhost:8080/realms/master"
+  client_id             = "my-client-id"
+  client_secret         = "my-client-secret"
+  auth_url              = "http://localhost:8080/realms/master/protocol/openid-connect/auth"
+  token_url             = "http://localhost:8080/realms/master/protocol/openid-connect/token"
+  jwks_url              = "http://localhost:8080/realms/master/protocol/openid-connect/certs"
+  auto_users_creation   = false
+  enable_group_mappings = false
+  session_max_age_hours = 24
+}
+`
+}

--- a/website/docs/r/iam_group_membership_v1.html.markdown
+++ b/website/docs/r/iam_group_membership_v1.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages group membership for Selectel products using public API v1.
 Selectel products support Identity and Access Management (IAM).
-For more information about groups, see the [official Selectel documentation](https://docs.selectel.ru/en/control-panel-actions/users-and-roles/groups/).
+For more information about groups, see the [official Selectel documentation](https://docs.selectel.ru/en/access-control/groups/about-groups/).
 
 ## Example Usage
 

--- a/website/docs/r/iam_group_v1.html.markdown
+++ b/website/docs/r/iam_group_v1.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Creates and manages a user group for Selectel products using public API v1.
 Selectel products support Identity and Access Management (IAM).
-For more information about user groups, see the [official Selectel documentation](https://docs.selectel.ru/en/control-panel-actions/users-and-roles/groups/).
+For more information about user groups, see the [official Selectel documentation](https://docs.selectel.ru/en/access-control/groups/about-groups/).
 
 ## Example Usage
 
@@ -37,7 +37,7 @@ resource "selectel_iam_group_v1" "group_1" {
 
     * `scope` - (Required) Scope of the role. Available scopes are `account` and `project`. If `scope` is `project`, the `project_id` argument is required.
 
-    * `project_id` - (Optional) Unique identifier of the associated project. If `scope` is `project`, the `project_id` argument is required. Retrieved from the [selectel_vpc_project_v2](https://registry.terraform.io/providers/selectel/selectel/latest/docs/resources/vpc_project_v2) resource. Learn more about [Projects](https://docs.selectel.ru/en/control-panel-actions/projects/about-projects/).
+    * `project_id` - (Optional) Unique identifier of the associated project. If `scope` is `project`, the `project_id` argument is required. Retrieved from the [selectel_vpc_project_v2](https://registry.terraform.io/providers/selectel/selectel/latest/docs/resources/vpc_project_v2) resource. Learn more about [Projects](https://docs.selectel.ru/en/access-control/projects/about-projects/).
 
 ### Roles
 
@@ -68,10 +68,10 @@ terraform import selectel_iam_group_v1.group_1 <group_id>
 
 where:
 
-* `<account_id>` — Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/). Learn more about [Registration](https://docs.selectel.ru/en/control-panel-actions/account/registration/).
+* `<account_id>` — Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/). Learn more about [Registration](https://docs.selectel.ru/en/account/registration/).
 
-* `<username>` — Name of the service user. To get the name, in the [Control panel](https://my.selectel.ru/iam/users_management/users?type=service), go to **Identity & Access Management** ⟶ **User management** ⟶ the **Service users** tab ⟶ copy the name of the required user. Learn more about [Service Users](https://docs.selectel.ru/en/control-panel-actions/users-and-roles/user-types-and-roles/).
+* `<username>` — Name of the service user. To get the name, in the [Control panel](https://my.selectel.ru/iam/service-users), go to **Account** ⟶ the **Service users** tab ⟶ copy the name of the required user. Learn more about [Service Users](https://docs.selectel.ru/en/access-control/user-types/).
 
 * `<password>` — Password of the service user.
 
-* `<group_id>` — Unique identifier of the group, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the group ID, use either [iam-go](https://github.com/selectel/iam-go) or [IAM API](https://developers.selectel.ru/docs/control-panel/iam/).
+* `<group_id>` — Unique identifier of the group, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the group ID, use either [Control panel](https://my.selectel.ru/iam/groups) or [IAM API](https://developers.selectel.ru/docs/control-panel/iam/).

--- a/website/docs/r/iam_group_v1.html.markdown
+++ b/website/docs/r/iam_group_v1.html.markdown
@@ -74,4 +74,4 @@ where:
 
 * `<password>` — Password of the service user.
 
-* `<group_id>` — Unique identifier of the group, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the group ID, use either [Control panel](https://my.selectel.ru/iam/groups) or [IAM API](https://developers.selectel.ru/docs/control-panel/iam/).
+* `<group_id>` — Unique identifier of the group, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the group ID, use either [Control panel](https://my.selectel.ru/iam/groups) or [IAM API](https://docs.selectel.ru/en/api/users-and-roles/).

--- a/website/docs/r/iam_group_v1.html.markdown
+++ b/website/docs/r/iam_group_v1.html.markdown
@@ -31,29 +31,13 @@ resource "selectel_iam_group_v1" "group_1" {
 
 * `description` - (Optional) Group description.
 
-* `role` - (Optional) Manages group roles. You can add multiple roles – each role in a separate block. For more information about roles, see the [Roles](#roles) section.
+* `role` - (Optional) Manages group roles. You can add multiple roles – each role in a separate block.
 
-    * `role_name` - (Required) Role name. Available role names are `iam_admin`, `member`, `reader`, and `billing`.
+    * `role_name` - (Required) Role name.
 
     * `scope` - (Required) Scope of the role. Available scopes are `account` and `project`. If `scope` is `project`, the `project_id` argument is required.
 
     * `project_id` - (Optional) Unique identifier of the associated project. If `scope` is `project`, the `project_id` argument is required. Retrieved from the [selectel_vpc_project_v2](https://registry.terraform.io/providers/selectel/selectel/latest/docs/resources/vpc_project_v2) resource. Learn more about [Projects](https://docs.selectel.ru/en/access-control/projects/about-projects/).
-
-### Roles
-
-To assign roles, use the following values for `scope` and `role_name`:
-
-* Account administrator - `scope` is `account`, `role_name` is `member`.
-
-* Billing administrator - `scope` is `account`, `role_name` is `billing`.
-
-* User administrator - `scope` is `account`, `role_name` is `iam_admin`.
-
-* Project administrator - `scope` is `project`, `role_name` is `member`.
-
-* Account viewer - `scope` is `account`, `role_name` is `reader`.
-
-* Project viewer - `scope` is `project`, `role_name` is `reader`.
 
 ## Import
 

--- a/website/docs/r/iam_oidc_federation_group_mappings_v1.html.markdown
+++ b/website/docs/r/iam_oidc_federation_group_mappings_v1.html.markdown
@@ -1,0 +1,82 @@
+---
+layout: "selectel"
+page_title: "Selectel: selectel_iam_oidc_federation_group_mappings_v1"
+sidebar_current: "docs-selectel-resource-iam-oidc-federation-group-mappings-v1"
+description: |-
+  Manages OIDC Federation group mappings for Selectel products using public API v1.
+---
+
+# selectel\_iam\_oidc\_federation\_group\_mappings\_v1
+
+Manages OIDC federation group mappings for Selectel products using public API v1.
+Selectel products support Identity and Access Management (IAM).
+For more information about federations, see the [official Selectel documentation](https://docs.selectel.ru/access-control/federations/).
+
+## Example Usage
+
+```hcl
+resource "selectel_iam_group_v1" "group_1" {
+  name = "example-group"
+
+  role {
+    role_name = "reader"
+    scope     = "account"
+  }
+}
+
+resource "selectel_iam_oidc_federation_v1" "federation_1" {
+  name                  = "Federation name"
+  description           = "Federation description"
+  issuer                = "https://idp.example.com/realms/master"
+  client_id             = "my-client-id"
+  client_secret         = "my-client-secret"
+  auth_url              = "https://idp.example.com/realms/master/protocol/openid-connect/auth"
+  token_url             = "https://idp.example.com/realms/master/protocol/openid-connect/token"
+  jwks_url              = "https://idp.example.com/realms/master/protocol/openid-connect/certs"
+  session_max_age_hours = 24
+}
+
+resource "selectel_iam_oidc_federation_group_mappings_v1" "group_mappings_1" {
+  federation_id = selectel_iam_oidc_federation_v1.federation_1.id
+
+  group_mapping {
+    internal_group_id = selectel_iam_group_v1.group_1.id
+    external_group_id = "external-group-1"
+  }
+}
+```
+
+## Argument Reference
+
+* `federation_id` - (Required) Federation ID to manage group mappings for.
+
+* `group_mapping` - (Required) Defines mappings between internal IAM groups and external identity provider groups. You can add multiple mappings – each mapping in a separate block.
+
+    * `internal_group_id` - (Required) Internal IAM group ID.
+
+    * `external_group_id` - (Required) External identity provider group ID.
+
+## Attributes Reference
+
+* `id` - Resource ID. Equals the `federation_id` value.
+
+## Import
+
+You can import OIDC Federation group mappings:
+
+```shell
+export OS_DOMAIN_NAME=<account_id>
+export OS_USERNAME=<username>
+export OS_PASSWORD=<password>
+terraform import selectel_iam_oidc_federation_group_mappings_v1.group_mappings_1 <federation_id>
+```
+
+where:
+
+* `<account_id>` — Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/). Learn more about [Registration](https://docs.selectel.ru/account/registration/).
+
+* `<username>` — Name of the service user. To get the name, in the [Control panel](https://my.selectel.ru/iam/service-users), go to **Account** ⟶ the **Service users** tab ⟶ copy the name of the required user. Learn more about [Service Users](https://docs.selectel.ru/access-control/user-types/).
+
+* `<password>` — Password of the service user.
+
+* `<federation_id>` — Unique identifier of the federation, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the federation ID, use either [Control Panel](https://my.selectel.ru/iam/federations) or [Federations API](https://docs.selectel.ru/api/federations/).

--- a/website/docs/r/iam_oidc_federation_group_mappings_v1.html.markdown
+++ b/website/docs/r/iam_oidc_federation_group_mappings_v1.html.markdown
@@ -16,7 +16,7 @@ For more information about federations, see the [official Selectel documentation
 
 ```hcl
 resource "selectel_iam_group_v1" "group_1" {
-  name = "example-group"
+  name = "Group name"
 
   role {
     role_name = "reader"

--- a/website/docs/r/iam_oidc_federation_group_mappings_v1.html.markdown
+++ b/website/docs/r/iam_oidc_federation_group_mappings_v1.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages OIDC federation group mappings for Selectel products using public API v1.
 Selectel products support Identity and Access Management (IAM).
-For more information about federations, see the [official Selectel documentation](https://docs.selectel.ru/en/access-control/federations/).
+For more information about group mappings, see the [official Selectel documentation](https://docs.selectel.ru/en/access-control/groups/mapping/).
 
 ## Example Usage
 
@@ -48,7 +48,7 @@ resource "selectel_iam_oidc_federation_group_mappings_v1" "group_mappings_1" {
 
 ## Argument Reference
 
-* `federation_id` - (Required) Federation ID to manage group mappings.
+* `federation_id` - (Required) Unique identifier of the federation, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the federation ID, in the [Control Panel](https://my.selectel.ru/iam/federations), go to **Account** → **Federations** → copy the ID under the federation name.
 
 * `group_mapping` - (Required) Defines mappings between internal IAM groups and external identity provider groups. You can add multiple mappings – each mapping in a separate block.
 
@@ -79,4 +79,4 @@ where:
 
 * `<password>` — Password of the service user.
 
-* `<federation_id>` — Unique identifier of the federation, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the federation ID, use either [Control Panel](https://my.selectel.ru/iam/federations) or [Federations API](https://docs.selectel.ru/en/api/federations/).
+* `<federation_id>` — Unique identifier of the federation, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the federation ID, in the [Control Panel](https://my.selectel.ru/iam/federations), go to **Account** → **Federations** → copy the ID under the federation name.

--- a/website/docs/r/iam_oidc_federation_group_mappings_v1.html.markdown
+++ b/website/docs/r/iam_oidc_federation_group_mappings_v1.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages OIDC federation group mappings for Selectel products using public API v1.
 Selectel products support Identity and Access Management (IAM).
-For more information about federations, see the [official Selectel documentation](https://docs.selectel.ru/access-control/federations/).
+For more information about federations, see the [official Selectel documentation](https://docs.selectel.ru/en/access-control/federations/).
 
 ## Example Usage
 
@@ -48,7 +48,7 @@ resource "selectel_iam_oidc_federation_group_mappings_v1" "group_mappings_1" {
 
 ## Argument Reference
 
-* `federation_id` - (Required) Federation ID to manage group mappings for.
+* `federation_id` - (Required) Federation ID to manage group mappings.
 
 * `group_mapping` - (Required) Defines mappings between internal IAM groups and external identity provider groups. You can add multiple mappings – each mapping in a separate block.
 
@@ -73,10 +73,10 @@ terraform import selectel_iam_oidc_federation_group_mappings_v1.group_mappings_1
 
 where:
 
-* `<account_id>` — Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/). Learn more about [Registration](https://docs.selectel.ru/account/registration/).
+* `<account_id>` — Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/). Learn more about [Registration](https://docs.selectel.ru/en/account/registration/).
 
-* `<username>` — Name of the service user. To get the name, in the [Control panel](https://my.selectel.ru/iam/service-users), go to **Account** ⟶ the **Service users** tab ⟶ copy the name of the required user. Learn more about [Service Users](https://docs.selectel.ru/access-control/user-types/).
+* `<username>` — Name of the service user. To get the name, in the [Control panel](https://my.selectel.ru/iam/service-users), go to **Account** ⟶ the **Service users** tab ⟶ copy the name of the required user. Learn more about [Service Users](https://docs.selectel.ru/en/access-control/user-types/).
 
 * `<password>` — Password of the service user.
 
-* `<federation_id>` — Unique identifier of the federation, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the federation ID, use either [Control Panel](https://my.selectel.ru/iam/federations) or [Federations API](https://docs.selectel.ru/api/federations/).
+* `<federation_id>` — Unique identifier of the federation, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the federation ID, use either [Control Panel](https://my.selectel.ru/iam/federations) or [Federations API](https://docs.selectel.ru/en/api/federations/).

--- a/website/docs/r/iam_oidc_federation_v1.html.markdown
+++ b/website/docs/r/iam_oidc_federation_v1.html.markdown
@@ -1,0 +1,83 @@
+---
+layout: "selectel"
+page_title: "Selectel: selectel_iam_oidc_federation_v1"
+sidebar_current: "docs-selectel-resource-iam-oidc-federation-v1"
+description: |-
+  Creates and manages OIDC Federation for Selectel products using public API v1.
+---
+
+# selectel\_iam\_oidc\_federation\_v1
+
+Manages OIDC Federation for Selectel products using public API v1.
+Selectel products support Identity and Access Management (IAM).
+For more information about federations, see the [official Selectel documentation](https://docs.selectel.ru/en/control-panel-actions/users-and-roles/federations/).
+
+## Example Usage
+
+```hcl
+resource "selectel_iam_oidc_federation_v1" "federation_1" {
+  name                  = "federation name"
+  alias                 = "federation-alias"
+  description           = "simple description"
+  issuer                = "https://idp.example.com/realms/master"
+  client_id             = "my-client-id"
+  client_secret         = "my-client-secret"
+  auth_url              = "https://idp.example.com/realms/master/protocol/openid-connect/auth"
+  token_url             = "https://idp.example.com/realms/master/protocol/openid-connect/token"
+  jwks_url              = "https://idp.example.com/realms/master/protocol/openid-connect/certs"
+  auto_users_creation   = true
+  enable_group_mappings = true
+  session_max_age_hours = 24
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) Federation name.
+
+* `alias` - (Optional) Federation alias.
+
+* `description` - (Optional) Federation description.
+
+* `issuer` - (Required) Identifier of the credential provider.
+
+* `client_id` - (Required) Client ID for OIDC authentication.
+
+* `client_secret` - (Required, Sensitive) Client secret for OIDC authentication.
+
+* `auth_url` - (Required) Authorization endpoint URL.
+
+* `token_url` - (Required) Token endpoint URL.
+
+* `jwks_url` - (Required) JWKS endpoint URL.
+
+* `auto_users_creation` - (Optional) Enables automatic creation of users for this federation.
+
+* `enable_group_mappings` - (Optional) Enables group mappings for this federation.
+
+* `session_max_age_hours` - (Required) Session lifetime.
+
+## Attributes Reference
+
+* `account_id` - Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/). Learn more about [Registration](https://docs.selectel.ru/en/control-panel-actions/account/registration/).
+
+## Import
+
+You can import a federation:
+
+```shell
+export OS_DOMAIN_NAME=<account_id>
+export OS_USERNAME=<username>
+export OS_PASSWORD=<password>
+terraform import selectel_iam_oidc_federation_v1.federation_1 <federation_id>
+```
+
+where:
+
+* `<account_id>` — Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/). Learn more about [Registration](https://docs.selectel.ru/en/control-panel-actions/account/registration/).
+
+* `<username>` — Name of the service user. To get the name, in the [Control panel](https://my.selectel.ru/iam/users_management/users?type=service), go to **Identity & Access Management** ⟶ **User management** ⟶ the **Service users** tab ⟶ copy the name of the required user. Learn more about [Service Users](https://docs.selectel.ru/en/control-panel-actions/users-and-roles/user-types-and-roles/).
+
+* `<password>` — Password of the service user.
+
+* `<federation_id>` — Unique identifier of the federation, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the federation ID, use either [Control Panel](https://my.selectel.ru/iam/federations) or [IAM API](https://developers.selectel.ru/docs/control-panel/iam/).

--- a/website/docs/r/iam_oidc_federation_v1.html.markdown
+++ b/website/docs/r/iam_oidc_federation_v1.html.markdown
@@ -10,15 +10,15 @@ description: |-
 
 Manages OIDC Federation for Selectel products using public API v1.
 Selectel products support Identity and Access Management (IAM).
-For more information about federations, see the [official Selectel documentation](https://docs.selectel.ru/en/control-panel-actions/users-and-roles/federations/).
+For more information about federations, see the [official Selectel documentation](https://docs.selectel.ru/en/access-control/federations/).
 
 ## Example Usage
 
 ```hcl
 resource "selectel_iam_oidc_federation_v1" "federation_1" {
-  name                  = "federation name"
+  name                  = "Federation name"
   alias                 = "federation-alias"
-  description           = "simple description"
+  description           = "Federation description"
   issuer                = "https://idp.example.com/realms/master"
   client_id             = "my-client-id"
   client_secret         = "my-client-secret"
@@ -45,13 +45,13 @@ resource "selectel_iam_oidc_federation_v1" "federation_1" {
 
 * `client_secret` - (Required, Sensitive) Client secret for OIDC authentication.
 
-* `auth_url` - (Required) Authorization endpoint URL.
+* `auth_url` - (Required) URL of the authorization endpoint used to authenticate users via the OIDC provider.
 
-* `token_url` - (Required) Token endpoint URL.
+* `token_url` - (Required) URL of the token endpoint.
 
-* `jwks_url` - (Required) JWKS endpoint URL.
+* `jwks_url` - (Required) URL of the JWKS endpoint with certificates used for token verification.
 
-* `auto_users_creation` - (Optional) Enables automatic creation of users for this federation.
+* `auto_users_creation` - (Optional) Enables automatic user creation for this federation.
 
 * `enable_group_mappings` - (Optional) Enables group mappings for this federation.
 
@@ -59,7 +59,7 @@ resource "selectel_iam_oidc_federation_v1" "federation_1" {
 
 ## Attributes Reference
 
-* `account_id` - Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/). Learn more about [Registration](https://docs.selectel.ru/en/control-panel-actions/account/registration/).
+* `account_id` - Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/). Learn more about [Registration](https://docs.selectel.ru/en/account/registration/).
 
 ## Import
 
@@ -74,10 +74,10 @@ terraform import selectel_iam_oidc_federation_v1.federation_1 <federation_id>
 
 where:
 
-* `<account_id>` — Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/). Learn more about [Registration](https://docs.selectel.ru/en/control-panel-actions/account/registration/).
+* `<account_id>` — Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/). Learn more about [Registration](https://docs.selectel.ru/en/account/registration/).
 
-* `<username>` — Name of the service user. To get the name, in the [Control panel](https://my.selectel.ru/iam/users_management/users?type=service), go to **Identity & Access Management** ⟶ **User management** ⟶ the **Service users** tab ⟶ copy the name of the required user. Learn more about [Service Users](https://docs.selectel.ru/en/control-panel-actions/users-and-roles/user-types-and-roles/).
+* `<username>` — Name of the service user. To get the name, in the [Control panel](https://my.selectel.ru/iam/service-users), go to **Account** ⟶ the **Service users** tab ⟶ copy the name of the required user. Learn more about [Service Users](https://docs.selectel.ru/en/access-control/user-types/).
 
 * `<password>` — Password of the service user.
 
-* `<federation_id>` — Unique identifier of the federation, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the federation ID, use either [Control Panel](https://my.selectel.ru/iam/federations) or [IAM API](https://developers.selectel.ru/docs/control-panel/iam/).
+* `<federation_id>` — Unique identifier of the federation, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the federation ID, use either [Control Panel](https://my.selectel.ru/iam/federations) or [Federations API](https://docs.selectel.ru/en/api/federations/).

--- a/website/docs/r/iam_oidc_federation_v1.html.markdown
+++ b/website/docs/r/iam_oidc_federation_v1.html.markdown
@@ -39,9 +39,9 @@ resource "selectel_iam_oidc_federation_v1" "federation_1" {
 
 * `description` - (Optional) Federation description.
 
-* `issuer` - (Required) Identifier of the credential provider.
+* `issuer` - (Required) Unique identifier of the credential provider.
 
-* `client_id` - (Required) Client ID for OIDC authentication.
+* `client_id` - (Required) Unique identifier of the client for OIDC authentication.
 
 * `client_secret` - (Required, Sensitive) Client secret for OIDC authentication.
 
@@ -49,17 +49,17 @@ resource "selectel_iam_oidc_federation_v1" "federation_1" {
 
 * `token_url` - (Required) URL of the token endpoint.
 
-* `jwks_url` - (Required) URL of the JWKS endpoint with certificates used for token verification.
+* `jwks_url` - (Required) URL of the JSON Web Key Set (JWKS) endpoint with certificates used for token verification.
 
 * `auto_users_creation` - (Optional) Enables automatic user creation for this federation.
 
 * `enable_group_mappings` - (Optional) Enables group mappings for this federation.
 
-* `session_max_age_hours` - (Required) Session lifetime.
+* `session_max_age_hours` - (Required) Session lifetime in hours.
 
 ## Attributes Reference
 
-* `account_id` - Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/). Learn more about [Registration](https://docs.selectel.ru/en/account/registration/).
+* `account_id` - Selectel account ID.
 
 ## Import
 
@@ -80,4 +80,4 @@ where:
 
 * `<password>` — Password of the service user.
 
-* `<federation_id>` — Unique identifier of the federation, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the federation ID, use either [Control Panel](https://my.selectel.ru/iam/federations) or [Federations API](https://docs.selectel.ru/en/api/federations/).
+* `<federation_id>` — Unique identifier of the federation, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the federation ID, in the [Control Panel](https://my.selectel.ru/iam/federations), go to **Account** → **Federations** → copy the ID under the federation name.

--- a/website/docs/r/iam_s3_credentials_v1.html.markdown
+++ b/website/docs/r/iam_s3_credentials_v1.html.markdown
@@ -56,6 +56,6 @@ where:
 
 * `<password>` — Password of the service user.
 
-* `<user_id>` — Unique identifier of the service user who owns S3 credentials, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the service user ID, use either [Control panel](https://my.selectel.ru/iam/service-users), or [IAM API](https://developers.selectel.ru/docs/control-panel/iam/).
+* `<user_id>` — Unique identifier of the service user who owns S3 credentials, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the service user ID, use either [Control panel](https://my.selectel.ru/iam/service-users), or [IAM API](https://docs.selectel.ru/en/api/users-and-roles/).
 
 * `<access_key>` — Access Key from S3 credentials. To get the Access Key, in the [Control panel](https://my.selectel.ru/iam/service-users), go to **Account** ⟶ the **Service users** tab ⟶ click on the service user who owns credentials ⟶ copy the Access Key in the **S3 keys** section.

--- a/website/docs/r/iam_s3_credentials_v1.html.markdown
+++ b/website/docs/r/iam_s3_credentials_v1.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # selectel\_iam\_s3_credentials\_v1
 
-Creates and manages S3 credentials for a service user using public API v1. S3 credentials are required to access Selectel Object Storage via S3 API. S3 credentials include Access Key and Secret Key. For more information about S3 сredentials, see the [official Selectel documentation](https://docs.selectel.ru/en/cloud/object-storage/manage/manage-access/#issue-s3-key).
+Creates and manages S3 credentials for a service user using public API v1. S3 credentials are required to access Selectel Object Storage via S3 API. S3 credentials include Access Key and Secret Key. For more information about S3 сredentials, see the [official Selectel documentation](https://docs.selectel.ru/en/s3/manage/manage-access/#issue-s3-key).
 
 ~> **Note:** In S3 credentials, the Secret Key is stored as raw data in a plain-text file. Learn more about [sensitive data in state](https://developer.hashicorp.com/terraform/language/state/sensitive-data).
 
@@ -24,9 +24,9 @@ resource "selectel_iam_s3_credentials_v1" "s3_credentials_1" {
 
 ## Argument Reference
 
-* `user_id` - (Required) Unique identifier of the service user. Changing this creates new credentials. Retrieved from the [selectel_iam_serviceuser_v1](https://registry.terraform.io/providers/selectel/selectel/latest/docs/resources/iam_serviceuser_v1) resource. Learn more about [Service Users](https://docs.selectel.ru/en/control-panel-actions/users-and-roles/user-types-and-roles/).
+* `user_id` - (Required) Unique identifier of the service user. Changing this creates new credentials. Retrieved from the [selectel_iam_serviceuser_v1](https://registry.terraform.io/providers/selectel/selectel/latest/docs/resources/iam_serviceuser_v1) resource. Learn more about [Service Users](https://docs.selectel.ru/en/access-control/user-types/).
 
-* `project_id` - (Required) Unique identifier of the associated project. Changing this creates new credentials. Retrieved from the [selectel_vpc_project_v2](https://registry.terraform.io/providers/selectel/selectel/latest/docs/resources/vpc_project_v2) resource. Learn more about [Projects](https://docs.selectel.ru/en/control-panel-actions/projects/about-projects/).
+* `project_id` - (Required) Unique identifier of the associated project. Changing this creates new credentials. Retrieved from the [selectel_vpc_project_v2](https://registry.terraform.io/providers/selectel/selectel/latest/docs/resources/vpc_project_v2) resource. Learn more about [Projects](https://docs.selectel.ru/en/access-control/projects/about-projects/).
 
 * `name` - (Required) Name of the S3 credentials. Changing this creates new credentials.
 
@@ -50,12 +50,12 @@ terraform import selectel_iam_s3_credentials_v1.s3_credentials_1 <access_key>
 
 where:
 
-* `<account_id>` — Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/). Learn more about [Registration](https://docs.selectel.ru/en/control-panel-actions/account/registration/).
+* `<account_id>` — Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/). Learn more about [Registration](https://docs.selectel.ru/en/account/registration/).
 
-* `<username>` — Name of the service user. To get the name, in the [Control panel](https://my.selectel.ru/iam/users_management/users?type=service), go to **Identity & Access Management** ⟶ **User management** ⟶ the **Service users** tab ⟶ copy the name of the required user. Learn more about [Service Users](https://docs.selectel.ru/en/control-panel-actions/users-and-roles/user-types-and-roles/).
+* `<username>` — Name of the service user. To get the name, in the [Control panel](https://my.selectel.ru/iam/service-users), go to **Account** ⟶ the **Service users** tab ⟶ copy the name of the required user. Learn more about [Service Users](https://docs.selectel.ru/en/access-control/user-types/).
 
 * `<password>` — Password of the service user.
 
-* `<user_id>` — Unique identifier of the service user who owns S3 credentials, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the ID, in the [Control panel](https://my.selectel.ru/iam/users_management/users?type=service), go to **Identity & Access Management** ⟶ **User management** ⟶ the **Service users** tab ⟶ copy the ID under the user name.
+* `<user_id>` — Unique identifier of the service user who owns S3 credentials, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the service user ID, use either [Control panel](https://my.selectel.ru/iam/service-users), or [IAM API](https://developers.selectel.ru/docs/control-panel/iam/).
 
-* `<access_key>` — Access Key from S3 сredentials. To get the Access Key, in the [Control panel](https://my.selectel.ru/iam/users_management/users?type=service), go to **Identity & Access Management** ⟶ **User management** ⟶ the **Service users** tab ⟶ click on the service user who owns credentials ⟶ copy the Access Key in the **S3 keys** section.
+* `<access_key>` — Access Key from S3 credentials. To get the Access Key, in the [Control panel](https://my.selectel.ru/iam/service-users), go to **Account** ⟶ the **Service users** tab ⟶ click on the service user who owns credentials ⟶ copy the Access Key in the **S3 keys** section.

--- a/website/docs/r/iam_saml_federation_certificate_v1.html.markdown
+++ b/website/docs/r/iam_saml_federation_certificate_v1.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages SAML Federation Certificates for Selectel products using public API v1.
 Selectel products support Identity and Access Management (IAM).
-For more information about Federation Certificates, see the [official Selectel documentation](https://docs.selectel.ru/en/control-panel-actions/users-and-roles/federations/certificates/).
+For more information about Federation Certificates, see the [official Selectel documentation](https://docs.selectel.ru/en/access-control/federations/certificates/).
 
 ## Example Usage
 
@@ -36,7 +36,7 @@ resource "selectel_iam_saml_federation_certificate_v1" "certificate" {
 
 ## Attributes Reference
 
-* `account_id` - Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/). Learn more about [Registration](https://docs.selectel.ru/en/control-panel-actions/account/registration/).
+* `account_id` - Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/). Learn more about [Registration](https://docs.selectel.ru/en/account/registration/).
 
 * `not_before` - Issue date of the certificate.
 
@@ -58,12 +58,12 @@ terraform import selectel_iam_saml_federation_certificate_v1.certificate_1 <cert
 
 where:
 
-* `<account_id>` — Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/). Learn more about [Registration](https://docs.selectel.ru/en/control-panel-actions/account/registration/).
+* `<account_id>` — Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/). Learn more about [Registration](https://docs.selectel.ru/en/account/registration/).
 
-* `<username>` — Name of the service user. To get the name, in the [Control panel](https://my.selectel.ru/iam/users_management/users?type=service), go to **Identity & Access Management** ⟶ **User management** ⟶ the **Service users** tab ⟶ copy the name of the required user. Learn more about [Service Users](https://docs.selectel.ru/en/control-panel-actions/users-and-roles/user-types-and-roles/).
+* `<username>` — Name of the service user. To get the name, in the [Control panel](https://my.selectel.ru/iam/service-users), go to **Account** ⟶ the **Service users** tab ⟶ copy the name of the required user. Learn more about [Service Users](https://docs.selectel.ru/en/access-control/user-types/).
 
 * `<password>` — Password of the service user.
 
-* `<federation_id>` — Unique identifier of the associated federation, for which the certificate is issued, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the federation ID, use either [Control Panel](https://my.selectel.ru/iam/federations) or [IAM API](https://developers.selectel.ru/docs/control-panel/iam/).
+* `<federation_id>` — Unique identifier of the associated federation, for which the certificate is issued, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the federation ID, use either [Control Panel](https://my.selectel.ru/iam/federations) or [Federations API](https://docs.selectel.ru/en/api/federations/).
 
 * `<certificate_id>` — Unique identifier of the certificate.

--- a/website/docs/r/iam_saml_federation_certificate_v1.html.markdown
+++ b/website/docs/r/iam_saml_federation_certificate_v1.html.markdown
@@ -36,7 +36,7 @@ resource "selectel_iam_saml_federation_certificate_v1" "certificate" {
 
 ## Attributes Reference
 
-* `account_id` - Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/). Learn more about [Registration](https://docs.selectel.ru/en/account/registration/).
+* `account_id` - Selectel account ID.
 
 * `not_before` - Issue date of the certificate.
 
@@ -64,6 +64,6 @@ where:
 
 * `<password>` — Password of the service user.
 
-* `<federation_id>` — Unique identifier of the associated federation, for which the certificate is issued, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the federation ID, use either [Control Panel](https://my.selectel.ru/iam/federations) or [Federations API](https://docs.selectel.ru/en/api/federations/).
+* `<federation_id>` — Unique identifier of the associated federation, for which the certificate is issued, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the federation ID, in the [Control Panel](https://my.selectel.ru/iam/federations), go to **Account** → **Federations** → copy the ID under the federation name.
 
 * `<certificate_id>` — Unique identifier of the certificate.

--- a/website/docs/r/iam_saml_federation_certificate_v1.html.markdown
+++ b/website/docs/r/iam_saml_federation_certificate_v1.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages SAML Federation Certificates for Selectel products using public API v1.
 Selectel products support Identity and Access Management (IAM).
-For more information about Federation Certificates, see the [official Selectel documentation](https://docs.selectel.ru/en/access-control/federations/certificates/).
+For more information about SAML Federation Certificates, see the [official Selectel documentation](https://docs.selectel.ru/en/access-control/federations/manage-saml/certificates/).
 
 ## Example Usage
 

--- a/website/docs/r/iam_saml_federation_group_mappings_v1.html.markdown
+++ b/website/docs/r/iam_saml_federation_group_mappings_v1.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages SAML federation group mappings for Selectel products using public API v1.
 Selectel products support Identity and Access Management (IAM).
-For more information about federations, see the [official Selectel documentation](https://docs.selectel.ru/en/access-control/federations/).
+For more information about group mappings, see the [official Selectel documentation](https://docs.selectel.ru/en/access-control/groups/mapping/).
 
 ## Example Usage
 
@@ -44,7 +44,7 @@ resource "selectel_iam_saml_federation_group_mappings_v1" "group_mappings_1" {
 
 ## Argument Reference
 
-* `federation_id` - (Required) Federation ID to manage group mappings.
+* `federation_id` - (Required) Unique identifier of the federation, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the federation ID, in the [Control Panel](https://my.selectel.ru/iam/federations), go to **Account** → **Federations** → copy the ID under the federation name.
 
 * `group_mapping` - (Required) Defines mappings between internal IAM groups and external identity provider groups. You can add multiple mappings – each mapping in a separate block.
 
@@ -75,5 +75,5 @@ where:
 
 * `<password>` — Password of the service user.
 
-* `<federation_id>` — Unique identifier of the federation, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the federation ID, use either [Control Panel](https://my.selectel.ru/iam/federations) or [Federations API](https://docs.selectel.ru/en/api/federations/).
+* `<federation_id>` — Unique identifier of the federation, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the federation ID, in the [Control Panel](https://my.selectel.ru/iam/federations), go to **Account** → **Federations** → copy the ID under the federation name.
 

--- a/website/docs/r/iam_saml_federation_group_mappings_v1.html.markdown
+++ b/website/docs/r/iam_saml_federation_group_mappings_v1.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages SAML federation group mappings for Selectel products using public API v1.
 Selectel products support Identity and Access Management (IAM).
-For more information about federations, see the [official Selectel documentation](https://docs.selectel.ru/access-control/federations/).
+For more information about federations, see the [official Selectel documentation](https://docs.selectel.ru/en/access-control/federations/).
 
 ## Example Usage
 
@@ -44,7 +44,7 @@ resource "selectel_iam_saml_federation_group_mappings_v1" "group_mappings_1" {
 
 ## Argument Reference
 
-* `federation_id` - (Required) Federation ID to manage group mappings for.
+* `federation_id` - (Required) Federation ID to manage group mappings.
 
 * `group_mapping` - (Required) Defines mappings between internal IAM groups and external identity provider groups. You can add multiple mappings – each mapping in a separate block.
 
@@ -69,11 +69,11 @@ terraform import selectel_iam_saml_federation_group_mappings_v1.group_mappings_1
 
 where:
 
-* `<account_id>` — Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/). Learn more about [Registration](https://docs.selectel.ru/account/registration/).
+* `<account_id>` — Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/). Learn more about [Registration](https://docs.selectel.ru/en/account/registration/).
 
-* `<username>` — Name of the service user. To get the name, in the [Control panel](https://my.selectel.ru/iam/service-users), go to **Account** ⟶ the **Service users** tab ⟶ copy the name of the required user. Learn more about [Service Users](https://docs.selectel.ru/access-control/user-types/).
+* `<username>` — Name of the service user. To get the name, in the [Control panel](https://my.selectel.ru/iam/service-users), go to **Account** ⟶ the **Service users** tab ⟶ copy the name of the required user. Learn more about [Service Users](https://docs.selectel.ru/en/access-control/user-types/).
 
 * `<password>` — Password of the service user.
 
-* `<federation_id>` — Unique identifier of the federation, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the federation ID, use either [Control Panel](https://my.selectel.ru/iam/federations) or [Federations API](https://docs.selectel.ru/api/federations/).
+* `<federation_id>` — Unique identifier of the federation, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the federation ID, use either [Control Panel](https://my.selectel.ru/iam/federations) or [Federations API](https://docs.selectel.ru/en/api/federations/).
 

--- a/website/docs/r/iam_saml_federation_v1.html.markdown
+++ b/website/docs/r/iam_saml_federation_v1.html.markdown
@@ -10,15 +10,15 @@ description: |-
 
 Manages SAML Federation for Selectel products using public API v1.
 Selectel products support Identity and Access Management (IAM).
-For more information about federations, see the [official Selectel documentation](https://docs.selectel.ru/en/control-panel-actions/users-and-roles/federations/).
+For more information about federations, see the [official Selectel documentation](https://docs.selectel.ru/en/access-control/federations/).
 
 ## Example Usage
 
 ```hcl
 resource "selectel_iam_saml_federation_v1" "federation_1" {
-  name                  = "federation name"
+  name                  = "Federation name"
   alias                 = "federation-alias"
-  description           = "simple description"
+  description           = "Federation description"
   issuer                = "http://localhost:8080/realms/master"
   sso_url               = "http://localhost:8080/realms/master/protocol/saml"
   sign_authn_requests   = true
@@ -45,7 +45,7 @@ resource "selectel_iam_saml_federation_v1" "federation_1" {
 
 * `force_authn` - (Optional) Requires users to authenticate via SSO every time they log in.
 
-* `auto_users_creation` - (Optional) Enables automatic creation of users for this federation.
+* `auto_users_creation` - (Optional) Enables automatic user creation for this federation.
 
 * `enable_group_mappings` - (Optional) Enables group mappings for this federation.
 
@@ -53,7 +53,7 @@ resource "selectel_iam_saml_federation_v1" "federation_1" {
 
 ## Attributes Reference
 
-* `account_id` - Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/). Learn more about [Registration](https://docs.selectel.ru/en/control-panel-actions/account/registration/).
+* `account_id` - Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/). Learn more about [Registration](https://docs.selectel.ru/en/account/registration/).
 
 ## Import
 
@@ -68,10 +68,10 @@ terraform import selectel_iam_saml_federation_v1.federation_1 <federation_id>
 
 where:
 
-* `<account_id>` — Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/). Learn more about [Registration](https://docs.selectel.ru/en/control-panel-actions/account/registration/).
+* `<account_id>` — Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/). Learn more about [Registration](https://docs.selectel.ru/en/account/registration/).
 
-* `<username>` — Name of the service user. To get the name, in the [Control panel](https://my.selectel.ru/iam/users_management/users?type=service), go to **Identity & Access Management** ⟶ **User management** ⟶ the **Service users** tab ⟶ copy the name of the required user. Learn more about [Service Users](https://docs.selectel.ru/en/control-panel-actions/users-and-roles/user-types-and-roles/).
+* `<username>` — Name of the service user. To get the name, in the [Control panel](https://my.selectel.ru/iam/service-users), go to **Account** ⟶ the **Service users** tab ⟶ copy the name of the required user. Learn more about [Service Users](https://docs.selectel.ru/en/access-control/user-types/).
 
 * `<password>` — Password of the service user.
 
-* `<federation_id>` — Unique identifier of the federation, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the federation ID, use either [Control Panel](https://my.selectel.ru/iam/federations) or [IAM API](https://developers.selectel.ru/docs/control-panel/iam/).
+* `<federation_id>` — Unique identifier of the federation, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the federation ID, use either [Control Panel](https://my.selectel.ru/iam/federations) or [Federations API](https://docs.selectel.ru/en/api/federations/).

--- a/website/docs/r/iam_saml_federation_v1.html.markdown
+++ b/website/docs/r/iam_saml_federation_v1.html.markdown
@@ -37,7 +37,7 @@ resource "selectel_iam_saml_federation_v1" "federation_1" {
 
 * `description` - (Optional) Federation description.
 
-* `issuer` - (Required) Identifier of the credential provider.
+* `issuer` - (Required) Unique identifier of the credential provider.
 
 * `sso_url` - (Required) Link to the credential provider login page.
 
@@ -49,11 +49,11 @@ resource "selectel_iam_saml_federation_v1" "federation_1" {
 
 * `enable_group_mappings` - (Optional) Enables group mappings for this federation.
 
-* `session_max_age_hours` - (Required) Session lifetime.
+* `session_max_age_hours` - (Required) Session lifetime in hours.
 
 ## Attributes Reference
 
-* `account_id` - Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/). Learn more about [Registration](https://docs.selectel.ru/en/account/registration/).
+* `account_id` - Selectel account ID.
 
 ## Import
 
@@ -74,4 +74,4 @@ where:
 
 * `<password>` — Password of the service user.
 
-* `<federation_id>` — Unique identifier of the federation, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the federation ID, use either [Control Panel](https://my.selectel.ru/iam/federations) or [Federations API](https://docs.selectel.ru/en/api/federations/).
+* `<federation_id>` — Unique identifier of the federation, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the federation ID, in the [Control Panel](https://my.selectel.ru/iam/federations), go to **Account** → **Federations** → copy the ID under the federation name.

--- a/website/docs/r/iam_serviceuser_v1.html.markdown
+++ b/website/docs/r/iam_serviceuser_v1.html.markdown
@@ -88,4 +88,4 @@ where:
 
 * `<password>` — Password of the service user.
 
-* `<user_id>` — Unique identifier of the service user to import, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the service user ID, use either [Control panel](https://my.selectel.ru/iam/service-users), or [IAM API](https://developers.selectel.ru/docs/control-panel/iam/).
+* `<user_id>` — Unique identifier of the service user to import, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the service user ID, use either [Control panel](https://my.selectel.ru/iam/service-users), or [IAM API](https://docs.selectel.ru/en/api/users-and-roles/).

--- a/website/docs/r/iam_serviceuser_v1.html.markdown
+++ b/website/docs/r/iam_serviceuser_v1.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # selectel\_iam\_serviceuser\_v1
 
-Creates and manages a service user using public API v1. Selectel products support Identity and Access Management (IAM). For more information about service users, see the [official Selectel documentation](https://docs.selectel.ru/en/control-panel-actions/users-and-roles/user-types-and-roles/).
+Creates and manages a service user using public API v1. Selectel products support Identity and Access Management (IAM). For more information about service users, see the [official Selectel documentation](https://docs.selectel.ru/en/access-control/user-types/).
 
 The `selectel_iam_serviceuser_v1` resource replaces the deprecated `selectel_vpc_user_v2` and `selectel_vpc_role_v2` resources. For additional information, see the [Upgrading Terraform Selectel Provider to version 5.0.0](https://registry.terraform.io/providers/selectel/selectel/latest/docs/guides/upgrading_to_version_5) guide.
 
@@ -45,7 +45,7 @@ resource "selectel_iam_serviceuser_v1" "serviceuser_1" {
 
     * `scope` - (Required) Scope of the role. Available scopes are `account` and `project`. If `scope` is `project`, the `project_id` argument is required.
 
-    * `project_id` - (Optional) Unique identifier of the associated project. Changing this creates a new service user. If `scope` is `project`, the `project_id` argument is required. Retrieved from the [selectel_vpc_project_v2](https://registry.terraform.io/providers/selectel/selectel/latest/docs/resources/vpc_project_v2) resource. Learn more about [Projects](https://docs.selectel.ru/en/control-panel-actions/projects/about-projects/).
+    * `project_id` - (Optional) Unique identifier of the associated project. Changing this creates a new service user. If `scope` is `project`, the `project_id` argument is required. Retrieved from the [selectel_vpc_project_v2](https://registry.terraform.io/providers/selectel/selectel/latest/docs/resources/vpc_project_v2) resource. Learn more about [Projects](https://docs.selectel.ru/en/access-control/projects/about-projects/).
 
 * `enabled` - (Optional) Specifies if you can create a IAM token for the service user. Boolean flag, the default value is `true`. Learn more about [IAM tokens](https://docs.selectel.ru/en/api/authorization/).
 
@@ -82,10 +82,10 @@ terraform import selectel_iam_serviceuser_v1.serviceuser_1 <user_id>
 
 where:
 
-* `<account_id>` — Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/). Learn more about [Registration](https://docs.selectel.ru/en/control-panel-actions/account/registration/).
+* `<account_id>` — Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/). Learn more about [Registration](https://docs.selectel.ru/en/account/registration/).
 
-* `<username>` — Name of the service user. To get the name, in the [Control panel](https://my.selectel.ru/iam/users_management/users?type=service), go to **Identity & Access Management** ⟶ **User management** ⟶ the **Service users** tab ⟶ copy the name of the required user. Learn more about [Service Users](https://docs.selectel.ru/en/control-panel-actions/users-and-roles/user-types-and-roles/).
+* `<username>` — Name of the service user. To get the name, in the [Control panel](https://my.selectel.ru/iam/service-users), go to **Account** ⟶ the **Service users** tab ⟶ copy the name of the required user. Learn more about [Service Users](https://docs.selectel.ru/en/access-control/user-types/).
 
 * `<password>` — Password of the service user.
 
-* `<user_id>` — Unique identifier of the service user to import, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the ID, in the [Control panel](https://my.selectel.ru/iam/users_management/users?type=service), go to **Identity & Access Management** ⟶ **User management** ⟶ the **Service users** tab ⟶ copy the ID under the user name.
+* `<user_id>` — Unique identifier of the service user to import, for example, `abc1bb378ac84e1234b869b77aadd2ab`. To get the service user ID, use either [Control panel](https://my.selectel.ru/iam/service-users), or [IAM API](https://developers.selectel.ru/docs/control-panel/iam/).

--- a/website/docs/r/iam_serviceuser_v1.html.markdown
+++ b/website/docs/r/iam_serviceuser_v1.html.markdown
@@ -41,33 +41,13 @@ resource "selectel_iam_serviceuser_v1" "serviceuser_1" {
 
 * `role` - (Optional) Manages service user roles. You can add multiple roles – each role in a separate block. For more information about roles, see the [Roles](#roles) section.
 
-    * `role_name` - (Required) Role name. Available role names are `iam_admin`, `member`, `reader`, `billing`, `object_storage:admin`, and `object_storage_user`.
+    * `role_name` - (Required) Role name.
 
     * `scope` - (Required) Scope of the role. Available scopes are `account` and `project`. If `scope` is `project`, the `project_id` argument is required.
 
     * `project_id` - (Optional) Unique identifier of the associated project. Changing this creates a new service user. If `scope` is `project`, the `project_id` argument is required. Retrieved from the [selectel_vpc_project_v2](https://registry.terraform.io/providers/selectel/selectel/latest/docs/resources/vpc_project_v2) resource. Learn more about [Projects](https://docs.selectel.ru/en/access-control/projects/about-projects/).
 
 * `enabled` - (Optional) Specifies if you can create a IAM token for the service user. Boolean flag, the default value is `true`. Learn more about [IAM tokens](https://docs.selectel.ru/en/api/authorization/).
-
-### Roles
-
-To assign roles, use the following values for `scope` and `role_name`:
-
-* Account administrator - `scope` is `account`, `role_name` is `member`.
-
-* Billing administrator - `scope` is `account`, `role_name` is `billing`.
-
-* User administrator - `scope` is `account`, `role_name` is `iam_admin`.
-
-* Project administrator - `scope` is `project`, `role_name` is `member`.
-
-* Account viewer - `scope` is `account`, `role_name` is `reader`.
-
-* Project viewer - `scope` is `project`, `role_name` is `reader`.
-
-* Object storage admin - `scope` is `project`, `role_name` is `object_storage:admin`.
-
-* Object storage user - `scope` is `project`, `role_name` is `object_storage_user`.
 
 ## Import
 

--- a/website/docs/r/iam_serviceuser_v1.html.markdown
+++ b/website/docs/r/iam_serviceuser_v1.html.markdown
@@ -39,7 +39,7 @@ resource "selectel_iam_serviceuser_v1" "serviceuser_1" {
 
 * `password` - (Required, Sensitive) Password of the service user.
 
-* `role` - (Optional) Manages service user roles. You can add multiple roles – each role in a separate block. For more information about roles, see the [Roles](#roles) section.
+* `role` - (Optional) Manages service user roles. You can add multiple roles – each role in a separate block.
 
     * `role_name` - (Required) Role name.
 

--- a/website/docs/r/iam_user_v1.html.markdown
+++ b/website/docs/r/iam_user_v1.html.markdown
@@ -36,31 +36,11 @@ resource "selectel_iam_user_v1" "user_1" {
 
 * `role` - (Optional) Manages service user roles. You can add multiple roles – each role in a separate block. For more information about roles, see the [Roles](#roles) section.
 
-    * `role_name` - (Required) Role name. Available role names are `iam_admin`, `member`, `reader`, and `billing`.
+    * `role_name` - (Required) Role name.
 
     * `scope` - (Required) Scope of the role. Available scopes are `account` and `project`. If `scope` is `project`, the `project_id` argument is required.
 
     * `project_id` - (Optional) Unique identifier of the associated project. Changing this creates a new service user. If `scope` is `project`, the `project_id` argument is required. Retrieved from the [selectel_vpc_project_v2](https://registry.terraform.io/providers/selectel/selectel/latest/docs/resources/vpc_project_v2) resource. Learn more about [Projects](https://docs.selectel.ru/en/access-control/projects/about-projects/).
-
-### Roles
-
-To assign roles, use the following values for `scope` and `role_name`:
-
-* Account administrator - `scope` is `account`, `role_name` is `member`.
-
-* Billing administrator - `scope` is `account`, `role_name` is `billing`.
-
-* User administrator - `scope` is `account`, `role_name` is `iam_admin`.
-
-* Project administrator - `scope` is `project`, `role_name` is `member`.
-
-* Account viewer - `scope` is `account`, `role_name` is `reader`.
-
-* Project viewer - `scope` is `project`, `role_name` is `reader`.
-
-* Object storage admin - `scope` is `project`, `role_name` is `object_storage:admin`.
-
-* Object storage user - `scope` is `project`, `role_name` is `object_storage_user`.
 
 ## Attributes Reference
 

--- a/website/docs/r/iam_user_v1.html.markdown
+++ b/website/docs/r/iam_user_v1.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # selectel\_iam\_user\_v1
 
-Creates and manages a control panel (local) user or a federated user using public API v1. Selectel products support Identity and Access Management (IAM). For more information about users, see the [official Selectel documentation](https://docs.selectel.ru/en/control-panel-actions/users-and-roles/user-types-and-roles/).
+Creates and manages a control panel (local) user or a federated user using public API v1. Selectel products support Identity and Access Management (IAM). For more information about users, see the [official Selectel documentation](https://docs.selectel.ru/en/access-control/user-types/).
 
 ## Example Usage
 
@@ -40,7 +40,7 @@ resource "selectel_iam_user_v1" "user_1" {
 
     * `scope` - (Required) Scope of the role. Available scopes are `account` and `project`. If `scope` is `project`, the `project_id` argument is required.
 
-    * `project_id` - (Optional) Unique identifier of the associated project. Changing this creates a new service user. If `scope` is `project`, the `project_id` argument is required. Retrieved from the [selectel_vpc_project_v2](https://registry.terraform.io/providers/selectel/selectel/latest/docs/resources/vpc_project_v2) resource. Learn more about [Projects](https://docs.selectel.ru/en/control-panel-actions/projects/about-projects/).
+    * `project_id` - (Optional) Unique identifier of the associated project. Changing this creates a new service user. If `scope` is `project`, the `project_id` argument is required. Retrieved from the [selectel_vpc_project_v2](https://registry.terraform.io/providers/selectel/selectel/latest/docs/resources/vpc_project_v2) resource. Learn more about [Projects](https://docs.selectel.ru/en/access-control/projects/about-projects/).
 
 ### Roles
 
@@ -79,10 +79,10 @@ terraform import selectel_iam_user_v1.user_1 <user_id>
 
 where:
 
-* `<account_id>` — Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/). Learn more about [Registration](https://docs.selectel.ru/en/control-panel-actions/account/registration/).
+* `<account_id>` — Selectel account ID. The account ID is in the top right corner of the [Control panel](https://my.selectel.ru/). Learn more about [Registration](https://docs.selectel.ru/en/account/registration/).
 
-* `<username>` — Name of the service user. To get the name, in the [Control panel](https://my.selectel.ru/iam/users_management/users?type=service), go to **Identity & Access Management** ⟶ **User management** ⟶ the **Service users** tab ⟶ copy the name of the required user. Learn more about [Service Users](https://docs.selectel.ru/en/control-panel-actions/users-and-roles/user-types-and-roles/).
+* `<username>` — Name of the service user. To get the name, in the [Control panel](https://my.selectel.ru/iam/service-users), go to **Account** ⟶ the **Service users** tab ⟶ copy the name of the required user. Learn more about [Service Users](https://docs.selectel.ru/en/access-control/user-types/).
 
 * `<password>` — Password of the service user.
 
-* `<user_id>` — Unique identifier of the user to import (not the Keystone ID), for example, `123456_5432`. To get the ID, use either [iam-go](https://github.com/selectel/iam-go) or [IAM API](https://developers.selectel.ru/docs/control-panel/iam/).
+* `<user_id>` — Unique identifier of the user to import (not the Keystone ID), for example, `123456_5432`. To get the user ID, use either [Control panel](https://my.selectel.ru/iam/users) or [IAM API](https://developers.selectel.ru/docs/control-panel/iam/).

--- a/website/docs/r/iam_user_v1.html.markdown
+++ b/website/docs/r/iam_user_v1.html.markdown
@@ -85,4 +85,4 @@ where:
 
 * `<password>` — Password of the service user.
 
-* `<user_id>` — Unique identifier of the user to import (not the Keystone ID), for example, `123456_5432`. To get the user ID, use either [Control panel](https://my.selectel.ru/iam/users) or [IAM API](https://developers.selectel.ru/docs/control-panel/iam/).
+* `<user_id>` — Unique identifier of the user to import (not the Keystone ID), for example, `123456_5432`. To get the user ID, use either [Control panel](https://my.selectel.ru/iam/users) or [IAM API](https://docs.selectel.ru/en/api/users-and-roles/).


### PR DESCRIPTION
## Changes:
- Add `selectel_iam_oidc_federation_v1` resource for managing OIDC federations.
- Add `selectel_iam_oidc_federation_group_mappings_v1` resource for managing group mappings for OIDC type federations.
- Update IAM documentation:
   - Remove outdated Roles sections and hardcoded role names from `iam_serviceuser_v1`, `iam_user_v1`, `iam_group_v1` docs.
   - Fix argument descriptions: `issuer`, `client_id`, `jwks_url`, `session_max_age_hours`.
   - Fix documentation links.
   - Add detailed instructions for getting `federation_id` in import sections.