### PR TITLE
ci: remove pin-sha-tags from verify stage

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -14,14 +14,17 @@ jobs:
 
     steps:
       - name: Checkout
+        # NOTE: to update the version, use `make pin-sha-tags`.
         uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
 
       - name: Set up Go
+        # NOTE: to update the version, use `make pin-sha-tags`.
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.26"
 
       - name: Set up Terraform
+        # NOTE: to update the version, use `make pin-sha-tags`.
         uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2
         with:
           terraform_wrapper: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,24 +15,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
+        # NOTE: to update the version, use `make pin-sha-tags`.
         uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
 
       - name: Unshallow
         run: git fetch --prune --unshallow
 
       - name: Set up Go
+        # NOTE: to update the version, use `make pin-sha-tags`.
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.26"
 
       - name: Import GPG key
         id: import_gpg
+        # NOTE: to update the version, use `make pin-sha-tags`.
         uses: paultyng/ghaction-import-gpg@53deb67fe3b05af114ad9488a4da7b782455d588 # v2.1.0
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
 
       - name: Run GoReleaser
+        # NOTE: to update the version, use `make pin-sha-tags`.
         uses: goreleaser/goreleaser-action@b953231f81b8dfd023c58e0854a721e35037f28b # v2
         with:
           version: latest

--- a/.github/workflows/secure.yml
+++ b/.github/workflows/secure.yml
@@ -20,6 +20,7 @@ jobs:
       contents: read
       security-events: write
     steps:
+      # NOTE: to update the version, use `make pin-sha-tags`.
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - run: semgrep scan --sarif --output=semgrep.sarif --error --severity=WARNING --severity=ERROR
         env:
@@ -40,6 +41,7 @@ jobs:
             p/security-audit
             p/sql-injection
             p/xss
+      # NOTE: to update the version, use `make pin-sha-tags`.
       - uses: github/codeql-action/upload-sarif@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3
         with:
           sarif_file: semgrep.sarif
@@ -56,15 +58,17 @@ jobs:
       contents: read
       security-events: write
     steps:
+      # NOTE: to update the version, use `make pin-sha-tags`.
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - run: trivy fs .
         env:
           TRIVY_FORMAT: sarif
           TRIVY_OUTPUT: trivy.sarif
-          TRIVY_severity: MEDIUM,HIGH
+          TRIVY_SEVERITY: MEDIUM,HIGH
           TRIVY_EXIT_CODE: 1
           TRIVY_IGNOREFILE: .trivyignore.yml
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
+      # NOTE: to update the version, use `make pin-sha-tags`.
       - uses: github/codeql-action/upload-sarif@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3
         with:
           sarif_file: trivy.sarif
@@ -75,6 +79,7 @@ jobs:
   govulncheck:
     runs-on: ubuntu-24.04
     steps:
+      # NOTE: to update the version, use `make pin-sha-tags`.
       - uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1
         with:
           go-version-input: "1.26"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -10,6 +10,7 @@ jobs:
   tests:
     runs-on: ubuntu-24.04
     steps:
+      # NOTE: to update the version, use `make pin-sha-tags`.
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
@@ -19,25 +20,21 @@ jobs:
   golangci-lint:
     runs-on: ubuntu-24.04
     steps:
+      # NOTE: to update the version, use `make pin-sha-tags`.
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.26"
+      # NOTE: to update the version, use `make pin-sha-tags`.
       - uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
         with:
           # NOTE: If you update the version, don't forget to update the Makefile.
           version: v2.12.2
 
-  pin-sha-tags:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-      - run: npx pin-github-action .github/workflows/
-      - run: git diff --exit-code
-
   tidy:
     runs-on: ubuntu-24.04
     steps:
+      # NOTE: to update the version, use `make pin-sha-tags`.
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
@@ -48,6 +45,7 @@ jobs:
   go-fix:
     runs-on: ubuntu-24.04
     steps:
+      # NOTE: to update the version, use `make pin-sha-tags`.
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:


### PR DESCRIPTION
Tag updates must be meaningful. Mindlessly bumping to the latest commit does not protect against supply chain vulnerabilities. Currently, CI is assumed to use pinned hashes updated via make pin-sha-tags, but CI does not enforce that the latest version is used.