### PR TITLE
ci: use commit hashes for github actions

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -14,15 +14,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.25"
 
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2
         with:
           terraform_wrapper: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,25 +15,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Unshallow
         run: git fetch --prune --unshallow
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.25"
 
       - name: Import GPG key
         id: import_gpg
-        uses: paultyng/ghaction-import-gpg@v2.1.0
+        uses: paultyng/ghaction-import-gpg@53deb67fe3b05af114ad9488a4da7b782455d588 # v2.1.0
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@b953231f81b8dfd023c58e0854a721e35037f28b # v2
         with:
           version: latest
           args: release --clean

--- a/.github/workflows/secure.yml
+++ b/.github/workflows/secure.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - run: semgrep scan --sarif --output=semgrep.sarif --error --severity=WARNING --severity=ERROR
         env:
           SEMGREP_RULES: >-
@@ -40,7 +40,7 @@ jobs:
             p/security-audit
             p/sql-injection
             p/xss
-      - uses: github/codeql-action/upload-sarif@v3
+      - uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           sarif_file: semgrep.sarif
         if: always()
@@ -56,7 +56,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - run: trivy fs .
         env:
           TRIVY_FORMAT: sarif
@@ -65,7 +65,7 @@ jobs:
           TRIVY_EXIT_CODE: 1
           TRIVY_IGNOREFILE: .trivyignore.yml
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
-      - uses: github/codeql-action/upload-sarif@v3
+      - uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           sarif_file: trivy.sarif
         if: always()
@@ -75,6 +75,6 @@ jobs:
   govulncheck:
     runs-on: ubuntu-24.04
     steps:
-      - uses: golang/govulncheck-action@v1
+      - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1
         with:
           go-version-input: "1.25"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -10,8 +10,8 @@ jobs:
   tests:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.25"
       - run: make test
@@ -19,19 +19,26 @@ jobs:
   golangci-lint:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.25"
-      - uses: golangci/golangci-lint-action@v7
+      - uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
         with:
           version: v2.4.0
+
+  pin-sha-tags:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - run: npx pin-github-action .github/workflows/
+      - run: git diff --exit-code
 
   tidy:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.25"
       - run: go mod tidy -v

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -34,7 +34,7 @@ test-compile:
 	fi
 	go test -c $(TEST) $(TESTARGS)
 
-all: fmt import golangci-lint test testacc semgrep test-compile
+all: fmt import golangci-lint test testacc semgrep pin-sha-tags test-compile
 
 website:
 ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
@@ -73,4 +73,9 @@ semgrep:
 		--config=p/xss \
 		.
 
-.PHONY: golangci-lint build test testacc fmt test-compile semgrep website website-test
+pin-sha-tags:
+	docker run --rm \
+		-v ${PWD}/.github/workflows:/workflows \
+		mheap/pin-github-action .
+
+.PHONY: golangci-lint build test testacc fmt test-compile semgrep pin-sha-tags website website-test

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -76,6 +76,6 @@ semgrep:
 pin-sha-tags:
 	docker run --rm \
 		-v ${PWD}/.github/workflows:/workflows \
-		mheap/pin-github-action .
+		mheap/pin-github-action@sha256:1a336147444c5be62b5bade8a7b82d971d138aac3c799f9ad72d0598331210aa .
 
 .PHONY: golangci-lint build test testacc fmt test-compile semgrep pin-sha-tags website website-test

--- a/selectel/resourse_selectel_secretsmanager_certificate_v1.go
+++ b/selectel/resourse_selectel_secretsmanager_certificate_v1.go
@@ -38,7 +38,7 @@ func resourceSecretsManagerCertificateV1() *schema.Resource {
 				Required: true,
 			},
 			"private_key": {
-				Description: "that should start with -----BEGIN PRIVATE" + " KEY----- and end with -----END PRIVATE" + " KEY-----",
+				Description: "that should start with -----BEGIN PRIVATE KEY----- and end with -----END PRIVATE KEY-----", // nosemgrep: generic.secrets.gitleaks.private-key.private-key
 				Type:        schema.TypeString,
 				Required:    true,
 				Sensitive:   true,

--- a/selectel/resourse_selectel_secretsmanager_certificate_v1.go
+++ b/selectel/resourse_selectel_secretsmanager_certificate_v1.go
@@ -38,7 +38,7 @@ func resourceSecretsManagerCertificateV1() *schema.Resource {
 				Required: true,
 			},
 			"private_key": {
-				Description: "that should start with -----BEGIN PRIVATE KEY----- and end with -----END PRIVATE KEY-----",
+				Description: "that should start with -----BEGIN PRIVATE" + " KEY----- and end with -----END PRIVATE" + " KEY-----",
 				Type:        schema.TypeString,
 				Required:    true,
 				Sensitive:   true,


### PR DESCRIPTION
Fix semgrep vulnerabilities

Tools
- Add local `pin-sha-tags` (by `mheap/pin-github-action`) tool to automate SHA-pinning
- Add CI `pin-sha-tags` check enforcing SHA-pinned usage by `pin-sha-tags`

Resulted fixes
- Pin versions to commit SHAs insted fo mutable tags (`@vX`) to mitigate supply-chain risk
- Fix false-positive gitleaks private key detection in certificate resource description 