### PR TITLE
fix(global_router): mark gateway and service_addresses as computed and update gloabalrouter-go version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 8.0.1 (May 28, 2026)
+
+BUG FIXES:
+
+* Fix optional parameters for `selectel_global_router_vpc_subnet_v1`, `selectel_global_router_dedicated_subnet_v1` resources in global_router_go sdk ([#395](https://github.com/selectel/terraform-provider-selectel/pull/395))
+
 ## 8.0.0 (May 28, 2026)
 
 FEATURES:

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/selectel/dbaas-go v0.18.0
 	github.com/selectel/dedicated-go/v2 v2.1.1
 	github.com/selectel/domains-go v1.0.2
-	github.com/selectel/globalrouter-go v1.2.0
+	github.com/selectel/globalrouter-go v1.2.1
 	github.com/selectel/go-selvpcclient/v4 v4.2.0
 	github.com/selectel/iam-go v0.9.0
 	github.com/selectel/mks-go v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -198,8 +198,8 @@ github.com/selectel/dedicated-go/v2 v2.1.1 h1:BQxkppIzCe1QlVazMdoCWck40RRavwsInh
 github.com/selectel/dedicated-go/v2 v2.1.1/go.mod h1:4x2656DDXxvQdEVGVO27/PcgydBuQwiqw2E7nFDbVVM=
 github.com/selectel/domains-go v1.0.2 h1:Si6iGaMnTFJxwiJVI50DOdZnwcxc87kqaWrVQYW0a4U=
 github.com/selectel/domains-go v1.0.2/go.mod h1:SugRKfq4sTpnOHquslCpzda72wV8u0cMBHx0C0l+bzA=
-github.com/selectel/globalrouter-go v1.2.0 h1:hNwxN9YAEaGSsveZ35u1m3CqTWjKIyIfvibJID8aEl0=
-github.com/selectel/globalrouter-go v1.2.0/go.mod h1:3FlK0iJBZx8Lil3KOkOsU72yv7EcetdV7xNOvfX2+/U=
+github.com/selectel/globalrouter-go v1.2.1 h1:7daw9GX67h04gV1wfviIIveIUwS2ju56j2H/0iRvKLY=
+github.com/selectel/globalrouter-go v1.2.1/go.mod h1:3FlK0iJBZx8Lil3KOkOsU72yv7EcetdV7xNOvfX2+/U=
 github.com/selectel/go-selvpcclient/v4 v4.2.0 h1:tVqSAdmNcdshv3AgfaIwGHs1oLk4jX8Tm+ccMg1rBmc=
 github.com/selectel/go-selvpcclient/v4 v4.2.0/go.mod h1:eFhL1KUW159KOJVeGO7k/Uxl0TYd/sBkWXjuF5WxmYk=
 github.com/selectel/iam-go v0.9.0 h1:iivGpZR4jHC3sSLWEY+vGPLjgM4kmSjPf1n4xa81yP8=

--- a/selectel/resource_selectel_global_router_dedicated_subnet_v1.go
+++ b/selectel/resource_selectel_global_router_dedicated_subnet_v1.go
@@ -46,12 +46,14 @@ func resourceGlobalRouterDedicatedSubnetV1() *schema.Resource {
 			"gateway": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "Subnet gateway address from specified cidr",
 				ForceNew:    true,
 			},
 			"service_addresses": {
 				Type:        schema.TypeSet,
 				Optional:    true,
+				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Set:         schema.HashString,
 				MaxItems:    2,

--- a/selectel/resource_selectel_global_router_vpc_subnet_v1.go
+++ b/selectel/resource_selectel_global_router_vpc_subnet_v1.go
@@ -52,12 +52,14 @@ func resourceGlobalRouterVPCSubnetV1() *schema.Resource {
 			"gateway": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: "Subnet gateway address from specified cidr",
 				ForceNew:    true,
 			},
 			"service_addresses": {
 				Type:        schema.TypeSet,
 				Optional:    true,
+				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Set:         schema.HashString,
 				MaxItems:    2,


### PR DESCRIPTION
Fix optional parameters for  selectel_global_router_*_subnet_v1 resources

Make Gateway and ServiceAddresses Computed and update sdk version with fix processing case, when these parameters are missed in template