### PR TITLE
Support high-availability multi-AZ clusters in MKS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 7.8.0 (May 19, 2026)
+
+FEATURES:
+
+* Add `cluster_type` argument for `selectel_mks_cluster_v1` ([#392](https://github.com/selectel/terraform-provider-selectel/pull/392)):
+  * Support `BASIC`, `HIGH_AVAILABILITY`, and `HIGH_AVAILABILITY_MULTI_AZ` cluster types
+  * `cluster_type` takes precedence over legacy `zonal` argument
+  * Mark `zonal` as deprecated
+
+BUG FIXES:
+
+* Fix quota check to support regions without `mks_cluster_regional` quota ([#392](https://github.com/selectel/terraform-provider-selectel/pull/392))
+
 ## 7.7.0 (May 19, 2026)
 
 FEATURES:

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	github.com/selectel/domains-go v1.0.2
 	github.com/selectel/globalrouter-go v1.2.0
 	github.com/selectel/go-selvpcclient/v4 v4.2.0
-	github.com/selectel/mks-go v1.1.0
 	github.com/selectel/iam-go v0.9.0
+	github.com/selectel/mks-go v1.1.0
 	github.com/selectel/private-dns-go v1.0.0
 	github.com/selectel/secretsmanager-go v0.2.1
 	github.com/stretchr/testify v1.11.1

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/selectel/globalrouter-go v1.2.0
 	github.com/selectel/go-selvpcclient/v4 v4.2.0
 	github.com/selectel/iam-go v0.8.1
-	github.com/selectel/mks-go v1.0.0
+	github.com/selectel/mks-go v1.1.0
 	github.com/selectel/private-dns-go v1.0.0
 	github.com/selectel/secretsmanager-go v0.2.1
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,8 @@ github.com/selectel/go-selvpcclient/v4 v4.2.0 h1:tVqSAdmNcdshv3AgfaIwGHs1oLk4jX8
 github.com/selectel/go-selvpcclient/v4 v4.2.0/go.mod h1:eFhL1KUW159KOJVeGO7k/Uxl0TYd/sBkWXjuF5WxmYk=
 github.com/selectel/iam-go v0.8.1 h1:bImeUgoDu/2JAH5AFwcnrDz4Kjf3tk855llYhH0qJM8=
 github.com/selectel/iam-go v0.8.1/go.mod h1:OIAkW7MZK97YUm+uvUgYbgDhkI9SdzTCxwd4yZoOR1o=
-github.com/selectel/mks-go v1.0.0 h1:futO/vA+bLM2RyCi0+8u3Xmdvg8HqJouRaOVTmD3Msc=
-github.com/selectel/mks-go v1.0.0/go.mod h1:VxtV3dzwgOEzZc+9VMQb9DvxfSlej2ZQ8jnT8kqIGgU=
+github.com/selectel/mks-go v1.1.0 h1:puJW2uuleAwsVyJaaAeRBwrK8+1cQ8tL7deBjLOyToQ=
+github.com/selectel/mks-go v1.1.0/go.mod h1:VxtV3dzwgOEzZc+9VMQb9DvxfSlej2ZQ8jnT8kqIGgU=
 github.com/selectel/private-dns-go v1.0.0 h1:gCi1fAxJ5aRiaSLR6xsIdYTFHGkG29vCZVmaXSWYbKw=
 github.com/selectel/private-dns-go v1.0.0/go.mod h1:cLVpLbPIJTqP/Wnp/nyTRBP9MTSqoyLvonrjrxbRiYE=
 github.com/selectel/secretsmanager-go v0.2.1 h1:OSBrA/07lm/Ecpwg59IJHFAoUHZR29oyfwUgTpr/dos=

--- a/selectel/mks.go
+++ b/selectel/mks.go
@@ -802,42 +802,36 @@ func findQuota(quotas []*quotas.Quota, resource string) []quotas.ResourceQuotaEn
 	return nil
 }
 
-func checkQuotasForCluster(projectQuotas []*quotas.Quota, zonal bool) error {
+func checkQuotasForCluster(projectQuotas []*quotas.Quota, clusterType cluster.ClusterType) error {
 	var (
 		clusterQuotaChecked bool
 		quota               []quotas.ResourceQuotaEntity
 	)
-
-	if zonal {
-		quota = findQuota(projectQuotas, "mks_cluster_zonal")
-	} else {
-		quota = findQuota(projectQuotas, "mks_cluster_regional")
+	var quotaName string
+	switch clusterType {
+	case cluster.ClusterTypeBasic:
+		quotaName = "mks_cluster_zonal"
+	case cluster.ClusterTypeHighAvailabilityMultiAZ:
+		quotaName = "mks_cluster_high_availability_multi_az"
+	default:
+		quotaName = "mks_cluster_regional"
 	}
+	quota = findQuota(projectQuotas, quotaName)
+
+	clusterTypeLabel := strings.ToLower(strings.ReplaceAll(string(clusterType), "_", " "))
 
 	if quota == nil {
-		if zonal {
-			return errors.New("unable to find zonal k8s cluster quotas")
-		}
-
-		return errors.New("unable to find regional k8s cluster quotas")
+		return fmt.Errorf("unable to find %s k8s cluster quotas (%s)", clusterTypeLabel, quotaName)
 	}
 
 	for _, v := range quota {
 		if v.Value-v.Used <= 0 {
-			if zonal {
-				return errors.New("not enough quota to create zonal k8s cluster")
-			}
-
-			return errors.New("not enough quota to create regional k8s cluster")
+			return fmt.Errorf("not enough quota to create %s k8s cluster (%s)", clusterTypeLabel, quotaName)
 		}
 		clusterQuotaChecked = true
 	}
 	if !clusterQuotaChecked {
-		if zonal {
-			return errors.New("unable to check zonal k8s cluster quotas for a given region")
-		}
-
-		return errors.New("unable to check regional k8s cluster quotas for a given region")
+		return fmt.Errorf("unable to check %s k8s cluster quotas for a given region (%s)", clusterTypeLabel, quotaName)
 	}
 
 	return nil

--- a/selectel/mks.go
+++ b/selectel/mks.go
@@ -813,6 +813,8 @@ func checkQuotasForCluster(projectQuotas []*quotas.Quota, clusterType cluster.Cl
 		quotaName = "mks_cluster_zonal"
 	case cluster.ClusterTypeHighAvailabilityMultiAZ:
 		quotaName = "mks_cluster_high_availability_multi_az"
+	case cluster.ClusterTypeHighAvailability:
+		fallthrough
 	default:
 		quotaName = "mks_cluster_regional"
 	}

--- a/selectel/mks_test.go
+++ b/selectel/mks_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/selectel/go-selvpcclient/v4/selvpcclient/quotamanager/quotas"
 	v1 "github.com/selectel/mks-go/pkg/v1"
+	"github.com/selectel/mks-go/pkg/v1/cluster"
 	"github.com/selectel/mks-go/pkg/v1/kubeversion"
 	"github.com/selectel/mks-go/pkg/v1/node"
 	"github.com/selectel/mks-go/pkg/v1/nodegroup"
@@ -700,10 +701,10 @@ func TestCheckQuotasForClusterErrRegional(t *testing.T) {
 		},
 	}
 
-	err := checkQuotasForCluster(testQuotas, false)
+	err := checkQuotasForCluster(testQuotas, cluster.ClusterTypeHighAvailability)
 
 	assert.Error(t, err)
-	assert.Equal(t, "not enough quota to create regional k8s cluster", err.Error())
+	assert.Equal(t, "not enough quota to create high availability k8s cluster (mks_cluster_regional)", err.Error())
 }
 
 func TestCheckQuotasForClusterErrZonal(t *testing.T) {
@@ -720,28 +721,28 @@ func TestCheckQuotasForClusterErrZonal(t *testing.T) {
 		},
 	}
 
-	err := checkQuotasForCluster(testQuotas, true)
+	err := checkQuotasForCluster(testQuotas, cluster.ClusterTypeBasic)
 
 	assert.Error(t, err)
-	assert.Equal(t, "not enough quota to create zonal k8s cluster", err.Error())
+	assert.Equal(t, "not enough quota to create basic k8s cluster (mks_cluster_zonal)", err.Error())
 }
 
 func TestCheckQuotasForRegionalClusterErrUnableToCheck(t *testing.T) {
 	var testQuotas []*quotas.Quota
 
-	err := checkQuotasForCluster(testQuotas, false)
+	err := checkQuotasForCluster(testQuotas, cluster.ClusterTypeHighAvailability)
 
 	assert.Error(t, err)
-	assert.Equal(t, "unable to find regional k8s cluster quotas", err.Error())
+	assert.Equal(t, "unable to find high availability k8s cluster quotas (mks_cluster_regional)", err.Error())
 }
 
 func TestCheckQuotasForZonalClusterErrUnableToCheck(t *testing.T) {
 	var testQuotas []*quotas.Quota
 
-	err := checkQuotasForCluster(testQuotas, true)
+	err := checkQuotasForCluster(testQuotas, cluster.ClusterTypeBasic)
 
 	assert.Error(t, err)
-	assert.Equal(t, "unable to find zonal k8s cluster quotas", err.Error())
+	assert.Equal(t, "unable to find basic k8s cluster quotas (mks_cluster_zonal)", err.Error())
 }
 
 func TestCheckQuotasForClusterOkRegional(t *testing.T) {
@@ -758,7 +759,7 @@ func TestCheckQuotasForClusterOkRegional(t *testing.T) {
 		},
 	}
 
-	assert.NoError(t, checkQuotasForCluster(testQuotas, false))
+	assert.NoError(t, checkQuotasForCluster(testQuotas, cluster.ClusterTypeHighAvailability))
 }
 
 func TestCheckQuotasForClusterOkZonal(t *testing.T) {
@@ -775,7 +776,7 @@ func TestCheckQuotasForClusterOkZonal(t *testing.T) {
 		},
 	}
 
-	assert.NoError(t, checkQuotasForCluster(testQuotas, true))
+	assert.NoError(t, checkQuotasForCluster(testQuotas, cluster.ClusterTypeBasic))
 }
 
 var testQuotasFull = []*quotas.Quota{

--- a/selectel/resource_selectel_mks_cluster_v1.go
+++ b/selectel/resource_selectel_mks_cluster_v1.go
@@ -569,5 +569,6 @@ func inferClusterType(d *schema.ResourceData, zonal bool) cluster.ClusterType {
 	if zonal {
 		return cluster.ClusterTypeBasic
 	}
+
 	return cluster.ClusterTypeHighAvailability
 }

--- a/selectel/resource_selectel_mks_cluster_v1.go
+++ b/selectel/resource_selectel_mks_cluster_v1.go
@@ -114,10 +114,23 @@ func resourceMKSClusterV1() *schema.Resource {
 				ForceNew: false,
 			},
 			"zonal": {
-				Type:     schema.TypeBool,
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				ForceNew:    true,
+				Description: "(Deprecated) Use cluster_type instead. This field will be removed in a future version.",
+			},
+			"cluster_type": {
+				Type:     schema.TypeString,
 				Optional: true,
-				Default:  false,
+				Computed: true,
 				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(cluster.ClusterTypeBasic),
+					string(cluster.ClusterTypeHighAvailability),
+					string(cluster.ClusterTypeHighAvailabilityMultiAZ),
+				}, true),
+				Description: "The type of the cluster. Supported values: BASIC, HIGH_AVAILABILITY, HIGH_AVAILABILITY_MULTI_AZ. If not specified, it is inferred from the zonal argument.",
 			},
 			"maintenance_window_end": {
 				Type:     schema.TypeString,
@@ -285,15 +298,16 @@ func resourceMKSClusterV1Create(ctx context.Context, d *schema.ResourceData, met
 	privateKubeAPI := d.Get("private_kube_api").(bool)
 	enableAuditLogs := d.Get("enable_audit_logs").(bool)
 
-	enablePatchVersionAutoUpgrade := !zonal // true by default only for regional clusters
+	clusterType := inferClusterType(d, zonal)
+
+	enablePatchVersionAutoUpgrade := clusterType != cluster.ClusterTypeBasic
 	if v, ok := d.GetOk("enable_patch_version_auto_upgrade"); ok {
 		enablePatchVersionAutoUpgrade = v.(bool)
 	}
 
-	// Check if "enable_patch_version_auto_upgrade" and "zonal" arguments are both not set to true.
-	if enablePatchVersionAutoUpgrade && zonal {
+	if enablePatchVersionAutoUpgrade && clusterType == cluster.ClusterTypeBasic {
 		return diag.FromErr(errors.New("\"enable_patch_version_auto_upgrade\" argument should be explicitly " +
-			"set to false in case of zonal cluster"))
+			"set to false in case of basic cluster"))
 	}
 
 	featureGates, err := getSetAsStrings(d, featureGatesKey)
@@ -335,6 +349,7 @@ func resourceMKSClusterV1Create(ctx context.Context, d *schema.ResourceData, met
 			},
 			OIDC: oidc,
 		},
+		ClusterType:       &clusterType,
 		Zonal:             &zonal,
 		PrivateKubeAPI:    &privateKubeAPI,
 		CNIType:           cniType,
@@ -345,14 +360,12 @@ func resourceMKSClusterV1Create(ctx context.Context, d *schema.ResourceData, met
 		selvpcClient,
 		projectID,
 		region,
-		quotas.WithResourceFilter("mks_cluster_zonal"),
-		quotas.WithResourceFilter("mks_cluster_regional"),
 	)
 	if err != nil {
 		return diag.FromErr(errGettingObject(objectProjectQuotas, projectID, err))
 	}
 
-	if err := checkQuotasForCluster(projectQuotas, zonal); err != nil {
+	if err := checkQuotasForCluster(projectQuotas, clusterType); err != nil {
 		return diag.FromErr(errCreatingObject(objectCluster, err))
 	}
 
@@ -407,6 +420,7 @@ func resourceMKSClusterV1Read(ctx context.Context, d *schema.ResourceData, meta 
 	d.Set("enable_patch_version_auto_upgrade", mksCluster.EnablePatchVersionAutoUpgrade)
 	d.Set("enable_pod_security_policy", mksCluster.KubernetesOptions.EnablePodSecurityPolicy)
 	d.Set("zonal", mksCluster.Zonal)
+	d.Set("cluster_type", mksCluster.ClusterType)
 	d.Set("private_kube_api", mksCluster.PrivateKubeAPI)
 	d.Set("cni_type", mksCluster.CNIType)
 	d.Set("cni_cilium_settings", flattenMKSClusterV1CNICiliumSettings(mksCluster))
@@ -546,4 +560,14 @@ func resourceMKSClusterV1ImportState(_ context.Context, d *schema.ResourceData, 
 	d.Set("region", config.Region)
 
 	return []*schema.ResourceData{d}, nil
+}
+
+func inferClusterType(d *schema.ResourceData, zonal bool) cluster.ClusterType {
+	if v, ok := d.GetOk("cluster_type"); ok {
+		return cluster.ClusterType(strings.ToUpper(v.(string)))
+	}
+	if zonal {
+		return cluster.ClusterTypeBasic
+	}
+	return cluster.ClusterTypeHighAvailability
 }

--- a/selectel/resource_selectel_mks_cluster_v1_test.go
+++ b/selectel/resource_selectel_mks_cluster_v1_test.go
@@ -126,6 +126,7 @@ func TestAccMKSClusterV1Zonal(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "enable_autorepair", "true"),
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "enable_patch_version_auto_upgrade", "false"),
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "zonal", "true"),
+					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "cluster_type", "BASIC"),
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "private_kube_api", "false"),
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "maintenance_window_start", maintenanceWindowStart),
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "status", "ACTIVE"),
@@ -181,6 +182,42 @@ func TestAccMKSClusterV1PrivateKubeAPI(t *testing.T) {
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "oidc.0.username_claim", ""),
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "oidc.0.groups_claim", ""),
 					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "oidc.0.ca_certs", ""),
+				),
+			},
+		},
+	})
+}
+
+func TestAccMKSClusterV1MultiAZ(t *testing.T) {
+	var (
+		mksCluster cluster.GetView
+		project    projects.Project
+	)
+
+	projectName := acctest.RandomWithPrefix("tf-acc")
+	clusterName := acctest.RandomWithPrefix("tf-acc-cl")
+	kubeVersion := testAccMKSClusterV1GetDefaultKubeVersion(t)
+	maintenanceWindowStart := testAccMKSClusterV1GetMaintenanceWindowStart(12 * time.Hour)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccSelectelPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckVPCV2ProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMKSClusterV1MultiAZ(projectName, clusterName, kubeVersion, maintenanceWindowStart),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVPCV2ProjectExists("selectel_vpc_project_v2.project_tf_acc_test_1", &project),
+					testAccCheckMKSClusterV1Exists("selectel_mks_cluster_v1.cluster_tf_acc_test_1", &mksCluster),
+					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "name", clusterName),
+					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "kube_version", kubeVersion),
+					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "region", "ru-9"),
+					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "enable_autorepair", "true"),
+					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "enable_patch_version_auto_upgrade", "true"),
+					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "cluster_type", "HIGH_AVAILABILITY_MULTI_AZ"),
+					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "private_kube_api", "false"),
+					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "maintenance_window_start", maintenanceWindowStart),
+					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "status", "ACTIVE"),
 				),
 			},
 		},
@@ -370,23 +407,38 @@ func testAccMKSClusterV1Zonal(projectName, clusterName, kubeVersion, maintenance
 
 func testAccMKSClusterV1PrivateKubeAPI(projectName, clusterName, kubeVersion, maintenanceWindowStart string) string {
 	return fmt.Sprintf(`
- resource "selectel_vpc_project_v2" "project_tf_acc_test_1" {
-   name        = "%s"
- }
- resource "selectel_mks_cluster_v1" "cluster_tf_acc_test_1" {
-   name                              = "%s"
-   kube_version                      = "%s"
-   project_id                        = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
-   region                            = "ru-9"
-   maintenance_window_start          = "%s"
-   enable_patch_version_auto_upgrade = false
-   zonal                             = false
-   private_kube_api                  = true
-   enable_audit_logs                 = false
-   oidc {
-     enabled = false
-   }
- }`, projectName, clusterName, kubeVersion, maintenanceWindowStart)
+  resource "selectel_vpc_project_v2" "project_tf_acc_test_1" {
+    name        = "%s"
+  }
+  resource "selectel_mks_cluster_v1" "cluster_tf_acc_test_1" {
+    name                              = "%s"
+    kube_version                      = "%s"
+    project_id                        = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+    region                            = "ru-9"
+    maintenance_window_start          = "%s"
+    enable_patch_version_auto_upgrade = false
+    zonal                             = false
+    private_kube_api                  = true
+    enable_audit_logs                 = false
+    oidc {
+      enabled = false
+    }
+  }`, projectName, clusterName, kubeVersion, maintenanceWindowStart)
+}
+
+func testAccMKSClusterV1MultiAZ(projectName, clusterName, kubeVersion, maintenanceWindowStart string) string {
+	return fmt.Sprintf(`
+  resource "selectel_vpc_project_v2" "project_tf_acc_test_1" {
+    name        = "%s"
+  }
+  resource "selectel_mks_cluster_v1" "cluster_tf_acc_test_1" {
+    name                              = "%s"
+    kube_version                      = "%s"
+    project_id                        = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+    region                            = "ru-9"
+    maintenance_window_start          = "%s"
+    cluster_type                      = "HIGH_AVAILABILITY_MULTI_AZ"
+  }`, projectName, clusterName, kubeVersion, maintenanceWindowStart)
 }
 
 func testDefaultFeatureGates(t *testing.T) []string {

--- a/website/docs/r/mks_cluster_v1.html.markdown
+++ b/website/docs/r/mks_cluster_v1.html.markdown
@@ -56,7 +56,7 @@ resource "selectel_mks_cluster_v1" "basic_cluster" {
 
   To upgrade a minor version, the desired version should match the next available minor release with the latest patch version.
 
-* `zonal` - (Optional) Specifies a cluster type. Changing this creates a new cluster.
+* `zonal` - (Optional, **Deprecated**, use `cluster_type` instead) Specifies a cluster type. Changing this creates a new cluster.
 
   Boolean flag:
 
@@ -65,6 +65,20 @@ resource "selectel_mks_cluster_v1" "basic_cluster" {
   * `true` - for a basic cluster with one master node. Set `enable_patch_version_auto_upgrade` to `false`.
 
   Learn more about [Cluster types](https://docs.selectel.ru/en/cloud/managed-kubernetes/about/about-managed-kubernetes/#cluster-types).
+
+* `cluster_type` - (Optional) The type of the cluster. Changing this creates a new cluster.
+
+  Supported values:
+  
+  * `BASIC` - for a basic cluster with one master node.
+  
+  * `HIGH_AVAILABILITY` (default) - for a high availability cluster with three master nodes located on different hosts in one pool segment.
+  
+  * `HIGH_AVAILABILITY_MULTI_AZ` - for a high availability cluster with three master nodes distributed across three pool segments.
+
+  Learn more about [Cluster types](https://docs.selectel.ru/en/cloud/managed-kubernetes/about/about-managed-kubernetes/#cluster-types).
+  
+  If both `zonal` and `cluster_type` are not specified, `HIGH_AVAILABILITY` is used by default. If `zonal` is set to `true`, `BASIC` is used. If `cluster_type` is explicitly set, it takes precedence over `zonal`.
 
 * `enable_autorepair` - (Optional) Enables or disables node auto-repairing (worker nodes are automatically restarted). Auto-repairing is not available if you have one worker node. After auto-repairing, all data on the boot volumes are deleted. Boolean flag, the default value is `true`. Learn more about [Nodes auto-repairing](https://docs.selectel.ru/en/cloud/managed-kubernetes/node-groups/reinstall-nodes/).
 


### PR DESCRIPTION
- Added cluster_type field: BASIC, HIGH_AVAILABILITY, HIGH_AVAILABILITY_MULTI_AZ
- cluster_type takes precedence over legacy zonal field
- Marked zonal as deprecated
- Actualized quota check: removed resource filter to avoid 400 error in regions without mks_cluster_regional quota
- Refactored checkQuotasForCluster() to support all cluster types with human-readable error messages