### PR TITLE
fix(mks): keep kubernetes options intact on cluster update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 8.3.1 (August 10, 2026)
+
+BUG FIXES:
+
+* `selectel_mks_cluster_v1`: fix `oidc`, `feature_gates`, `admission_controllers` and `enable_pod_security_policy` being reset when another kubernetes option is changed. ([#420](https://github.com/selectel/terraform-provider-selectel/pull/420))
+* `selectel_mks_cluster_v1`: read `feature_gates` and `admission_controllers` back from the API. ([#420](https://github.com/selectel/terraform-provider-selectel/pull/420))
+
 ## 8.3.0 (August 6, 2026)
 
 BUG FIXES:

--- a/selectel/mks.go
+++ b/selectel/mks.go
@@ -679,6 +679,35 @@ func expandAndValidateMKSClusterV1OIDC(d *schema.ResourceData) (cluster.OIDC, er
 	return oidc, nil
 }
 
+// expandMKSClusterV1KubernetesOptions builds the whole kubernetes_options object from the config:
+// the API replaces it as a whole, so a partially filled struct turns off the options it omits.
+func expandMKSClusterV1KubernetesOptions(d *schema.ResourceData) (*cluster.KubernetesOptions, error) {
+	featureGates, err := getSetAsStrings(d, featureGatesKey)
+	if err != nil {
+		return nil, err
+	}
+
+	admissionControllers, err := getSetAsStrings(d, admissionControllersKey)
+	if err != nil {
+		return nil, err
+	}
+
+	oidc, err := expandAndValidateMKSClusterV1OIDC(d)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cluster.KubernetesOptions{
+		EnablePodSecurityPolicy: d.Get("enable_pod_security_policy").(bool),
+		FeatureGates:            featureGates,
+		AdmissionControllers:    admissionControllers,
+		AuditLogs: cluster.AuditLogs{
+			Enabled: d.Get("enable_audit_logs").(bool),
+		},
+		OIDC: oidc,
+	}, nil
+}
+
 func expandAndValidateMKSClusterV1CNICiliumSettings(
 	d *schema.ResourceData, cniType cluster.CNIType,
 ) (*cluster.CNICiliumSettings, error) {

--- a/selectel/resource_selectel_mks_cluster_v1.go
+++ b/selectel/resource_selectel_mks_cluster_v1.go
@@ -294,10 +294,8 @@ func resourceMKSClusterV1Create(ctx context.Context, d *schema.ResourceData, met
 
 	// Prepare cluster create options.
 	enableAutorepair := d.Get("enable_autorepair").(bool)
-	enablePodSecurityPolicy := d.Get("enable_pod_security_policy").(bool)
 	zonal := d.Get("zonal").(bool)
 	privateKubeAPI := d.Get("private_kube_api").(bool)
-	enableAuditLogs := d.Get("enable_audit_logs").(bool)
 
 	clusterType := inferClusterType(d, zonal)
 
@@ -312,19 +310,9 @@ func resourceMKSClusterV1Create(ctx context.Context, d *schema.ResourceData, met
 			"set to false in case of basic cluster"))
 	}
 
-	featureGates, err := getSetAsStrings(d, featureGatesKey)
+	kubeOptions, err := expandMKSClusterV1KubernetesOptions(d)
 	if err != nil {
 		return diag.FromErr(errCreatingObject(objectCluster, err))
-	}
-
-	admissionControllers, err := getSetAsStrings(d, admissionControllersKey)
-	if err != nil {
-		return diag.FromErr(errCreatingObject(objectCluster, err))
-	}
-
-	oidc, err := expandAndValidateMKSClusterV1OIDC(d)
-	if err != nil {
-		return diag.FromErr(err)
 	}
 
 	cniType := cluster.CNIType(strings.ToUpper(d.Get("cni_type").(string)))
@@ -342,20 +330,12 @@ func resourceMKSClusterV1Create(ctx context.Context, d *schema.ResourceData, met
 		EnableAutorepair:              &enableAutorepair,
 		EnablePatchVersionAutoUpgrade: &enablePatchVersionAutoUpgrade,
 		Region:                        region,
-		KubernetesOptions: &cluster.KubernetesOptions{
-			EnablePodSecurityPolicy: enablePodSecurityPolicy,
-			FeatureGates:            featureGates,
-			AdmissionControllers:    admissionControllers,
-			AuditLogs: cluster.AuditLogs{
-				Enabled: enableAuditLogs,
-			},
-			OIDC: oidc,
-		},
-		ClusterType:       &clusterType,
-		Zonal:             &zonal,
-		PrivateKubeAPI:    &privateKubeAPI,
-		CNIType:           cniType,
-		CNICiliumSettings: cniCiliumSettings,
+		KubernetesOptions:             kubeOptions,
+		ClusterType:                   &clusterType,
+		Zonal:                         &zonal,
+		PrivateKubeAPI:                &privateKubeAPI,
+		CNIType:                       cniType,
+		CNICiliumSettings:             cniCiliumSettings,
 	}
 
 	projectQuotas, _, err := quotas.GetProjectQuotas(
@@ -428,6 +408,8 @@ func resourceMKSClusterV1Read(ctx context.Context, d *schema.ResourceData, meta 
 	d.Set("cni_cilium_settings", flattenMKSClusterV1CNICiliumSettings(mksCluster))
 	d.Set("enable_audit_logs", mksCluster.KubernetesOptions.AuditLogs.Enabled)
 	d.Set("oidc", flattenMKSClusterV1OIDC(mksCluster))
+	d.Set(featureGatesKey, mksCluster.KubernetesOptions.FeatureGates)
+	d.Set(admissionControllersKey, mksCluster.KubernetesOptions.AdmissionControllers)
 
 	return nil
 }
@@ -457,38 +439,15 @@ func resourceMKSClusterV1Update(ctx context.Context, d *schema.ResourceData, met
 		updateOpts.EnablePatchVersionAutoUpgrade = &v
 	}
 
-	kubeOptions := new(cluster.KubernetesOptions)
-	if d.HasChange("enable_pod_security_policy") {
-		v := d.Get("enable_pod_security_policy").(bool)
-		kubeOptions.EnablePodSecurityPolicy = v
-	}
-	if d.HasChange(featureGatesKey) {
-		v, err := getSetAsStrings(d, featureGatesKey)
+	// Leave nil unless one of the options changed, so an unrelated update doesn't touch them.
+	if d.HasChanges("enable_pod_security_policy", featureGatesKey, admissionControllersKey, "enable_audit_logs", "oidc") {
+		kubeOptions, err := expandMKSClusterV1KubernetesOptions(d)
 		if err != nil {
-			return diag.FromErr(errCreatingObject(objectCluster, err))
+			return diag.FromErr(errUpdatingObject(objectCluster, d.Id(), err))
 		}
-		kubeOptions.FeatureGates = v
-	}
-	if d.HasChange(admissionControllersKey) {
-		v, err := getSetAsStrings(d, admissionControllersKey)
-		if err != nil {
-			return diag.FromErr(errCreatingObject(objectCluster, err))
-		}
-		kubeOptions.AdmissionControllers = v
-	}
-	if d.HasChange("enable_audit_logs") {
-		v := d.Get("enable_audit_logs").(bool)
-		kubeOptions.AuditLogs.Enabled = v
-	}
-	if d.HasChange("oidc") {
-		oidc, err := expandAndValidateMKSClusterV1OIDC(d)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		kubeOptions.OIDC = oidc
-	}
 
-	updateOpts.KubernetesOptions = kubeOptions
+		updateOpts.KubernetesOptions = kubeOptions
+	}
 
 	if updateOpts != (cluster.UpdateOpts{}) {
 		log.Print(msgUpdate(objectCluster, d.Id(), updateOpts))

--- a/selectel/resource_selectel_mks_cluster_v1_test.go
+++ b/selectel/resource_selectel_mks_cluster_v1_test.go
@@ -99,6 +99,54 @@ func TestAccMKSClusterV1Basic(t *testing.T) {
 	})
 }
 
+// TestAccMKSClusterV1KubeOptionsPartialUpdate changes one kubernetes option and checks the rest survive.
+func TestAccMKSClusterV1KubeOptionsPartialUpdate(t *testing.T) {
+	var (
+		mksCluster cluster.GetView
+		project    projects.Project
+	)
+
+	projectName := acctest.RandomWithPrefix("tf-acc")
+	clusterName := acctest.RandomWithPrefix("tf-acc-cl")
+	kubeVersion := testAccMKSClusterV1GetDefaultKubeVersion(t)
+	maintenanceWindowStart := testAccMKSClusterV1GetMaintenanceWindowStart(12 * time.Hour)
+	featureGates := testDefaultFeatureGates(t)[:1]
+	admissionControllers := testDefaultAdmissionControllers(t)[:1]
+
+	checkKubeOptionsKept := resource.ComposeTestCheckFunc(
+		resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "feature_gates.0", featureGates[0]),
+		resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "admission_controllers.0", admissionControllers[0]),
+		resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "oidc.0.enabled", "true"),
+		resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "oidc.0.provider_name", "kubernetes"),
+		resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "oidc.0.issuer_url", "https://keycloak.example.com/realms/kubernetes"),
+		resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "oidc.0.client_id", "test"),
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccSelectelPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckVPCV2ProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMKSClusterV1KubeOptions(projectName, clusterName, kubeVersion, maintenanceWindowStart, featureGates, admissionControllers, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVPCV2ProjectExists("selectel_vpc_project_v2.project_tf_acc_test_1", &project),
+					testAccCheckMKSClusterV1Exists("selectel_mks_cluster_v1.cluster_tf_acc_test_1", &mksCluster),
+					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "enable_audit_logs", "true"),
+					checkKubeOptionsKept,
+				),
+			},
+			{
+				Config: testAccMKSClusterV1KubeOptions(projectName, clusterName, kubeVersion, maintenanceWindowStart, featureGates, admissionControllers, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("selectel_mks_cluster_v1.cluster_tf_acc_test_1", "enable_audit_logs", "false"),
+					checkKubeOptionsKept,
+				),
+			},
+		},
+	})
+}
+
 func TestAccMKSClusterV1Zonal(t *testing.T) {
 	var (
 		mksCluster cluster.GetView
@@ -377,6 +425,33 @@ resource "selectel_mks_cluster_v1" "cluster_tf_acc_test_1" {
   admission_controllers             = [%s]
   enable_audit_logs                 = true
 }`, projectName, clusterName, kubeVersion, maintenanceWindowStart, flatFeatureGates, flatAdmissionControllers)
+}
+
+func testAccMKSClusterV1KubeOptions(
+	projectName, clusterName, kubeVersion, maintenanceWindowStart string,
+	featureGates, admissionControllers []string, enableAuditLogs bool,
+) string {
+	return fmt.Sprintf(`
+resource "selectel_vpc_project_v2" "project_tf_acc_test_1" {
+  name        = "%s"
+}
+resource "selectel_mks_cluster_v1" "cluster_tf_acc_test_1" {
+  name                     = "%s"
+  kube_version             = "%s"
+  project_id               = "${selectel_vpc_project_v2.project_tf_acc_test_1.id}"
+  region                   = "ru-9"
+  maintenance_window_start = "%s"
+  feature_gates            = [%s]
+  admission_controllers    = [%s]
+  enable_audit_logs        = %t
+  oidc {
+    enabled       = true
+    provider_name = "kubernetes"
+    client_id     = "test"
+    issuer_url    = "https://keycloak.example.com/realms/kubernetes"
+  }
+}`, projectName, clusterName, kubeVersion, maintenanceWindowStart,
+		flatStringsListWithQuotes(featureGates), flatStringsListWithQuotes(admissionControllers), enableAuditLogs)
 }
 
 func testAccMKSClusterV1Zonal(projectName, clusterName, kubeVersion, maintenanceWindowStart string) string {


### PR DESCRIPTION
- send the whole `kubernetes_options` object on update instead of only the changed field, so changing one option no longer resets `oidc`, `feature_gates`, `admission_controllers` and `enable_pod_security_policy`
- attach `kubernetes_options` only when one of those options changed
- read `feature_gates` and `admission_controllers` back from the API in `Read`
- add `TestAccMKSClusterV1KubeOptionsPartialUpdate`